### PR TITLE
feat: reimplement LRU cache (flru replacement)

### DIFF
--- a/src/utils/lru-cache.ts
+++ b/src/utils/lru-cache.ts
@@ -1,0 +1,68 @@
+/**
+ * Zero-dependency LRU cache using Map for O(1) access
+ * with insertion-order eviction.
+ *
+ * @module lru-cache
+ */
+
+/**
+ * Least-recently-used cache with configurable max size.
+ * Uses Map's insertion-order iteration to track recency.
+ */
+export class LruCache<K, V> {
+  /** Internal storage; insertion order = access recency. */
+  private readonly cache: Map<K, V>;
+
+  /** Maximum number of entries before eviction. */
+  private readonly maxSize: number;
+
+  constructor(maxSize: number) {
+    if (maxSize < 1 || !Number.isInteger(maxSize)) {
+      throw new Error('LruCache: maxSize must be a positive integer');
+    }
+    this.maxSize = maxSize;
+    this.cache = new Map<K, V>();
+  }
+
+  /** Number of entries currently stored. */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Retrieve a value and promote the key to most-recent. */
+  get(key: K): V | undefined {
+    if (!this.cache.has(key)) {
+      return undefined;
+    }
+    const value = this.cache.get(key) as V;
+    this.cache.delete(key);
+    this.cache.set(key, value);
+    return value;
+  }
+
+  /** Insert or update a key-value pair; evicts oldest on overflow. */
+  set(key: K, value: V): void {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.maxSize) {
+      const oldest = this.cache.keys().next().value as K;
+      this.cache.delete(oldest);
+    }
+    this.cache.set(key, value);
+  }
+
+  /** Check whether a key exists without promoting it. */
+  has(key: K): boolean {
+    return this.cache.has(key);
+  }
+
+  /** Remove a key. Returns true if the key existed. */
+  delete(key: K): boolean {
+    return this.cache.delete(key);
+  }
+
+  /** Remove all entries. */
+  clear(): void {
+    this.cache.clear();
+  }
+}

