### PR TITLE
chore: configure package.json and tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "steamroller",
+  "version": "0.0.0",
+  "description": "A zero-dependency JavaScript bundler",
+  "license": "MIT",
+  "author": "Asymmetric Effort <info@asymmetric-effort.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/asymmetric-effort/steamroller.git"
+  },
+  "type": "module",
+  "main": "dist/steamroller.cjs",
+  "module": "dist/steamroller.mjs",
+  "types": "dist/steamroller.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/steamroller.mjs",
+      "require": "./dist/steamroller.cjs",
+      "types": "./dist/steamroller.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --coverage",
+    "lint": "prettier --check .",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "clean": "rm -rf dist coverage",
+    "prepublishOnly": "npm run clean && npm run lint && npm run typecheck && npm run test && npm run build"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "coverage"]
+}


### PR DESCRIPTION
## Summary

- Adds `package.json` with zero runtime dependencies, dual CJS/ESM output configuration, and standard npm scripts (build, test, lint, typecheck, format, clean, prepublishOnly)
- Adds `tsconfig.json` with TypeScript strict mode enabled, ES2022 target, Node16 module resolution, and declaration/source map generation
- Configures project as ESM (`"type": "module"`) with proper exports map for import/require/types

## Test plan

- [ ] Verify `package.json` has no `dependencies` field (zero runtime deps)
- [ ] Verify `tsconfig.json` has `"strict": true`
- [ ] Verify exports map points to correct dist paths
- [ ] Run `npx tsc --showConfig` to confirm tsconfig is valid

Closes #5
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)