### PR TITLE
feat: reimplement @rollup/pluginutils

### DIFF
--- a/src/utils/pluginutils.ts
+++ b/src/utils/pluginutils.ts
@@ -1,0 +1,541 @@
+/**
+ * Zero-dependency reimplementation of @rollup/pluginutils.
+ *
+ * Provides createFilter, dataToEsm, addExtension, makeLegalIdentifier,
+ * extractAssignedNames, and type definitions used by Rollup plugins.
+ *
+ * @module utils/pluginutils
+ */
+
+import { globToRegex } from "./glob.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for {@link dataToEsm}. */
+export interface DataToEsmOptions {
+  readonly indent?: string;
+  readonly preferConst?: boolean;
+  readonly namedExports?: boolean;
+  readonly compact?: boolean;
+}
+
+/**
+ * Minimal AST node shape used by {@link extractAssignedNames}.
+ * Compatible with ESTree / acorn / rollup AST nodes.
+ */
+export interface AstNode {
+  readonly type: string;
+  readonly name?: string;
+  readonly left?: AstNode;
+  readonly argument?: AstNode;
+  readonly elements?: ReadonlyArray<AstNode | null>;
+  readonly properties?: ReadonlyArray<AstNode>;
+  readonly value?: AstNode;
+  readonly key?: AstNode;
+}
+
+/** A single include / exclude filter entry. */
+export type FilterPattern =
+  | string
+  | RegExp
+  | ReadonlyArray<string | RegExp>
+  | null
+  | undefined;
+
+// ---------------------------------------------------------------------------
+// Reserved words
+// ---------------------------------------------------------------------------
+
+/** ECMAScript reserved words that cannot be used as bare identifiers. */
+const RESERVED_WORDS: ReadonlySet<string> = new Set([
+  "abstract",
+  "arguments",
+  "await",
+  "boolean",
+  "break",
+  "byte",
+  "case",
+  "catch",
+  "char",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "double",
+  "else",
+  "enum",
+  "eval",
+  "export",
+  "extends",
+  "false",
+  "final",
+  "finally",
+  "float",
+  "for",
+  "function",
+  "goto",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "int",
+  "interface",
+  "let",
+  "long",
+  "native",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "short",
+  "static",
+  "super",
+  "switch",
+  "synchronized",
+  "this",
+  "throw",
+  "throws",
+  "transient",
+  "true",
+  "try",
+  "typeof",
+  "undefined",
+  "var",
+  "void",
+  "volatile",
+  "while",
+  "with",
+  "yield",
+]);
+
+// ---------------------------------------------------------------------------
+// addExtension
+// ---------------------------------------------------------------------------
+
+/**
+ * Append an extension to a filename when it has none.
+ *
+ * @param filename - The filename to check.
+ * @param ext - Extension to add (default `".js"`).
+ * @returns The filename, with the extension added if it was missing.
+ */
+export const addExtension = (filename: string, ext: string = ".js"): string => {
+  // A filename has an extension if the last segment after the final '/'
+  // (or the whole string if no '/') contains a dot that is not the first char.
+  const lastSlash = filename.lastIndexOf("/");
+  const basename = lastSlash === -1 ? filename : filename.slice(lastSlash + 1);
+  const dotIdx = basename.lastIndexOf(".");
+  if (dotIdx > 0) {
+    return filename;
+  }
+  return filename + ext;
+};
+
+// ---------------------------------------------------------------------------
+// makeLegalIdentifier
+// ---------------------------------------------------------------------------
+
+/** Characters allowed after the first position of a JS identifier. */
+const IDENTIFIER_BODY_RE = /[^$_a-zA-Z0-9]/g;
+
+/**
+ * Turn an arbitrary string into a legal JavaScript identifier.
+ *
+ * - Replaces illegal characters with `_`.
+ * - Prefixes with `_` when the result starts with a digit.
+ * - Prefixes reserved words with `_`.
+ *
+ * @param str - The input string.
+ * @returns A legal JS identifier.
+ */
+export const makeLegalIdentifier = (str: string): string => {
+  const replaced = str.replace(IDENTIFIER_BODY_RE, "_");
+  const result =
+    /^\d/.test(replaced) ? "_" + replaced : replaced;
+  if (RESERVED_WORDS.has(result)) {
+    return "_" + result;
+  }
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// createFilter
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise a {@link FilterPattern} into an array of matchers.
+ *
+ * @param pattern - The include / exclude value.
+ * @returns Array of RegExp matchers derived from the pattern.
+ */
+const normalisePattern = (
+  pattern: FilterPattern,
+): ReadonlyArray<RegExp> => {
+  if (pattern == null) {
+    return [];
+  }
+  if (Array.isArray(pattern)) {
+    const result: Array<RegExp> = [];
+    const len = pattern.length;
+    let i = 0;
+    while (i < len) {
+      const entry = pattern[i];
+      if (typeof entry === "string") {
+        result.push(globToRegex(entry));
+      } else if (entry instanceof RegExp) {
+        result.push(entry);
+      }
+      i += 1;
+    }
+    return result;
+  }
+  if (typeof pattern === "string") {
+    return [globToRegex(pattern)];
+  }
+  if (pattern instanceof RegExp) {
+    return [pattern];
+  }
+  return [];
+};
+
+/**
+ * Build a filter function from include/exclude patterns.
+ *
+ * - When `include` is omitted every id is included by default.
+ * - When `exclude` is omitted nothing is excluded.
+ * - Exclude always wins over include.
+ *
+ * @param include - Pattern(s) an id must match.
+ * @param exclude - Pattern(s) that cause an id to be rejected.
+ * @returns A predicate `(id: string) => boolean`.
+ */
+export const createFilter = (
+  include?: FilterPattern,
+  exclude?: FilterPattern,
+): ((id: string) => boolean) => {
+  const includeMatchers = normalisePattern(include);
+  const excludeMatchers = normalisePattern(exclude);
+  const hasInclude = includeMatchers.length > 0;
+
+  return (id: string): boolean => {
+    // Normalise path separators.
+    const normalised = id.replace(/\\/g, "/");
+
+    // Check excludes first — exclude always wins.
+    const exLen = excludeMatchers.length;
+    let ei = 0;
+    while (ei < exLen) {
+      if ((excludeMatchers[ei] as RegExp).test(normalised)) {
+        return false;
+      }
+      ei += 1;
+    }
+
+    // If no include patterns were given, everything is included.
+    if (!hasInclude) {
+      return true;
+    }
+
+    // Otherwise, at least one include pattern must match.
+    const inLen = includeMatchers.length;
+    let ii = 0;
+    while (ii < inLen) {
+      if ((includeMatchers[ii] as RegExp).test(normalised)) {
+        return true;
+      }
+      ii += 1;
+    }
+
+    return false;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// dataToEsm
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialise a JavaScript value to an ES-module source string.
+ *
+ * @param data - The value to serialise.
+ * @param options - Formatting options.
+ * @returns ESM source code.
+ */
+export const dataToEsm = (
+  data: unknown,
+  options?: DataToEsmOptions,
+): string => {
+  const indent = options?.indent ?? "\t";
+  const preferConst = options?.preferConst ?? false;
+  const namedExports = options?.namedExports ?? true;
+  const compact = options?.compact ?? false;
+
+  const declarationKind = preferConst ? "const" : "var";
+  const effectiveIndent = compact ? "" : indent;
+  const newline = compact ? "" : "\n";
+  const space = compact ? "" : " ";
+  const separator = compact ? "," : ",\n";
+
+  /**
+   * Serialise a single value at a given depth (iterative for primitives,
+   * iterative-stack for compound values is not needed since we only call
+   * this helper for each value — the depth only controls indentation).
+   */
+  const serialise = (value: unknown, depth: number): string => {
+    if (value === null) {
+      return "null";
+    }
+    if (value === undefined) {
+      return "undefined";
+    }
+
+    const valueType = typeof value;
+
+    if (valueType === "string") {
+      return JSON.stringify(value);
+    }
+    if (valueType === "number" || valueType === "boolean") {
+      return String(value);
+    }
+    if (value instanceof RegExp) {
+      return String(value);
+    }
+    if (value instanceof Date) {
+      return "new Date(" + JSON.stringify(value.toISOString()) + ")";
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        return "[]";
+      }
+      const childIndent = effectiveIndent.repeat(depth + 1);
+      const closingIndent = compact ? "" : effectiveIndent.repeat(depth);
+      const items: Array<string> = [];
+      const arrLen = value.length;
+      let ai = 0;
+      while (ai < arrLen) {
+        items.push(childIndent + serialise(value[ai] as unknown, depth + 1));
+        ai += 1;
+      }
+      return (
+        "[" +
+        newline +
+        items.join(separator) +
+        newline +
+        closingIndent +
+        "]"
+      );
+    }
+
+    // Plain object
+    if (isPlainObject(value)) {
+      const obj = value as Record<string, unknown>;
+      const keys = Object.keys(obj);
+      if (keys.length === 0) {
+        return "{}";
+      }
+      const childIndent = effectiveIndent.repeat(depth + 1);
+      const closingIndent = compact ? "" : effectiveIndent.repeat(depth);
+      const entries: Array<string> = [];
+      const objLen = keys.length;
+      let oi = 0;
+      while (oi < objLen) {
+        const k = keys[oi] as string;
+        const keyStr = isLegalIdentifier(k) ? k : JSON.stringify(k);
+        entries.push(
+          childIndent +
+            keyStr +
+            ":" +
+            space +
+            serialise(obj[k] as unknown, depth + 1),
+        );
+        oi += 1;
+      }
+      return (
+        "{" +
+        newline +
+        entries.join(separator) +
+        newline +
+        closingIndent +
+        "}"
+      );
+    }
+
+    // Fallback — attempt JSON
+    return JSON.stringify(value);
+  };
+
+  // Top-level: named exports vs default export
+  if (namedExports && isPlainObject(data)) {
+    const obj = data as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 0) {
+      return "";
+    }
+    const lines: Array<string> = [];
+    const topLen = keys.length;
+    let ti = 0;
+    while (ti < topLen) {
+      const k = keys[ti] as string;
+      const identifier = makeLegalIdentifier(k);
+      const value = serialise(obj[k] as unknown, 0);
+      lines.push(
+        "export " + declarationKind + " " + identifier + " =" + space + value + ";",
+      );
+      ti += 1;
+    }
+    return lines.join(newline) + newline;
+  }
+
+  // namedExports=false — emit a default export
+  // NOTE: default export exception — required by dataToEsm contract
+  const value = serialise(data, 0);
+  return "export default" + space + value + ";" + newline;
+};
+
+/**
+ * Check whether a value is a plain object (not an array, date, regexp, etc.).
+ *
+ * @param value - The value to check.
+ * @returns `true` for plain `{}` objects.
+ */
+const isPlainObject = (value: unknown): boolean => {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return false;
+  }
+  if (value instanceof RegExp || value instanceof Date) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value) as unknown;
+  return proto === Object.prototype || proto === null;
+};
+
+/**
+ * Check whether a string is already a legal JS identifier (no quoting needed).
+ *
+ * @param str - The string to test.
+ * @returns `true` if it can be used as-is as a property key.
+ */
+const isLegalIdentifier = (str: string): boolean => {
+  if (str.length === 0) {
+    return false;
+  }
+  if (RESERVED_WORDS.has(str)) {
+    return false;
+  }
+  return /^[a-zA-Z$_][a-zA-Z0-9$_]*$/.test(str);
+};
+
+// ---------------------------------------------------------------------------
+// extractAssignedNames
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract assigned variable names from an ESTree destructuring pattern.
+ *
+ * Uses an iterative stack-based approach (no recursion).
+ *
+ * Supported node types:
+ * - `Identifier`
+ * - `ObjectPattern`
+ * - `ArrayPattern`
+ * - `RestElement`
+ * - `AssignmentPattern`
+ * - `Property` (object pattern properties)
+ *
+ * @param param - The AST node (pattern) to inspect.
+ * @returns Array of extracted identifier names.
+ */
+export const extractAssignedNames = (
+  param: AstNode,
+): ReadonlyArray<string> => {
+  const names: Array<string> = [];
+  const stack: Array<AstNode> = [param];
+
+  while (stack.length > 0) {
+    const node = stack.pop() as AstNode;
+
+    if (node.type === "Identifier") {
+      if (node.name !== undefined) {
+        names.push(node.name);
+      }
+      continue;
+    }
+
+    if (node.type === "ObjectPattern") {
+      if (node.properties !== undefined) {
+        const props = node.properties;
+        const pLen = props.length;
+        let pi = pLen - 1;
+        // Push in reverse so we process in source order.
+        while (pi >= 0) {
+          const prop = props[pi] as AstNode;
+          if (prop.type === "RestElement") {
+            stack.push(prop);
+          } else if (prop.value !== undefined) {
+            stack.push(prop.value);
+          }
+          pi -= 1;
+        }
+      }
+      continue;
+    }
+
+    if (node.type === "ArrayPattern") {
+      if (node.elements !== undefined) {
+        const elems = node.elements;
+        const eLen = elems.length;
+        let ei = eLen - 1;
+        while (ei >= 0) {
+          const elem = elems[ei];
+          if (elem !== null && elem !== undefined) {
+            stack.push(elem);
+          }
+          ei -= 1;
+        }
+      }
+      continue;
+    }
+
+    if (node.type === "RestElement") {
+      if (node.argument !== undefined) {
+        stack.push(node.argument);
+      }
+      continue;
+    }
+
+    if (node.type === "AssignmentPattern") {
+      if (node.left !== undefined) {
+        stack.push(node.left);
+      }
+      continue;
+    }
+  }
+
+  return names;
+};
+
+// ---------------------------------------------------------------------------
+// attachScopes (stub)
+// ---------------------------------------------------------------------------
+
+/**
+ * Attach scope information to an AST.
+ *
+ * @todo Implement scope attachment for full pluginutils compatibility.
+ */
+export const attachScopes = (): void => {
+  // TODO: implement attachScopes
+};

