### PR TITLE
chore: set up rollup compatibility test harness

### DIFF
--- a/tests/compat/harness.test.ts
+++ b/tests/compat/harness.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { diffOutputs } from './harness.js';
+
+describe('compat harness', () => {
+  describe('diffOutputs', () => {
+    it('reports match when outputs are identical', () => {
+      const result = diffOutputs('const x = 1;\n', 'const x = 1;\n');
+      expect(result.match).toBe(true);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+
+    it('reports mismatch with diagnostics', () => {
+      const result = diffOutputs('const x = 1;\n', 'const x = 2;\n');
+      expect(result.match).toBe(false);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it('reports line count mismatch', () => {
+      const result = diffOutputs('line1\nline2\n', 'line1\n');
+      expect(result.match).toBe(false);
+      expect(result.diagnostics.some(d => d.includes('Line count mismatch'))).toBe(true);
+    });
+  });
+});

--- a/tests/compat/harness.ts
+++ b/tests/compat/harness.ts
@@ -1,0 +1,73 @@
+import { execSync } from 'node:child_process';
+
+export interface ComparisonResult {
+  readonly input: string;
+  readonly rollupOutput: string;
+  readonly steamrollerOutput: string;
+  readonly match: boolean;
+  readonly diagnostics: ReadonlyArray<string>;
+}
+
+export interface HarnessOptions {
+  readonly inputDir: string;
+  readonly outputDir: string;
+  readonly rollupConfig?: string;
+  readonly steamrollerConfig?: string;
+}
+
+export const runRollup = (inputFile: string, outputFile: string, configFile?: string): string => {
+  const configArg = configFile ? `--config ${configFile}` : '';
+  const result = execSync(
+    `npx rollup ${inputFile} --file ${outputFile} ${configArg}`,
+    { encoding: 'utf-8' }
+  );
+  return result;
+};
+
+export const runSteamroller = (inputFile: string, outputFile: string, configFile?: string): string => {
+  // TODO: Replace with steamroller CLI once implemented
+  throw new Error('steamroller CLI not yet implemented');
+};
+
+export const diffOutputs = (rollupOutput: string, steamrollerOutput: string): ComparisonResult => {
+  const diagnostics: Array<string> = [];
+  const match = rollupOutput === steamrollerOutput;
+
+  if (!match) {
+    const rollupLines = rollupOutput.split('\n');
+    const steamrollerLines = steamrollerOutput.split('\n');
+
+    if (rollupLines.length !== steamrollerLines.length) {
+      diagnostics.push(
+        `Line count mismatch: rollup=${rollupLines.length}, steamroller=${steamrollerLines.length}`
+      );
+    }
+
+    const maxLines = Math.max(rollupLines.length, steamrollerLines.length);
+    for (let i = 0; i < maxLines; i++) {
+      if (rollupLines[i] !== steamrollerLines[i]) {
+        diagnostics.push(`Line ${i + 1} differs:`);
+        diagnostics.push(`  rollup:       ${rollupLines[i] ?? '<missing>'}`);
+        diagnostics.push(`  steamroller:  ${steamrollerLines[i] ?? '<missing>'}`);
+        if (diagnostics.length > 30) {
+          diagnostics.push('... (truncated)');
+          break;
+        }
+      }
+    }
+  }
+
+  return {
+    input: '',
+    rollupOutput,
+    steamrollerOutput,
+    match,
+    diagnostics,
+  };
+};
+
+export const runComparison = (options: HarnessOptions): ReadonlyArray<ComparisonResult> => {
+  const results: Array<ComparisonResult> = [];
+  // TODO: Implement full comparison workflow once steamroller CLI exists
+  return results;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
 
-export const config = defineConfig({
+// vitest requires a default export for config files
+// eslint-disable-next-line import/no-default-export
+export default defineConfig({
   test: {
     coverage: {
       provider: 'v8',
@@ -17,6 +19,7 @@ export const config = defineConfig({
       'tests/unit/**/*.test.ts',
       'tests/integration/**/*.test.ts',
       'tests/e2e/**/*.test.ts',
+      'tests/compat/**/*.test.ts',
     ],
   },
 });


### PR DESCRIPTION
## Summary
- Adds differential testing framework at `tests/compat/` that compares rollup and steamroller outputs
- Includes `diffOutputs` function with line-by-line mismatch diagnostics (truncated at 30 entries)
- Scaffolds `runRollup`, `runSteamroller`, and `runComparison` functions for future implementation
- Adds `tests/compat/fixtures/.gitkeep` for future test fixture files
- Fixes vitest config to use default export (required by vitest API)
- Adds `tests/compat/**/*.test.ts` to vitest include paths

Closes #13

## Test plan
- [x] `diffOutputs` reports match when outputs are identical
- [x] `diffOutputs` reports mismatch with line-level diagnostics
- [x] `diffOutputs` detects line count mismatches
- [ ] Full comparison workflow to be implemented once steamroller CLI exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)