### PR TITLE
feat: implement performance instrumentation (perf option)

### DIFF
--- a/src/utils/perf.ts
+++ b/src/utils/perf.ts
@@ -1,0 +1,140 @@
+/**
+ * Performance instrumentation utilities for build profiling.
+ *
+ * Provides start/end timers with memory tracking and serialized
+ * timing output via the getTimings() API.
+ *
+ * @module utils/perf
+ */
+
+/**
+ * Serialized timing data: each entry is a readonly 3-element tuple
+ * of [elapsedMs, memoryDeltaBytes, totalHeapBytes].
+ */
+export type SerializedTimings = Readonly<
+  Record<string, readonly [number, number, number]>
+>;
+
+/** Phase label for parsing. */
+export const PERF_PARSE = "PARSE" as const;
+
+/** Phase label for resolving module IDs. */
+export const PERF_RESOLVE_ID = "RESOLVE_ID" as const;
+
+/** Phase label for transforming source. */
+export const PERF_TRANSFORM = "TRANSFORM" as const;
+
+/** Phase label for building the bundle. */
+export const PERF_BUILD = "BUILD" as const;
+
+/** Phase label for code generation. */
+export const PERF_GENERATE = "GENERATE" as const;
+
+/** Phase label for tree-shaking. */
+export const PERF_TREESHAKE = "TREESHAKE" as const;
+
+/** Phase label for rendering chunks. */
+export const PERF_RENDER_CHUNK = "RENDER_CHUNK" as const;
+
+/** Phase label for writing output. */
+export const PERF_WRITE = "WRITE" as const;
+
+/**
+ * Timer interface for recording phase durations and memory usage.
+ * Exposes start/end for individual phases and getTimings for results.
+ */
+export interface PerfTimer {
+  readonly start: (label: string) => void;
+  readonly end: (label: string) => void;
+  readonly getTimings: () => SerializedTimings;
+  readonly reset: () => void;
+}
+
+/**
+ * Internal mutable type for accumulating timing data inside the Map.
+ * Properties must be mutable so that elapsed/memory values can be
+ * accumulated across multiple start/end calls for the same label.
+ */
+interface TimingEntry {
+  startTime: number;
+  startMemory: number;
+  elapsed: number;
+  memory: number;
+  totalMemory: number;
+}
+
+/**
+ * Create a no-op timer that does nothing.
+ * Used when performance instrumentation is disabled.
+ */
+export const createNoopTimer = (): PerfTimer => {
+  return {
+    start: (): void => {},
+    end: (): void => {},
+    getTimings: (): SerializedTimings => ({}),
+    reset: (): void => {},
+  };
+};
+
+/**
+ * Create an active performance timer that records elapsed time
+ * and heap memory deltas for each labeled phase.
+ */
+export const createPerfTimer = (): PerfTimer => {
+  const timings = new Map<string, TimingEntry>();
+
+  return {
+    start: (label: string): void => {
+      const startTime = performance.now();
+      const memUsage = process.memoryUsage();
+      const existing = timings.get(label);
+      if (existing) {
+        existing.startTime = startTime;
+        existing.startMemory = memUsage.heapUsed;
+      } else {
+        timings.set(label, {
+          startTime,
+          startMemory: memUsage.heapUsed,
+          elapsed: 0,
+          memory: 0,
+          totalMemory: memUsage.heapTotal,
+        });
+      }
+    },
+    end: (label: string): void => {
+      const endTime = performance.now();
+      const memUsage = process.memoryUsage();
+      const entry = timings.get(label);
+      if (!entry) {
+        return;
+      }
+      entry.elapsed += endTime - entry.startTime;
+      entry.memory += memUsage.heapUsed - entry.startMemory;
+      entry.totalMemory = memUsage.heapTotal;
+    },
+    getTimings: (): SerializedTimings => {
+      const result: Record<string, readonly [number, number, number]> = {};
+      timings.forEach((value: TimingEntry, key: string) => {
+        result[key] = [
+          value.elapsed,
+          value.memory,
+          value.totalMemory,
+        ] as const;
+      });
+      return result;
+    },
+    reset: (): void => {
+      timings.clear();
+    },
+  };
+};
+
+/**
+ * Factory function: create the appropriate timer based on the perf option.
+ *
+ * @param enabled - Whether performance instrumentation is active
+ * @returns A PerfTimer (active or no-op)
+ */
+export const createTimer = (enabled: boolean): PerfTimer => {
+  return enabled ? createPerfTimer() : createNoopTimer();
+};

