### PR TITLE
docs: create project documentation (docs/ directory)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,195 @@
+# CLI Usage
+
+The Steamroller CLI provides command-line access to bundling, watching, and configuration.
+
+> **Note:** Steamroller is pre-implementation. Detailed documentation will be added as features are
+> implemented.
+
+## Installation
+
+```bash
+# Install globally
+npm install -g steamroller
+
+# Or use as a project dependency
+npm install --save-dev steamroller
+```
+
+## Basic Usage
+
+```bash
+# Bundle using a config file
+steamroller
+
+# Bundle with a specific config file
+steamroller --config rollup.config.ts
+
+# Bundle with explicit input and output
+steamroller --input src/index.ts --output dist/bundle.js --format es
+```
+
+## Flags
+
+### `--config`, `-c`
+
+Path to the configuration file. Defaults to `steamroller.config.js` or `rollup.config.js`.
+
+```bash
+steamroller --config my-config.ts
+```
+
+---
+
+### `--input`, `-i`
+
+The entry point file(s) for the bundle.
+
+```bash
+steamroller --input src/index.ts
+
+# Multiple inputs
+steamroller --input src/index.ts --input src/cli.ts
+```
+
+---
+
+### `--output.dir`, `-d`
+
+Output directory for code-split builds.
+
+```bash
+steamroller --input src/index.ts --output.dir dist
+```
+
+---
+
+### `--output.file`, `-o`
+
+Output file path for single-file builds.
+
+```bash
+steamroller --input src/index.ts --output.file dist/bundle.js
+```
+
+---
+
+### `--format`, `-f`
+
+Output format: `es`, `cjs`, `iife`, `umd`, `amd`, or `system`.
+
+```bash
+steamroller --input src/index.ts --output.file dist/bundle.js --format cjs
+```
+
+---
+
+### `--name`, `-n`
+
+Global variable name for `iife` and `umd` formats.
+
+```bash
+steamroller --input src/index.ts --output.file dist/bundle.js --format iife --name MyLib
+```
+
+---
+
+### `--watch`, `-w`
+
+Watch input files and rebuild on changes.
+
+```bash
+steamroller --config rollup.config.ts --watch
+```
+
+---
+
+### `--sourcemap`
+
+Generate source maps. Values: `true`, `inline`, or `hidden`.
+
+```bash
+steamroller --input src/index.ts --output.file dist/bundle.js --sourcemap
+
+# Inline source maps
+steamroller --input src/index.ts --output.file dist/bundle.js --sourcemap inline
+```
+
+---
+
+### `--external`, `-e`
+
+Mark module IDs as external.
+
+```bash
+steamroller --input src/index.ts --output.file dist/bundle.js --external lodash --external react
+```
+
+---
+
+### `--globals`, `-g`
+
+Map external module IDs to global variable names (for `iife`/`umd`).
+
+```bash
+steamroller --format iife --globals jquery:$,react:React
+```
+
+---
+
+### `--plugin`
+
+Load a plugin by module name.
+
+```bash
+steamroller --plugin @rollup/plugin-node-resolve
+```
+
+---
+
+### `--environment`
+
+Pass environment variables to the config file.
+
+```bash
+steamroller --environment BUILD:production,DEBUG:false
+```
+
+---
+
+### `--no-treeshake`
+
+Disable tree-shaking.
+
+```bash
+steamroller --no-treeshake
+```
+
+---
+
+### `--silent`
+
+Suppress warnings.
+
+```bash
+steamroller --silent
+```
+
+---
+
+### `--version`, `-v`
+
+Print the Steamroller version.
+
+```bash
+steamroller --version
+```
+
+---
+
+### `--help`, `-h`
+
+Show help information.
+
+```bash
+steamroller --help
+```

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -1,0 +1,174 @@
+# Configuration Options
+
+This page documents all input and output configuration options for Steamroller.
+
+> **Note:** Steamroller is pre-implementation. Detailed documentation will be added as features are
+> implemented.
+
+## Input Options
+
+### `input`
+
+The entry point(s) for the bundle.
+
+```typescript
+// Single entry
+input: "src/index.ts"
+
+// Multiple entries
+input: ["src/index.ts", "src/cli.ts"]
+
+// Named entries
+input: { main: "src/index.ts", cli: "src/cli.ts" }
+```
+
+**Type:** `string | string[] | Record<string, string>`
+
+---
+
+### `plugins`
+
+An array of plugins to use during bundling.
+
+```typescript
+plugins: [resolve(), commonjs()]
+```
+
+**Type:** `(Plugin | null | false | undefined)[]`
+
+---
+
+### `external`
+
+Modules to treat as external (not included in the bundle).
+
+```typescript
+// Array of module IDs
+external: ["lodash", "react"]
+
+// Function
+external: (id) => id.startsWith("node:")
+```
+
+**Type:** `string[] | RegExp[] | ((id: string) => boolean)`
+
+---
+
+### `onwarn`
+
+Handler for warning messages during bundling.
+
+**Type:** `(warning: RollupWarning, defaultHandler: (warning: RollupWarning) => void) => void`
+
+---
+
+### `cache`
+
+The cache from a previous build to speed up subsequent builds.
+
+**Type:** `RollupCache | false`
+
+---
+
+### `treeshake`
+
+Controls tree-shaking behavior.
+
+**Type:** `boolean | TreeshakingOptions`
+
+---
+
+## Output Options
+
+### `dir`
+
+The directory for output chunks when code-splitting.
+
+**Type:** `string`
+
+---
+
+### `file`
+
+The output file path for single-file builds.
+
+**Type:** `string`
+
+---
+
+### `format`
+
+The output format.
+
+**Type:** `"es" | "cjs" | "iife" | "umd" | "amd" | "system"`
+
+---
+
+### `name`
+
+The global variable name for `iife` and `umd` builds.
+
+**Type:** `string`
+
+---
+
+### `globals`
+
+Global variable names for external modules in `iife` and `umd` builds.
+
+```typescript
+globals: {
+  jquery: "$",
+  react: "React",
+}
+```
+
+**Type:** `Record<string, string> | ((id: string) => string)`
+
+---
+
+### `sourcemap`
+
+Controls source map generation.
+
+**Type:** `boolean | "inline" | "hidden"`
+
+---
+
+### `banner` / `footer`
+
+Code to prepend or append to the bundle.
+
+**Type:** `string | (() => string | Promise<string>)`
+
+---
+
+### `intro` / `outro`
+
+Code to insert inside the wrapper (after the banner, before the footer).
+
+**Type:** `string | (() => string | Promise<string>)`
+
+---
+
+### `exports`
+
+Controls what is exported from the bundle.
+
+**Type:** `"auto" | "default" | "named" | "none"`
+
+---
+
+### `interop`
+
+Controls interop behavior for default/namespace imports from CommonJS modules.
+
+**Type:** `"auto" | "esModule" | "default" | "defaultOnly" | ((id: string) => string)`
+
+---
+
+### `paths`
+
+Rewrites external module IDs in the output.
+
+**Type:** `Record<string, string> | ((id: string) => string)`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Steamroller Documentation
+
+Steamroller is a Rollup-compatible JavaScript module bundler. This documentation covers the
+JavaScript API, configuration options, plugin development, CLI usage, and migration from Rollup.
+
+> **Note:** Steamroller is pre-implementation. These pages outline the planned structure and will be
+> expanded as features are implemented.
+
+## Pages
+
+- [JavaScript API](javascript-api.md) - `rollup()`, `watch()`, `defineConfig()`, and `VERSION`
+- [Configuration Options](configuration-options.md) - Input and output options reference
+- [Plugin Development](plugin-development.md) - Plugin hooks, context object, and emitted files
+- [CLI Usage](cli.md) - Command-line flags and usage
+- [Migration from Rollup](migration-from-rollup.md) - Guide for migrating existing Rollup projects

