### PR TITLE
feat: reimplement is-reference and locate-character utilities

### DIFF
--- a/src/utils/ast-utils.ts
+++ b/src/utils/ast-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * AST reference detection and source position mapping utilities.
+ *
+ * Provides isReference() to determine if an AST node represents a
+ * variable reference (vs declaration, property key, or label), and
+ * locateCharacter() to map a byte offset to a line/column position.
+ *
+ * @module utils/ast-utils
+ */
+
+/** Minimal AST node shape needed for reference detection. */
+export interface AstNode {
+  readonly type: string;
+  readonly name?: string;
+  readonly computed?: boolean;
+  readonly key?: AstNode;
+  readonly object?: AstNode;
+  readonly property?: AstNode;
+  readonly label?: AstNode;
+  readonly left?: AstNode;
+}
+
+/** A source position expressed as line number and column offset. */
+export interface SourceLocation {
+  readonly line: number;
+  readonly column: number;
+}
+
+/**
+ * Detect whether an AST node is a reference (vs a declaration,
+ * property key, or label) based on its relationship to its parent.
+ *
+ * @param node - The AST node to check.
+ * @param parent - The parent AST node.
+ * @returns true if the node is used as a reference.
+ */
+export const isReference = (node: AstNode, parent: AstNode): boolean => {
+  if (parent.type === "MemberExpression") {
+    return parent.object === node || (parent.computed === true && parent.property === node);
+  }
+
+  if (parent.type === "Property") {
+    return parent.computed === true || parent.key !== node;
+  }
+
+  if (parent.type === "MethodDefinition") {
+    return parent.computed === true || parent.key !== node;
+  }
+
+  if (
+    parent.type === "LabeledStatement" ||
+    parent.type === "BreakStatement" ||
+    parent.type === "ContinueStatement"
+  ) {
+    return parent.label !== node;
+  }
+
+  if (parent.type === "VariableDeclarator") {
+    return parent.left !== node;
+  }
+
+  return true;
+};
+
+/**
+ * Map a byte offset to its line and column position in source text.
+ * Lines are 1-indexed; columns are 0-indexed.
+ *
+ * @param source - The source text.
+ * @param index - The byte offset to locate.
+ * @returns The line/column position, or null if the index is out of bounds.
+ */
+export const locateCharacter = (source: string, index: number): SourceLocation | null => {
+  if (index < 0 || index > source.length) {
+    return null;
+  }
+
+  const lineOffsets: Array<number> = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) {
+      lineOffsets.push(i + 1);
+    }
+  }
+
+  /* Iterative binary search to find the line containing the index. */
+  let low = 0;
+  let high = lineOffsets.length - 1;
+
+  while (low < high) {
+    const mid = (low + high + 1) >>> 1;
+    if (lineOffsets[mid] <= index) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return { line: low + 1, column: index - lineOffsets[low] };
+};

