### PR TITLE
fix: remove || true from pre-commit prettier check

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -5,6 +5,6 @@ echo "==> pre-commit: running typecheck..."
 npx tsc --noEmit
 
 echo "==> pre-commit: checking formatting..."
-npx prettier --check 'src/**/*.ts' 'tests/**/*.ts' 2>/dev/null || true
+npx prettier --check 'src/**/*.ts' 'tests/**/*.ts'
 
 echo "==> pre-commit: all checks passed."


### PR DESCRIPTION
## Summary
- Removed `2>/dev/null || true` from the prettier check in `git-hooks/pre-commit` so formatting errors are no longer silently ignored and will correctly block commits.

Closes #138

## Test plan
- [ ] Verify that a commit with improperly formatted TypeScript files is blocked by the pre-commit hook.
- [ ] Verify that a commit with properly formatted files passes the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)