--- a/tests/unit/utils/perf.test.ts
+++ b/tests/unit/utils/perf.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for src/utils/perf.ts
+ *
+ * Covers createNoopTimer, createPerfTimer, createTimer factory,
+ * and all exported phase constants.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createNoopTimer,
+  createPerfTimer,
+  createTimer,
+  PERF_PARSE,
+  PERF_RESOLVE_ID,
+  PERF_TRANSFORM,
+  PERF_BUILD,
+  PERF_GENERATE,
+  PERF_TREESHAKE,
+  PERF_RENDER_CHUNK,
+  PERF_WRITE,
+} from "../../../src/utils/perf";
+import type { PerfTimer, SerializedTimings } from "../../../src/utils/perf";
+
+describe("perf", () => {
+  describe("phase constants", () => {
+    it("should export correct phase label strings", () => {
+      expect(PERF_PARSE).toBe("PARSE");
+      expect(PERF_RESOLVE_ID).toBe("RESOLVE_ID");
+      expect(PERF_TRANSFORM).toBe("TRANSFORM");
+      expect(PERF_BUILD).toBe("BUILD");
+      expect(PERF_GENERATE).toBe("GENERATE");
+      expect(PERF_TREESHAKE).toBe("TREESHAKE");
+      expect(PERF_RENDER_CHUNK).toBe("RENDER_CHUNK");
+      expect(PERF_WRITE).toBe("WRITE");
+    });
+  });
+
+  describe("createNoopTimer", () => {
+    it("should return a PerfTimer object with all required methods", () => {
+      const timer = createNoopTimer();
+      expect(typeof timer.start).toBe("function");
+      expect(typeof timer.end).toBe("function");
+      expect(typeof timer.getTimings).toBe("function");
+      expect(typeof timer.reset).toBe("function");
+    });
+
+    it("should not throw when start is called", () => {
+      const timer = createNoopTimer();
+      expect(() => timer.start("test")).not.toThrow();
+    });
+
+    it("should not throw when end is called", () => {
+      const timer = createNoopTimer();
+      expect(() => timer.end("test")).not.toThrow();
+    });
+
+    it("should return an empty object from getTimings", () => {
+      const timer = createNoopTimer();
+      timer.start("test");
+      timer.end("test");
+      const timings: SerializedTimings = timer.getTimings();
+      expect(timings).toEqual({});
+    });
+
+    it("should not throw when reset is called", () => {
+      const timer = createNoopTimer();
+      expect(() => timer.reset()).not.toThrow();
+    });
+
+    it("should return empty object from getTimings after reset", () => {
+      const timer = createNoopTimer();
+      timer.reset();
+      expect(timer.getTimings()).toEqual({});
+    });
+  });
+
+  describe("createPerfTimer", () => {
+    it("should return a PerfTimer with all required methods", () => {
+      const timer = createPerfTimer();
+      expect(typeof timer.start).toBe("function");
+      expect(typeof timer.end).toBe("function");
+      expect(typeof timer.getTimings).toBe("function");
+      expect(typeof timer.reset).toBe("function");
+    });
+
+    it("should produce a timing entry after start + end", () => {
+      const timer = createPerfTimer();
+      timer.start("phase1");
+      timer.end("phase1");
+      const timings = timer.getTimings();
+      expect(timings).toHaveProperty("phase1");
+      const entry = timings["phase1"];
+      expect(entry).toBeDefined();
+      expect(Array.isArray(entry)).toBe(true);
+      expect(entry).toHaveLength(3);
+    });
+
+    it("should return a 3-element tuple with numeric values", () => {
+      const timer = createPerfTimer();
+      timer.start("myPhase");
+      timer.end("myPhase");
+      const timings = timer.getTimings();
+      const [elapsed, memory, totalMemory] = timings["myPhase"]!;
+      expect(typeof elapsed).toBe("number");
+      expect(typeof memory).toBe("number");
+      expect(typeof totalMemory).toBe("number");
+    });
+
+    it("should record non-negative elapsed time", () => {
+      const timer = createPerfTimer();
+      timer.start("elapsed-test");
+      timer.end("elapsed-test");
+      const timings = timer.getTimings();
+      const [elapsed] = timings["elapsed-test"]!;
+      expect(elapsed).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should record positive totalMemory", () => {
+      const timer = createPerfTimer();
+      timer.start("mem-test");
+      timer.end("mem-test");
+      const timings = timer.getTimings();
+      const [, , totalMemory] = timings["mem-test"]!;
+      expect(totalMemory).toBeGreaterThan(0);
+    });
+
+    it("should accumulate time across multiple start/end calls", () => {
+      const timer = createPerfTimer();
+      timer.start("accum");
+      timer.end("accum");
+      const first = timer.getTimings()["accum"]![0];
+
+      timer.start("accum");
+      timer.end("accum");
+      const second = timer.getTimings()["accum"]![0];
+
+      expect(second).toBeGreaterThanOrEqual(first);
+    });
+
+    it("should handle end without prior start as a no-op", () => {
+      const timer = createPerfTimer();
+      expect(() => timer.end("nonexistent")).not.toThrow();
+      const timings = timer.getTimings();
+      expect(timings).not.toHaveProperty("nonexistent");
+    });
+
+    it("should track multiple labels independently", () => {
+      const timer = createPerfTimer();
+      timer.start("a");
+      timer.end("a");
+      timer.start("b");
+      timer.end("b");
+      const timings = timer.getTimings();
+      expect(timings).toHaveProperty("a");
+      expect(timings).toHaveProperty("b");
+      expect(timings["a"]).toHaveLength(3);
+      expect(timings["b"]).toHaveLength(3);
+    });
+
+    it("should clear all timings on reset", () => {
+      const timer = createPerfTimer();
+      timer.start("clear-me");
+      timer.end("clear-me");
+      expect(Object.keys(timer.getTimings())).toHaveLength(1);
+      timer.reset();
+      expect(timer.getTimings()).toEqual({});
+    });
+
+    it("should allow recording new timings after reset", () => {
+      const timer = createPerfTimer();
+      timer.start("before");
+      timer.end("before");
+      timer.reset();
+      timer.start("after");
+      timer.end("after");
+      const timings = timer.getTimings();
+      expect(timings).not.toHaveProperty("before");
+      expect(timings).toHaveProperty("after");
+    });
+
+    it("should return empty object from getTimings when nothing recorded", () => {
+      const timer = createPerfTimer();
+      expect(timer.getTimings()).toEqual({});
+    });
+
+    it("should handle start called multiple times before end", () => {
+      const timer = createPerfTimer();
+      timer.start("restart");
+      timer.start("restart");
+      timer.end("restart");
+      const timings = timer.getTimings();
+      expect(timings).toHaveProperty("restart");
+      expect(timings["restart"]![0]).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("createTimer", () => {
+    it("should return an active timer when enabled is true", () => {
+      const timer = createTimer(true);
+      timer.start("test");
+      timer.end("test");
+      const timings = timer.getTimings();
+      expect(timings).toHaveProperty("test");
+      expect(timings["test"]).toHaveLength(3);
+    });
+
+    it("should return a noop timer when enabled is false", () => {
+      const timer = createTimer(false);
+      timer.start("test");
+      timer.end("test");
+      const timings = timer.getTimings();
+      expect(timings).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/utils/perf.ts` with `PerfTimer` interface, `createPerfTimer()`, `createNoopTimer()`, and `createTimer()` factory
- Provides start/end timers with elapsed time and heap memory tracking per labeled phase
- Exports 8 phase label constants (PERF_PARSE, PERF_RESOLVE_ID, PERF_TRANSFORM, etc.)
- `SerializedTimings` type returns readonly 3-element tuples: [elapsedMs, memoryDeltaBytes, totalHeapBytes]
- 21 unit tests covering all branches at 100% coverage for the new module

## Test plan

- [x] `npx vitest run tests/unit/utils/perf.test.ts` -- 21 tests pass
- [x] 100% statement, branch, function, and line coverage on `perf.ts`
- [x] No-op timer: start/end don't throw, getTimings returns empty, reset works
- [x] Active timer: start+end produces timing entries with 3-element tuples
- [x] Multiple start/end calls accumulate elapsed time
- [x] End without start is a safe no-op
- [x] Reset clears all timings
- [x] createTimer(true) returns active timer, createTimer(false) returns noop

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)