--- a/tests/unit/utils/ast-utils.test.ts
+++ b/tests/unit/utils/ast-utils.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for src/utils/ast-utils.ts
+ *
+ * Covers isReference() and locateCharacter() with happy and
+ * sad paths for >=98% branch/line coverage.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isReference,
+  locateCharacter,
+  type AstNode,
+} from "../../../src/utils/ast-utils";
+
+describe("isReference", () => {
+  describe("MemberExpression", () => {
+    it("returns true when node is the object", () => {
+      const node: AstNode = { type: "Identifier", name: "foo" };
+      const parent: AstNode = {
+        type: "MemberExpression",
+        object: node,
+        property: { type: "Identifier", name: "bar" },
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+
+    it("returns false when node is a non-computed property", () => {
+      const node: AstNode = { type: "Identifier", name: "bar" };
+      const parent: AstNode = {
+        type: "MemberExpression",
+        object: { type: "Identifier", name: "foo" },
+        property: node,
+        computed: false,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+
+    it("returns true when node is a computed property", () => {
+      const node: AstNode = { type: "Identifier", name: "bar" };
+      const parent: AstNode = {
+        type: "MemberExpression",
+        object: { type: "Identifier", name: "foo" },
+        property: node,
+        computed: true,
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+
+    it("returns false when node is unrelated to object and non-computed property", () => {
+      const node: AstNode = { type: "Identifier", name: "baz" };
+      const parent: AstNode = {
+        type: "MemberExpression",
+        object: { type: "Identifier", name: "foo" },
+        property: { type: "Identifier", name: "bar" },
+        computed: false,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+  });
+
+  describe("Property", () => {
+    it("returns false when node is a non-computed key", () => {
+      const node: AstNode = { type: "Identifier", name: "key" };
+      const parent: AstNode = {
+        type: "Property",
+        key: node,
+        computed: false,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+
+    it("returns true when node is a computed key", () => {
+      const node: AstNode = { type: "Identifier", name: "key" };
+      const parent: AstNode = {
+        type: "Property",
+        key: node,
+        computed: true,
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+
+    it("returns true when node is the value (not the key)", () => {
+      const node: AstNode = { type: "Identifier", name: "val" };
+      const parent: AstNode = {
+        type: "Property",
+        key: { type: "Identifier", name: "key" },
+        computed: false,
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+  });
+
+  describe("MethodDefinition", () => {
+    it("returns false when node is a non-computed key", () => {
+      const node: AstNode = { type: "Identifier", name: "method" };
+      const parent: AstNode = {
+        type: "MethodDefinition",
+        key: node,
+        computed: false,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+
+    it("returns true when node is a computed key", () => {
+      const node: AstNode = { type: "Identifier", name: "method" };
+      const parent: AstNode = {
+        type: "MethodDefinition",
+        key: node,
+        computed: true,
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+
+    it("returns true when node is not the key", () => {
+      const node: AstNode = { type: "Identifier", name: "other" };
+      const parent: AstNode = {
+        type: "MethodDefinition",
+        key: { type: "Identifier", name: "method" },
+        computed: false,
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+  });
+
+  describe("LabeledStatement", () => {
+    it("returns false when node is the label", () => {
+      const node: AstNode = { type: "Identifier", name: "loop" };
+      const parent: AstNode = {
+        type: "LabeledStatement",
+        label: node,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+
+    it("returns true when node is not the label", () => {
+      const node: AstNode = { type: "Identifier", name: "other" };
+      const parent: AstNode = {
+        type: "LabeledStatement",
+        label: { type: "Identifier", name: "loop" },
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+  });
+
+  describe("BreakStatement", () => {
+    it("returns false when node is the label", () => {
+      const node: AstNode = { type: "Identifier", name: "loop" };
+      const parent: AstNode = {
+        type: "BreakStatement",
+        label: node,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+
+    it("returns true when node is not the label", () => {
+      const node: AstNode = { type: "Identifier", name: "other" };
+      const parent: AstNode = {
+        type: "BreakStatement",
+        label: { type: "Identifier", name: "loop" },
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+  });
+
+  describe("ContinueStatement", () => {
+    it("returns false when node is the label", () => {
+      const node: AstNode = { type: "Identifier", name: "loop" };
+      const parent: AstNode = {
+        type: "ContinueStatement",
+        label: node,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+
+    it("returns true when node is not the label", () => {
+      const node: AstNode = { type: "Identifier", name: "other" };
+      const parent: AstNode = {
+        type: "ContinueStatement",
+        label: { type: "Identifier", name: "loop" },
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+  });
+
+  describe("VariableDeclarator", () => {
+    it("returns false when node is the left (declaration target)", () => {
+      const node: AstNode = { type: "Identifier", name: "x" };
+      const parent: AstNode = {
+        type: "VariableDeclarator",
+        left: node,
+      };
+      expect(isReference(node, parent)).toBe(false);
+    });
+
+    it("returns true when node is not the left", () => {
+      const node: AstNode = { type: "Identifier", name: "y" };
+      const parent: AstNode = {
+        type: "VariableDeclarator",
+        left: { type: "Identifier", name: "x" },
+      };
+      expect(isReference(node, parent)).toBe(true);
+    });
+  });
+
+  describe("other parent types", () => {
+    it("returns true for ExpressionStatement", () => {
+      const node: AstNode = { type: "Identifier", name: "foo" };
+      const parent: AstNode = { type: "ExpressionStatement" };
+      expect(isReference(node, parent)).toBe(true);
+    });
+
+    it("returns true for CallExpression", () => {
+      const node: AstNode = { type: "Identifier", name: "fn" };
+      const parent: AstNode = { type: "CallExpression" };
+      expect(isReference(node, parent)).toBe(true);
+    });
+
+    it("returns true for ReturnStatement", () => {
+      const node: AstNode = { type: "Identifier", name: "result" };
+      const parent: AstNode = { type: "ReturnStatement" };
+      expect(isReference(node, parent)).toBe(true);
+    });
+
+    it("returns true for AssignmentExpression", () => {
+      const node: AstNode = { type: "Identifier", name: "x" };
+      const parent: AstNode = { type: "AssignmentExpression" };
+      expect(isReference(node, parent)).toBe(true);
+    });
+  });
+});
+
+describe("locateCharacter", () => {
+  it("returns line 1 column 0 for the first character", () => {
+    expect(locateCharacter("hello", 0)).toEqual({ line: 1, column: 0 });
+  });
+
+  it("returns correct position within first line", () => {
+    expect(locateCharacter("hello", 3)).toEqual({ line: 1, column: 3 });
+  });
+
+  it("returns correct position after a newline", () => {
+    expect(locateCharacter("ab\ncd", 3)).toEqual({ line: 2, column: 0 });
+  });
+
+  it("returns correct position for second character on second line", () => {
+    expect(locateCharacter("ab\ncd", 4)).toEqual({ line: 2, column: 1 });
+  });
+
+  it("handles multi-line source", () => {
+    const source = "line1\nline2\nline3";
+    expect(locateCharacter(source, 0)).toEqual({ line: 1, column: 0 });
+    expect(locateCharacter(source, 5)).toEqual({ line: 1, column: 5 });
+    expect(locateCharacter(source, 6)).toEqual({ line: 2, column: 0 });
+    expect(locateCharacter(source, 11)).toEqual({ line: 2, column: 5 });
+    expect(locateCharacter(source, 12)).toEqual({ line: 3, column: 0 });
+    expect(locateCharacter(source, 16)).toEqual({ line: 3, column: 4 });
+  });
+
+  it("returns null for negative index", () => {
+    expect(locateCharacter("hello", -1)).toBeNull();
+  });
+
+  it("returns null for index beyond source length", () => {
+    expect(locateCharacter("hello", 6)).toBeNull();
+  });
+
+  it("handles index at exactly source length (end position)", () => {
+    expect(locateCharacter("hello", 5)).toEqual({ line: 1, column: 5 });
+  });
+
+  it("returns line 1 column 0 for empty source with index 0", () => {
+    expect(locateCharacter("", 0)).toEqual({ line: 1, column: 0 });
+  });
+
+  it("returns null for empty source with index 1", () => {
+    expect(locateCharacter("", 1)).toBeNull();
+  });
+
+  it("handles the newline character itself", () => {
+    expect(locateCharacter("a\nb", 1)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("handles consecutive newlines", () => {
+    const source = "a\n\nb";
+    expect(locateCharacter(source, 0)).toEqual({ line: 1, column: 0 });
+    expect(locateCharacter(source, 1)).toEqual({ line: 1, column: 1 });
+    expect(locateCharacter(source, 2)).toEqual({ line: 2, column: 0 });
+    expect(locateCharacter(source, 3)).toEqual({ line: 3, column: 0 });
+  });
+
+  it("handles source ending with newline", () => {
+    const source = "abc\n";
+    expect(locateCharacter(source, 3)).toEqual({ line: 1, column: 3 });
+    expect(locateCharacter(source, 4)).toEqual({ line: 2, column: 0 });
+  });
+
+  it("handles single newline source", () => {
+    expect(locateCharacter("\n", 0)).toEqual({ line: 1, column: 0 });
+    expect(locateCharacter("\n", 1)).toEqual({ line: 2, column: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `isReference(node, parent)` to detect whether an AST node is a variable reference vs a declaration, property key, or label
- Implements `locateCharacter(source, index)` to map a byte offset to line/column position using an iterative binary search
- 36 tests covering all branches with 100% statement, branch, function, and line coverage

Closes #110

## Test plan
- [x] `npx vitest run tests/unit/utils/ast-utils.test.ts` -- 36 tests pass
- [x] 100% coverage on `src/utils/ast-utils.ts` (statements, branches, functions, lines)
- [x] Happy and sad paths covered for both `isReference` and `locateCharacter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)