### PR TITLE
feat: implement defineConfig() and VERSION export

### DIFF
--- a/src/define-config.ts
+++ b/src/define-config.ts
@@ -1,0 +1,47 @@
+/**
+ * Type helper for Steamroller configuration files.
+ *
+ * Provides IntelliSense and type checking when authoring config files.
+ */
+
+/**
+ * Placeholder type for Rollup-compatible configuration options.
+ *
+ * This will be replaced with a full type definition when the config
+ * system is implemented (see #116).
+ */
+export interface RollupOptions {
+  readonly [key: string]: unknown;
+}
+
+/**
+ * A function form of configuration that receives CLI arguments and
+ * returns one or more config objects (optionally async).
+ */
+export type RollupOptionsFunction = (
+  commandLineArgs: Record<string, unknown>,
+) => RollupOptions | ReadonlyArray<RollupOptions> | Promise<RollupOptions | ReadonlyArray<RollupOptions>>;
+
+// NOTE: defineConfig uses function overloads, which require the
+// `function` keyword in TypeScript. This is an acceptable exception
+// to any preference for arrow functions.
+
+/** Accept a single configuration object. */
+export function defineConfig(options: RollupOptions): RollupOptions;
+/** Accept an array of configuration objects. */
+export function defineConfig(
+  options: ReadonlyArray<RollupOptions>,
+): ReadonlyArray<RollupOptions>;
+/** Accept a function that produces configuration. */
+export function defineConfig(options: RollupOptionsFunction): RollupOptionsFunction;
+/**
+ * Identity helper that returns its input unchanged.
+ *
+ * Use this in `steamroller.config.ts` to get type checking and
+ * editor auto-completion for configuration options.
+ */
+export function defineConfig(
+  options: RollupOptions | ReadonlyArray<RollupOptions> | RollupOptionsFunction,
+): RollupOptions | ReadonlyArray<RollupOptions> | RollupOptionsFunction {
+  return options;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Steamroller — a zero-dependency JavaScript bundler.
+ *
+ * Public API surface.
+ */
+export { VERSION } from "./version.js";
+export { defineConfig } from "./define-config.js";
+export type { RollupOptions, RollupOptionsFunction } from "./define-config.js";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,6 @@
+/**
+ * The current version of Steamroller.
+ *
+ * Kept in sync with the version field in package.json.
+ */
+export const VERSION: string = "0.0.0";

--- a/tests/unit/define-config.test.ts
+++ b/tests/unit/define-config.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for src/define-config.ts and src/version.ts
+ *
+ * Covers defineConfig() with single object, array, sync function,
+ * and async function forms, plus the VERSION constant.
+ */
+import { describe, it, expect } from "vitest";
+import { defineConfig, VERSION } from "../../src/index";
+import type { RollupOptions, RollupOptionsFunction } from "../../src/index";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("VERSION", () => {
+  it("is a string", () => {
+    expect(typeof VERSION).toBe("string");
+  });
+
+  it("matches the version in package.json", () => {
+    const pkgPath = resolve(__dirname, "../../package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+  });
+
+  it("follows semver format", () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("defineConfig", () => {
+  describe("single object form", () => {
+    it("returns the same object reference", () => {
+      const config: RollupOptions = { input: "src/index.ts" };
+      const result = defineConfig(config);
+      expect(result).toBe(config);
+    });
+
+    it("preserves all properties", () => {
+      const config: RollupOptions = {
+        input: "src/index.ts",
+        output: { file: "dist/bundle.js", format: "esm" },
+      };
+      const result = defineConfig(config);
+      expect(result).toEqual(config);
+    });
+
+    it("works with an empty object", () => {
+      const config: RollupOptions = {};
+      const result = defineConfig(config);
+      expect(result).toBe(config);
+    });
+  });
+
+  describe("array form", () => {
+    it("returns the same array reference", () => {
+      const configs: ReadonlyArray<RollupOptions> = [
+        { input: "src/a.ts" },
+        { input: "src/b.ts" },
+      ];
+      const result = defineConfig(configs);
+      expect(result).toBe(configs);
+    });
+
+    it("preserves all elements", () => {
+      const configs: ReadonlyArray<RollupOptions> = [
+        { input: "src/a.ts" },
+        { input: "src/b.ts" },
+      ];
+      const result = defineConfig(configs);
+      expect(result).toHaveLength(2);
+    });
+
+    it("works with an empty array", () => {
+      const configs: ReadonlyArray<RollupOptions> = [];
+      const result = defineConfig(configs);
+      expect(result).toBe(configs);
+    });
+
+    it("works with a single-element array", () => {
+      const configs: ReadonlyArray<RollupOptions> = [{ input: "src/index.ts" }];
+      const result = defineConfig(configs);
+      expect(result).toBe(configs);
+    });
+  });
+
+  describe("function form", () => {
+    it("returns the same function reference (sync)", () => {
+      const fn: RollupOptionsFunction = (_args) => ({ input: "src/index.ts" });
+      const result = defineConfig(fn);
+      expect(result).toBe(fn);
+    });
+
+    it("returned function is callable and produces expected output", () => {
+      const fn: RollupOptionsFunction = (args) => ({
+        input: args["entry"] as string,
+      });
+      const result = defineConfig(fn) as RollupOptionsFunction;
+      expect(result({ entry: "main.ts" })).toEqual({ input: "main.ts" });
+    });
+
+    it("returns the same function reference (async)", () => {
+      const fn: RollupOptionsFunction = async (_args) =>
+        Promise.resolve({ input: "src/index.ts" });
+      const result = defineConfig(fn);
+      expect(result).toBe(fn);
+    });
+
+    it("works with a function returning an array", () => {
+      const fn: RollupOptionsFunction = (_args) => [
+        { input: "src/a.ts" },
+        { input: "src/b.ts" },
+      ];
+      const result = defineConfig(fn) as RollupOptionsFunction;
+      const output = result({});
+      expect(Array.isArray(output)).toBe(true);
+    });
+
+    it("works with an async function returning an array", async () => {
+      const fn: RollupOptionsFunction = async (_args) =>
+        Promise.resolve([{ input: "src/a.ts" }]);
+      const result = defineConfig(fn) as RollupOptionsFunction;
+      const output = await result({});
+      expect(Array.isArray(output)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `defineConfig()` type helper with overloads for single config, array, and function forms
- Add `VERSION` constant exported from `src/version.ts`
- Create `src/index.ts` as the main public API entry point re-exporting both

## Test plan

- [x] 15 unit tests covering all defineConfig overloads (object, array, sync fn, async fn) and VERSION constant
- [x] 100% coverage on all three new source files
- [x] All 609 existing tests continue to pass
- [x] TypeScript strict mode typecheck passes cleanly

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)