--- a/docs/javascript-api.md
+++ b/docs/javascript-api.md
@@ -1,0 +1,97 @@
+# JavaScript API
+
+Steamroller exposes a JavaScript API for programmatic bundling, file watching, configuration
+helpers, and version information.
+
+> **Note:** Steamroller is pre-implementation. Detailed documentation will be added as features are
+> implemented.
+
+## `rollup()`
+
+Creates a bundle from the given input options.
+
+```typescript
+import { rollup } from "steamroller";
+
+const bundle = await rollup(inputOptions);
+const { output } = await bundle.write(outputOptions);
+await bundle.close();
+```
+
+### Parameters
+
+| Parameter      | Type           | Description                |
+| -------------- | -------------- | -------------------------- |
+| `inputOptions` | `InputOptions` | Bundle input configuration |
+
+### Returns
+
+`Promise<RollupBuild>` - A build object with `generate()`, `write()`, and `close()` methods.
+
+---
+
+## `watch()`
+
+Watches input files and rebuilds on changes.
+
+```typescript
+import { watch } from "steamroller";
+
+const watcher = watch(watchOptions);
+
+watcher.on("event", (event) => {
+  // handle rebuild events
+});
+
+watcher.close();
+```
+
+### Parameters
+
+| Parameter      | Type                              | Description              |
+| -------------- | --------------------------------- | ------------------------ |
+| `watchOptions` | `RollupWatchOptions \| RollupWatchOptions[]` | Watch configuration |
+
+### Returns
+
+`RollupWatcher` - A watcher instance with event subscription and `close()` methods.
+
+---
+
+## `defineConfig()`
+
+A helper for defining configuration with type inference. Returns the input unchanged.
+
+```typescript
+import { defineConfig } from "steamroller";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "es",
+  },
+});
+```
+
+### Parameters
+
+| Parameter | Type                              | Description               |
+| --------- | --------------------------------- | ------------------------- |
+| `config`  | `RollupOptions \| RollupOptions[]` | Configuration object(s) |
+
+### Returns
+
+`RollupOptions | RollupOptions[]` - The same configuration, unchanged.
+
+---
+
+## `VERSION`
+
+A string constant containing the current Steamroller version.
+
+```typescript
+import { VERSION } from "steamroller";
+
+console.log(VERSION); // e.g., "0.1.0"
+```