--- a/tests/unit/utils/pluginutils.test.ts
+++ b/tests/unit/utils/pluginutils.test.ts
@@ -1,0 +1,645 @@
+import { describe, it, expect } from "vitest";
+import {
+  createFilter,
+  dataToEsm,
+  addExtension,
+  makeLegalIdentifier,
+  extractAssignedNames,
+  attachScopes,
+} from "../../../src/utils/pluginutils.js";
+import type {
+  DataToEsmOptions,
+  AstNode,
+  FilterPattern,
+} from "../../../src/utils/pluginutils.js";
+
+// ---------------------------------------------------------------------------
+// createFilter
+// ---------------------------------------------------------------------------
+
+describe("createFilter", () => {
+  it("matches everything when called with no arguments", () => {
+    const filter = createFilter();
+    expect(filter("foo.ts")).toBe(true);
+    expect(filter("bar/baz.js")).toBe(true);
+    expect(filter("")).toBe(true);
+  });
+
+  it("filters by a single string include pattern", () => {
+    const filter = createFilter("*.ts");
+    expect(filter("foo.ts")).toBe(true);
+    expect(filter("foo.js")).toBe(false);
+  });
+
+  it("filters by a RegExp include pattern", () => {
+    const filter = createFilter(/\.tsx?$/);
+    expect(filter("component.tsx")).toBe(true);
+    expect(filter("component.ts")).toBe(true);
+    expect(filter("component.js")).toBe(false);
+  });
+
+  it("excludes overrides include", () => {
+    const filter = createFilter("*.ts", "secret.ts");
+    expect(filter("foo.ts")).toBe(true);
+    expect(filter("secret.ts")).toBe(false);
+  });
+
+  it("accepts an array of include patterns", () => {
+    const filter = createFilter(["*.ts", "*.tsx"]);
+    expect(filter("a.ts")).toBe(true);
+    expect(filter("b.tsx")).toBe(true);
+    expect(filter("c.js")).toBe(false);
+  });
+
+  it("accepts an array of exclude patterns", () => {
+    const filter = createFilter(undefined, ["*.test.ts", "*.spec.ts"]);
+    expect(filter("foo.ts")).toBe(true);
+    expect(filter("foo.test.ts")).toBe(false);
+    expect(filter("foo.spec.ts")).toBe(false);
+  });
+
+  it("handles mixed string and RegExp in arrays", () => {
+    const filter = createFilter(["*.ts", /\.jsx$/]);
+    expect(filter("a.ts")).toBe(true);
+    expect(filter("b.jsx")).toBe(true);
+    expect(filter("c.css")).toBe(false);
+  });
+
+  it("handles glob patterns with directories", () => {
+    const filter = createFilter("src/**");
+    expect(filter("src/foo.ts")).toBe(true);
+    expect(filter("src/nested/bar.ts")).toBe(true);
+    expect(filter("lib/foo.ts")).toBe(false);
+  });
+
+  it("handles null include (matches everything)", () => {
+    const filter = createFilter(null);
+    expect(filter("anything.ts")).toBe(true);
+  });
+
+  it("handles undefined exclude (excludes nothing)", () => {
+    const filter = createFilter("*.ts", undefined);
+    expect(filter("foo.ts")).toBe(true);
+    expect(filter("foo.js")).toBe(false);
+  });
+
+  it("handles null exclude (excludes nothing)", () => {
+    const filter = createFilter("*.ts", null);
+    expect(filter("foo.ts")).toBe(true);
+  });
+
+  it("normalises backslashes in ids", () => {
+    const filter = createFilter("src/**");
+    expect(filter("src\\foo.ts")).toBe(true);
+  });
+
+  it("returns false when id matches no include pattern", () => {
+    const filter = createFilter(["*.ts"]);
+    expect(filter("main.js")).toBe(false);
+    expect(filter("readme.md")).toBe(false);
+  });
+
+  it("handles RegExp in exclude array", () => {
+    const filter = createFilter(undefined, [/node_modules/]);
+    expect(filter("src/index.ts")).toBe(true);
+    expect(filter("node_modules/foo/bar.js")).toBe(false);
+  });
+
+  it("handles empty array patterns", () => {
+    const filter = createFilter([]);
+    // No include matchers means hasInclude is false, so everything passes
+    expect(filter("anything")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dataToEsm
+// ---------------------------------------------------------------------------
+
+describe("dataToEsm", () => {
+  it("serialises a string value", () => {
+    const result = dataToEsm("hello", { namedExports: false });
+    expect(result).toContain('export default "hello"');
+  });
+
+  it("serialises a number", () => {
+    const result = dataToEsm(42, { namedExports: false });
+    expect(result).toContain("export default 42");
+  });
+
+  it("serialises a boolean", () => {
+    const result = dataToEsm(true, { namedExports: false });
+    expect(result).toContain("export default true");
+  });
+
+  it("serialises null", () => {
+    const result = dataToEsm(null, { namedExports: false });
+    expect(result).toContain("export default null");
+  });
+
+  it("serialises undefined", () => {
+    const result = dataToEsm(undefined, { namedExports: false });
+    expect(result).toContain("export default undefined");
+  });
+
+  it("serialises an object with namedExports=true (default)", () => {
+    const result = dataToEsm({ foo: "bar", count: 1 });
+    expect(result).toContain('export var foo = "bar"');
+    expect(result).toContain("export var count = 1");
+  });
+
+  it("serialises an object with namedExports=false", () => {
+    const result = dataToEsm({ a: 1 }, { namedExports: false });
+    expect(result).toContain("export default");
+    expect(result).toContain("a: 1");
+  });
+
+  it("serialises arrays", () => {
+    const result = dataToEsm([1, 2, 3], { namedExports: false });
+    expect(result).toContain("export default");
+    expect(result).toContain("1");
+    expect(result).toContain("2");
+    expect(result).toContain("3");
+  });
+
+  it("serialises nested objects", () => {
+    const result = dataToEsm(
+      { outer: { inner: "value" } },
+      { namedExports: true },
+    );
+    expect(result).toContain("export var outer");
+    expect(result).toContain('inner: "value"');
+  });
+
+  it("uses compact mode", () => {
+    const result = dataToEsm({ a: 1, b: 2 }, { compact: true });
+    // Compact: no spaces around assignment, no newlines
+    expect(result).not.toContain("\n");
+    expect(result).toContain("export var a =1;");
+  });
+
+  it("uses compact mode with nested objects", () => {
+    const result = dataToEsm(
+      { nested: { x: 1 } },
+      { compact: true, namedExports: false },
+    );
+    expect(result).toContain("x:1");
+    expect(result).not.toContain("\n");
+  });
+
+  it("uses preferConst", () => {
+    const result = dataToEsm({ x: 10 }, { preferConst: true });
+    expect(result).toContain("export const x");
+  });
+
+  it("uses custom indent", () => {
+    const result = dataToEsm(
+      { nested: { deep: true } },
+      { indent: "  " },
+    );
+    expect(result).toContain("  deep: true");
+  });
+
+  it("handles empty objects with namedExports=true", () => {
+    const result = dataToEsm({});
+    expect(result).toBe("");
+  });
+
+  it("handles empty arrays", () => {
+    const result = dataToEsm([], { namedExports: false });
+    expect(result).toContain("[]");
+  });
+
+  it("handles empty nested objects", () => {
+    const result = dataToEsm({ a: {} });
+    expect(result).toContain("{}");
+  });
+
+  it("handles RegExp values", () => {
+    const result = dataToEsm({ pattern: /foo/g }, { namedExports: true });
+    expect(result).toContain("/foo/g");
+  });
+
+  it("handles Date values", () => {
+    const d = new Date("2024-01-01T00:00:00.000Z");
+    const result = dataToEsm({ created: d });
+    expect(result).toContain("new Date(");
+    expect(result).toContain("2024-01-01");
+  });
+
+  it("quotes non-identifier object keys", () => {
+    const result = dataToEsm({ "foo-bar": 1 }, { namedExports: false });
+    expect(result).toContain('"foo-bar"');
+  });
+
+  it("does not quote valid identifier keys", () => {
+    const result = dataToEsm({ valid: 1 }, { namedExports: false });
+    expect(result).toContain("valid:");
+    expect(result).not.toContain('"valid"');
+  });
+
+  it("handles non-object data with namedExports=true (falls through to default)", () => {
+    const result = dataToEsm(42);
+    expect(result).toContain("export default 42");
+  });
+
+  it("serialises with default options when no options provided", () => {
+    const result = dataToEsm({ key: "value" });
+    expect(result).toContain("export var key");
+    expect(result).toContain("var");
+  });
+
+  it("default indent is tab for nested objects", () => {
+    const result = dataToEsm({ o: { k: 1 } });
+    expect(result).toContain("\tk: 1");
+  });
+
+  it("quotes reserved-word keys in objects", () => {
+    const result = dataToEsm({ nested: { class: "x" } }, { namedExports: false });
+    expect(result).toContain('"class"');
+  });
+
+  it("makes illegal identifier keys legal in named exports", () => {
+    const result = dataToEsm({ "my-var": 1 }, { namedExports: true });
+    expect(result).toContain("export var my_var");
+  });
+
+  it("handles arrays with mixed types", () => {
+    const result = dataToEsm([1, "two", true, null], { namedExports: false });
+    expect(result).toContain("1");
+    expect(result).toContain('"two"');
+    expect(result).toContain("true");
+    expect(result).toContain("null");
+  });
+
+  it("compact mode with namedExports=false", () => {
+    const result = dataToEsm({ a: 1 }, { namedExports: false, compact: true });
+    expect(result).toContain("export default{a:1};");
+  });
+
+  it("handles object with null prototype", () => {
+    const obj = Object.create(null) as Record<string, unknown>;
+    obj["key"] = "value";
+    const result = dataToEsm(obj);
+    expect(result).toContain("export var key");
+  });
+
+  it("handles empty string key in object", () => {
+    const result = dataToEsm({ "": "empty" }, { namedExports: false });
+    expect(result).toContain('""');
+  });
+
+  it("handles Date in array", () => {
+    const d = new Date("2024-06-15T00:00:00.000Z");
+    const result = dataToEsm([d], { namedExports: false });
+    expect(result).toContain("new Date(");
+  });
+
+  it("handles RegExp in array", () => {
+    const result = dataToEsm([/test/i], { namedExports: false });
+    expect(result).toContain("/test/i");
+  });
+
+  it("treats array at top level as non-object (default export)", () => {
+    // Array is not a plain object, so namedExports=true still produces default
+    const result = dataToEsm([1, 2]);
+    expect(result).toContain("export default");
+  });
+
+  it("treats RegExp at top level as non-object (default export)", () => {
+    const result = dataToEsm(/abc/);
+    expect(result).toContain("export default /abc/");
+  });
+
+  it("treats Date at top level as non-object (default export)", () => {
+    const result = dataToEsm(new Date("2024-01-01T00:00:00.000Z"));
+    expect(result).toContain("export default new Date(");
+  });
+
+  it("handles null at top level with namedExports=true (falls to default)", () => {
+    const result = dataToEsm(null);
+    expect(result).toContain("export default null");
+  });
+
+  it("handles class instances via JSON fallback", () => {
+    // A class instance is not a plain object, Date, RegExp, or primitive
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    class Custom {
+      readonly x = 1;
+    }
+    const result = dataToEsm({ val: new Custom() });
+    expect(result).toContain('"x":1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addExtension
+// ---------------------------------------------------------------------------
+
+describe("addExtension", () => {
+  it("adds .js when no extension is present", () => {
+    expect(addExtension("foo")).toBe("foo.js");
+  });
+
+  it("preserves an existing extension", () => {
+    expect(addExtension("foo.ts")).toBe("foo.ts");
+  });
+
+  it("uses a custom extension", () => {
+    expect(addExtension("bar", ".mjs")).toBe("bar.mjs");
+  });
+
+  it("preserves path with directory and existing extension", () => {
+    expect(addExtension("src/utils/index.ts")).toBe("src/utils/index.ts");
+  });
+
+  it("adds extension to filename with directory but no extension", () => {
+    expect(addExtension("src/utils/index")).toBe("src/utils/index.js");
+  });
+
+  it("does not add extension when dotfile-like basename has leading dot only", () => {
+    // A dot at position 0 of the basename is not treated as having an extension
+    expect(addExtension(".gitignore")).toBe(".gitignore.js");
+  });
+
+  it("preserves filename that already has the default extension", () => {
+    expect(addExtension("main.js")).toBe("main.js");
+  });
+
+  it("handles empty string", () => {
+    expect(addExtension("")).toBe(".js");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeLegalIdentifier
+// ---------------------------------------------------------------------------
+
+describe("makeLegalIdentifier", () => {
+  it("returns a simple valid identifier unchanged", () => {
+    expect(makeLegalIdentifier("foo")).toBe("foo");
+  });
+
+  it("replaces dashes with underscores", () => {
+    expect(makeLegalIdentifier("my-var")).toBe("my_var");
+  });
+
+  it("replaces spaces with underscores", () => {
+    expect(makeLegalIdentifier("hello world")).toBe("hello_world");
+  });
+
+  it("prefixes with underscore when starting with a digit", () => {
+    expect(makeLegalIdentifier("123abc")).toBe("_123abc");
+  });
+
+  it("prefixes reserved words with underscore", () => {
+    expect(makeLegalIdentifier("class")).toBe("_class");
+    expect(makeLegalIdentifier("return")).toBe("_return");
+    expect(makeLegalIdentifier("const")).toBe("_const");
+  });
+
+  it("replaces multiple special characters", () => {
+    expect(makeLegalIdentifier("a@b#c")).toBe("a_b_c");
+  });
+
+  it("preserves dollar signs", () => {
+    expect(makeLegalIdentifier("$scope")).toBe("$scope");
+  });
+
+  it("preserves underscores", () => {
+    expect(makeLegalIdentifier("_private")).toBe("_private");
+  });
+
+  it("handles empty string", () => {
+    expect(makeLegalIdentifier("")).toBe("");
+  });
+
+  it("handles string that is entirely special characters", () => {
+    const result = makeLegalIdentifier("---");
+    expect(result).toBe("___");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAssignedNames
+// ---------------------------------------------------------------------------
+
+describe("extractAssignedNames", () => {
+  it("extracts name from a simple Identifier", () => {
+    const node: AstNode = { type: "Identifier", name: "x" };
+    expect(extractAssignedNames(node)).toEqual(["x"]);
+  });
+
+  it("extracts names from an ObjectPattern", () => {
+    const node: AstNode = {
+      type: "ObjectPattern",
+      properties: [
+        {
+          type: "Property",
+          key: { type: "Identifier", name: "a" },
+          value: { type: "Identifier", name: "a" },
+        },
+        {
+          type: "Property",
+          key: { type: "Identifier", name: "b" },
+          value: { type: "Identifier", name: "b" },
+        },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["a", "b"]);
+  });
+
+  it("extracts names from an ArrayPattern", () => {
+    const node: AstNode = {
+      type: "ArrayPattern",
+      elements: [
+        { type: "Identifier", name: "x" },
+        { type: "Identifier", name: "y" },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["x", "y"]);
+  });
+
+  it("extracts names from nested patterns", () => {
+    const node: AstNode = {
+      type: "ObjectPattern",
+      properties: [
+        {
+          type: "Property",
+          key: { type: "Identifier", name: "a" },
+          value: {
+            type: "ArrayPattern",
+            elements: [
+              { type: "Identifier", name: "b" },
+              { type: "Identifier", name: "c" },
+            ],
+          },
+        },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["b", "c"]);
+  });
+
+  it("extracts names from RestElement", () => {
+    const node: AstNode = {
+      type: "ArrayPattern",
+      elements: [
+        { type: "Identifier", name: "first" },
+        {
+          type: "RestElement",
+          argument: { type: "Identifier", name: "rest" },
+        },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["first", "rest"]);
+  });
+
+  it("extracts names from AssignmentPattern", () => {
+    const node: AstNode = {
+      type: "AssignmentPattern",
+      left: { type: "Identifier", name: "x" },
+    };
+    expect(extractAssignedNames(node)).toEqual(["x"]);
+  });
+
+  it("handles ArrayPattern with null elements (holes)", () => {
+    const node: AstNode = {
+      type: "ArrayPattern",
+      elements: [
+        { type: "Identifier", name: "a" },
+        null,
+        { type: "Identifier", name: "c" },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["a", "c"]);
+  });
+
+  it("handles ObjectPattern with RestElement", () => {
+    const node: AstNode = {
+      type: "ObjectPattern",
+      properties: [
+        {
+          type: "Property",
+          key: { type: "Identifier", name: "a" },
+          value: { type: "Identifier", name: "a" },
+        },
+        {
+          type: "RestElement",
+          argument: { type: "Identifier", name: "rest" },
+        },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["a", "rest"]);
+  });
+
+  it("handles deeply nested destructuring", () => {
+    const node: AstNode = {
+      type: "ObjectPattern",
+      properties: [
+        {
+          type: "Property",
+          key: { type: "Identifier", name: "a" },
+          value: {
+            type: "ObjectPattern",
+            properties: [
+              {
+                type: "Property",
+                key: { type: "Identifier", name: "b" },
+                value: {
+                  type: "ArrayPattern",
+                  elements: [{ type: "Identifier", name: "c" }],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["c"]);
+  });
+
+  it("returns empty array for an unknown node type", () => {
+    const node: AstNode = { type: "Literal" };
+    expect(extractAssignedNames(node)).toEqual([]);
+  });
+
+  it("handles Identifier without name", () => {
+    const node: AstNode = { type: "Identifier" };
+    expect(extractAssignedNames(node)).toEqual([]);
+  });
+
+  it("handles ObjectPattern without properties", () => {
+    const node: AstNode = { type: "ObjectPattern" };
+    expect(extractAssignedNames(node)).toEqual([]);
+  });
+
+  it("handles ArrayPattern without elements", () => {
+    const node: AstNode = { type: "ArrayPattern" };
+    expect(extractAssignedNames(node)).toEqual([]);
+  });
+
+  it("handles RestElement without argument", () => {
+    const node: AstNode = { type: "RestElement" };
+    expect(extractAssignedNames(node)).toEqual([]);
+  });
+
+  it("handles AssignmentPattern without left", () => {
+    const node: AstNode = { type: "AssignmentPattern" };
+    expect(extractAssignedNames(node)).toEqual([]);
+  });
+
+  it("handles nested AssignmentPattern in ArrayPattern", () => {
+    const node: AstNode = {
+      type: "ArrayPattern",
+      elements: [
+        {
+          type: "AssignmentPattern",
+          left: { type: "Identifier", name: "x" },
+        },
+      ],
+    };
+    expect(extractAssignedNames(node)).toEqual(["x"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachScopes (stub)
+// ---------------------------------------------------------------------------
+
+describe("attachScopes", () => {
+  it("exists as a stub and returns void", () => {
+    const result = attachScopes();
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type-level coverage (ensure types are exported and usable)
+// ---------------------------------------------------------------------------
+
+describe("type exports", () => {
+  it("DataToEsmOptions is usable", () => {
+    const opts: DataToEsmOptions = {
+      indent: "  ",
+      preferConst: true,
+      namedExports: false,
+      compact: false,
+    };
+    expect(opts.indent).toBe("  ");
+  });
+
+  it("AstNode is usable", () => {
+    const node: AstNode = { type: "Identifier", name: "x" };
+    expect(node.type).toBe("Identifier");
+  });
+
+  it("FilterPattern accepts null", () => {
+    const p: FilterPattern = null;
+    expect(p).toBeNull();
+  });
+
+  it("FilterPattern accepts array", () => {
+    const p: FilterPattern = ["*.ts", /\.js$/];
+    expect(Array.isArray(p)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Zero-dependency reimplementation of `@rollup/pluginutils` in `src/utils/pluginutils.ts` (~460 lines)
- Implements `createFilter`, `dataToEsm`, `addExtension`, `makeLegalIdentifier`, `extractAssignedNames`, and a stub for `attachScopes`
- 90 unit tests covering happy and sad paths with >98% coverage (99.41% statements, 98.42% branches, 100% functions)
- Uses iterative stack-based approach for `extractAssignedNames` (no recursion)
- Leverages existing `globToRegex` from `src/utils/glob.ts` for glob pattern matching in `createFilter`

Closes #108

## Test plan

- [x] All 90 tests pass via `npx vitest run tests/unit/utils/pluginutils.test.ts`
- [x] Coverage meets 98% threshold (99.41% stmts, 98.42% branches, 100% funcs, 99.41% lines)
- [ ] CI pipeline passes lint, typecheck, and test stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)