### PR TITLE
chore: set up cross-platform CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,12 @@ jobs:
         run: npm run lint
 
   test:
-    name: Test (Node ${{ matrix.node-version }})
+    name: Test (${{ matrix.os }}, Node ${{ matrix.node-version }})
     needs: lint-typecheck
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [18, 20, 22]
     steps:
       - name: Checkout
@@ -58,7 +59,7 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: coverage-node-${{ matrix.node-version }}
+          name: coverage-${{ matrix.os }}-node-${{ matrix.node-version }}
           path: coverage/
           retention-days: 7
 


### PR DESCRIPTION
## Summary
- Expands the CI test job to run across Ubuntu, macOS, and Windows
- Tests against Node.js 18, 20, and 22 on all three platforms (9 matrix combinations)
- Updates coverage artifact names to include the OS for uniqueness

Closes #125

## Test plan
- [ ] Verify CI matrix runs all 9 combinations (3 OS x 3 Node versions)
- [ ] Confirm coverage artifacts are uploaded with OS-specific names
- [ ] Ensure lint-typecheck and build jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)