--- a/docs/migration-from-rollup.md
+++ b/docs/migration-from-rollup.md
@@ -1,0 +1,102 @@
+# Migration from Rollup
+
+This guide covers migrating an existing Rollup project to Steamroller.
+
+> **Note:** Steamroller is pre-implementation. This guide will be updated as features are
+> implemented and compatibility details are finalized.
+
+## Overview
+
+Steamroller aims for full compatibility with the Rollup configuration format and plugin interface.
+In most cases, migrating involves replacing the `rollup` package with `steamroller` and updating
+import paths. Existing configuration files and plugins should work with minimal or no changes.
+
+## Configuration Changes
+
+### Package Installation
+
+```bash
+# Remove Rollup
+npm uninstall rollup
+
+# Install Steamroller
+npm install --save-dev steamroller
+```
+
+### Config File
+
+Rename your config file (optional) and update imports:
+
+```typescript
+// Before (rollup.config.ts)
+import { defineConfig } from "rollup";
+
+// After (steamroller.config.ts)
+import { defineConfig } from "steamroller";
+```
+
+Steamroller reads both `steamroller.config.*` and `rollup.config.*` files, so renaming is optional.
+
+### Package Scripts
+
+Update your `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "build": "steamroller --config",
+    "dev": "steamroller --config --watch"
+  }
+}
+```
+
+### Programmatic API
+
+Update import paths in any code that uses the programmatic API:
+
+```typescript
+// Before
+import { rollup, watch } from "rollup";
+
+// After
+import { rollup, watch } from "steamroller";
+```
+
+## Plugin Compatibility
+
+Steamroller implements the same plugin interface as Rollup. Most Rollup plugins should work without
+modification.
+
+### Compatible Plugins
+
+The following categories of plugins are expected to be compatible:
+
+- `@rollup/plugin-node-resolve`
+- `@rollup/plugin-commonjs`
+- `@rollup/plugin-typescript`
+- `@rollup/plugin-json`
+- `@rollup/plugin-replace`
+- `@rollup/plugin-terser`
+- Other plugins using standard Rollup hook APIs
+
+### Plugin Compatibility Notes
+
+- Plugins that rely on Rollup internals (not the public plugin API) may require updates
+- Plugins must use documented hook APIs for guaranteed compatibility
+- Plugin compatibility will be validated and documented as Steamroller matures
+
+## Known Differences
+
+This section documents intentional deviations from Rollup behavior. As Steamroller is
+pre-implementation, this list will be updated as development progresses.
+
+### Planned Differences
+
+- Implementation language and internal architecture differ from Rollup
+- Performance characteristics may differ
+- Error messages and warning text will differ
+
+### Feature Parity Status
+
+A detailed feature parity tracker will be maintained as implementation progresses. The goal is
+full compatibility with the Rollup configuration and plugin API surface.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,167 @@
+# Plugin Development
+
+Steamroller plugins follow the Rollup plugin interface. A plugin is an object with a `name`
+property and one or more hook functions.
+
+> **Note:** Steamroller is pre-implementation. Detailed documentation will be added as features are
+> implemented.
+
+## Plugin Structure
+
+```typescript
+import type { Plugin } from "steamroller";
+
+export const myPlugin = (): Plugin => ({
+  name: "my-plugin",
+
+  resolveId(source) {
+    // resolve module IDs
+  },
+
+  load(id) {
+    // load module content
+  },
+
+  transform(code, id) {
+    // transform module content
+  },
+});
+```
+
+---
+
+## Build Hooks
+
+Build hooks run during the build phase and control how modules are located, loaded, and
+transformed.
+
+### `options`
+
+Replaces or manipulates the options object. This is the first hook and has no access to prior
+plugin context.
+
+### `buildStart`
+
+Called once at the beginning of a build. Receives the final resolved input options.
+
+### `resolveId`
+
+Resolves an import to a module ID (file path or virtual module). Controls how imports are located.
+
+### `load`
+
+Loads the content of a module given its resolved ID. Returns source code as a string.
+
+### `transform`
+
+Transforms the loaded source code. Can return modified code and an optional source map.
+
+### `moduleParsed`
+
+Called after a module has been fully parsed and its dependencies are known.
+
+### `buildEnd`
+
+Called when the build phase completes, regardless of success or failure.
+
+---
+
+## Output Generation Hooks
+
+Output generation hooks run during `bundle.generate()` or `bundle.write()` and control how chunks
+are rendered and written.
+
+### `outputOptions`
+
+Replaces or manipulates the output options object.
+
+### `renderStart`
+
+Called at the beginning of output generation. Receives output and input options.
+
+### `banner` / `footer` / `intro` / `outro`
+
+Return code strings to be included at specific positions in each chunk.
+
+### `renderChunk`
+
+Transforms individual chunk code after it has been rendered.
+
+### `augmentChunkHash`
+
+Adds additional data to be included in the chunk hash calculation.
+
+### `generateBundle`
+
+Called after all chunks have been generated. Can add, modify, or remove files from the output.
+
+### `writeBundle`
+
+Called after all files have been written to disk (only during `bundle.write()`).
+
+### `closeBundle`
+
+Called when `bundle.close()` is invoked. Use for cleanup.
+
+---
+
+## Plugin Context
+
+Within hook functions, `this` provides access to the plugin context object with utility methods.
+
+### `this.emitFile()`
+
+Emits a file (chunk or asset) to be included in the output.
+
+```typescript
+const refId = this.emitFile({
+  type: "asset",
+  fileName: "data.json",
+  source: JSON.stringify(data),
+});
+```
+
+### `this.getFileName()`
+
+Returns the output file name for an emitted file reference.
+
+### `this.resolve()`
+
+Resolves an import using the plugin pipeline.
+
+### `this.parse()`
+
+Parses code into an AST.
+
+### `this.warn()`
+
+Emits a warning message.
+
+### `this.error()`
+
+Emits an error and aborts the build.
+
+---
+
+## Emitted Files
+
+Plugins can emit two types of files:
+
+- **Chunks** - Additional entry points that go through the full bundling pipeline
+- **Assets** - Static files included in the output as-is
+
+```typescript
+// Emit a chunk
+this.emitFile({
+  type: "chunk",
+  id: "src/worker.ts",
+  fileName: "worker.js",
+});
+
+// Emit an asset
+this.emitFile({
+  type: "asset",
+  fileName: "manifest.json",
+  source: JSON.stringify(manifest),
+});
+```


### PR DESCRIPTION
## Summary

- Adds skeleton documentation directory (`docs/`) with an index page linking to all sub-pages
- Creates placeholder pages for JavaScript API, configuration options, plugin development, CLI usage, and migration from Rollup
- Uses GitHub-flavored Markdown with language-tagged code blocks, one concept per page, and relative internal links

## Test plan

- [ ] Verify all six markdown files render correctly on GitHub
- [ ] Verify relative links between pages resolve properly
- [ ] Confirm no broken links in `docs/index.md`

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)