--- a/tests/unit/utils/lru-cache.test.ts
+++ b/tests/unit/utils/lru-cache.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { LruCache } from '../../../src/utils/lru-cache';
+
+describe('LruCache', () => {
+  describe('constructor', () => {
+    it('creates a cache with valid maxSize', () => {
+      const cache = new LruCache<string, number>(5);
+      expect(cache.size).toBe(0);
+    });
+
+    it('throws on maxSize < 1', () => {
+      expect(() => new LruCache<string, number>(0)).toThrow(
+        'LruCache: maxSize must be a positive integer',
+      );
+    });
+
+    it('throws on negative maxSize', () => {
+      expect(() => new LruCache<string, number>(-1)).toThrow(
+        'LruCache: maxSize must be a positive integer',
+      );
+    });
+
+    it('throws on non-integer maxSize', () => {
+      expect(() => new LruCache<string, number>(2.5)).toThrow(
+        'LruCache: maxSize must be a positive integer',
+      );
+    });
+  });
+
+  describe('set() and get()', () => {
+    it('stores and retrieves a value', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      expect(cache.get('a')).toBe(1);
+    });
+
+    it('returns undefined for non-existent key', () => {
+      const cache = new LruCache<string, number>(3);
+      expect(cache.get('missing')).toBeUndefined();
+    });
+
+    it('updates existing key without changing size', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.set('a', 10);
+      expect(cache.size).toBe(2);
+      expect(cache.get('a')).toBe(10);
+    });
+
+    it('handles multiple types as keys', () => {
+      const cache = new LruCache<number, string>(3);
+      cache.set(1, 'one');
+      cache.set(2, 'two');
+      expect(cache.get(1)).toBe('one');
+      expect(cache.get(2)).toBe('two');
+    });
+  });
+
+  describe('eviction', () => {
+    it('evicts oldest entry when max size exceeded', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.set('c', 3);
+      cache.set('d', 4);
+      expect(cache.size).toBe(3);
+      expect(cache.has('a')).toBe(false);
+      expect(cache.get('b')).toBe(2);
+      expect(cache.get('c')).toBe(3);
+      expect(cache.get('d')).toBe(4);
+    });
+
+    it('evicts correct entry after get() promotes a key', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.set('c', 3);
+      // promote 'a' to most recent
+      cache.get('a');
+      // insert 'd' — should evict 'b' (now oldest)
+      cache.set('d', 4);
+      expect(cache.has('b')).toBe(false);
+      expect(cache.has('a')).toBe(true);
+      expect(cache.has('c')).toBe(true);
+      expect(cache.has('d')).toBe(true);
+    });
+
+    it('evicts correct entry after set() updates existing key', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.set('c', 3);
+      // update 'a' — moves it to most recent
+      cache.set('a', 10);
+      // insert 'd' — should evict 'b' (now oldest)
+      cache.set('d', 4);
+      expect(cache.has('b')).toBe(false);
+      expect(cache.has('a')).toBe(true);
+      expect(cache.get('a')).toBe(10);
+    });
+  });
+
+  describe('has()', () => {
+    it('returns true for existing key', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      expect(cache.has('a')).toBe(true);
+    });
+
+    it('returns false for non-existing key', () => {
+      const cache = new LruCache<string, number>(3);
+      expect(cache.has('missing')).toBe(false);
+    });
+  });
+
+  describe('delete()', () => {
+    it('returns true and removes existing key', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      expect(cache.delete('a')).toBe(true);
+      expect(cache.has('a')).toBe(false);
+      expect(cache.size).toBe(0);
+    });
+
+    it('returns false for non-existing key', () => {
+      const cache = new LruCache<string, number>(3);
+      expect(cache.delete('missing')).toBe(false);
+    });
+  });
+
+  describe('clear()', () => {
+    it('removes all entries', () => {
+      const cache = new LruCache<string, number>(3);
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.set('c', 3);
+      cache.clear();
+      expect(cache.size).toBe(0);
+      expect(cache.has('a')).toBe(false);
+      expect(cache.has('b')).toBe(false);
+      expect(cache.has('c')).toBe(false);
+    });
+  });
+
+  describe('size', () => {
+    it('reflects current entry count', () => {
+      const cache = new LruCache<string, number>(5);
+      expect(cache.size).toBe(0);
+      cache.set('a', 1);
+      expect(cache.size).toBe(1);
+      cache.set('b', 2);
+      expect(cache.size).toBe(2);
+      cache.delete('a');
+      expect(cache.size).toBe(1);
+    });
+  });
+
+  describe('edge: max size of 1', () => {
+    it('holds only one entry at a time', () => {
+      const cache = new LruCache<string, number>(1);
+      cache.set('a', 1);
+      expect(cache.size).toBe(1);
+      expect(cache.get('a')).toBe(1);
+
+      cache.set('b', 2);
+      expect(cache.size).toBe(1);
+      expect(cache.has('a')).toBe(false);
+      expect(cache.get('b')).toBe(2);
+    });
+
+    it('updates in place without eviction', () => {
+      const cache = new LruCache<string, number>(1);
+      cache.set('a', 1);
+      cache.set('a', 2);
+      expect(cache.size).toBe(1);
+      expect(cache.get('a')).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Zero-dependency generic `LruCache<K, V>` class using `Map` for O(1) access with insertion-order eviction
- Configurable max size with `get`, `set`, `has`, `delete`, `clear`, and `size` API
- 100% test coverage across 19 tests including eviction ordering, promotion on access, edge cases (max size 1), and constructor validation

Closes #112

## Test plan
- [x] Basic set/get stores and retrieves values
- [x] Eviction removes oldest entry when max size exceeded
- [x] `get()` promotes key to most recent (changes eviction order)
- [x] `set()` update on existing key preserves size and promotes
- [x] `has()` returns correct boolean for existing/missing keys
- [x] `delete()` returns true/false and removes entry
- [x] `clear()` empties entire cache
- [x] Edge: max size of 1 holds only one entry
- [x] Edge: non-existent key returns undefined
- [x] Constructor rejects invalid maxSize (0, negative, non-integer)
- [x] 100% statement, branch, function, and line coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)