### PR TITLE
chore: set up CodeQL and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@48ab28a6b1c830e7e27c0b14aef1f29c3ba5b30a
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@48ab28a6b1c830e7e27c0b14aef1f29c3ba5b30a
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@48ab28a6b1c830e7e27c0b14aef1f29c3ba5b30a
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary
- Adds CodeQL security scanning workflow for JavaScript/TypeScript (runs on push, PR, and weekly schedule)
- Adds Dependabot configuration for npm and GitHub Actions dependency updates (weekly on Mondays)
- All GitHub Actions are pinned to specific commit SHAs per coding standards

Closes #124

## Test plan
- [ ] Verify CodeQL workflow triggers on push to main
- [ ] Verify CodeQL workflow triggers on PRs to main
- [ ] Verify Dependabot opens dependency update PRs on schedule
- [ ] Confirm GitHub Actions are pinned to commit SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)