### PR TITLE
feat: implement lexer token types and keyword detection

### DIFF
--- a/src/parser/keywords.ts
+++ b/src/parser/keywords.ts
@@ -1,0 +1,180 @@
+/**
+ * Keyword detection and classification for the Steamroller lexer.
+ *
+ * Provides O(1) lookup of JavaScript/TypeScript keywords using a Map,
+ * including reserved words, contextual keywords, and strict-mode
+ * reserved words.
+ *
+ * @module parser/keywords
+ */
+
+import { TokenType } from "./token-types.js";
+
+/**
+ * Information about a keyword, including its token type and
+ * classification flags.
+ */
+export interface KeywordInfo {
+  /** The numeric token type value from {@link TokenType}. */
+  readonly tokenType: number;
+  /** Whether the word is a reserved keyword in all contexts. */
+  readonly isReserved: boolean;
+  /** Whether the word is reserved only in strict mode. */
+  readonly isStrictReserved: boolean;
+  /** Whether the word is a contextual keyword. */
+  readonly isContextual: boolean;
+}
+
+/**
+ * Helper to create a reserved keyword entry.
+ */
+const reserved = (tokenType: number): KeywordInfo => ({
+  tokenType,
+  isReserved: true,
+  isStrictReserved: false,
+  isContextual: false,
+});
+
+/**
+ * Helper to create a contextual keyword entry.
+ */
+const contextual = (tokenType: number): KeywordInfo => ({
+  tokenType,
+  isReserved: false,
+  isStrictReserved: false,
+  isContextual: true,
+});
+
+/**
+ * Helper to create a strict-mode reserved word entry.
+ * These are contextual keywords that become reserved in strict mode.
+ */
+const strictReserved = (tokenType: number): KeywordInfo => ({
+  tokenType,
+  isReserved: false,
+  isStrictReserved: true,
+  isContextual: false,
+});
+
+/**
+ * Internal keyword lookup map. Populated eagerly at module load time.
+ */
+const keywordMap: ReadonlyMap<string, KeywordInfo> = new Map<string, KeywordInfo>([
+  // Reserved keywords (ES5)
+  ["break", reserved(TokenType.Break)],
+  ["case", reserved(TokenType.Case)],
+  ["catch", reserved(TokenType.Catch)],
+  ["continue", reserved(TokenType.Continue)],
+  ["debugger", reserved(TokenType.Debugger)],
+  ["default", reserved(TokenType.Default)],
+  ["delete", reserved(TokenType.Delete)],
+  ["do", reserved(TokenType.Do)],
+  ["else", reserved(TokenType.Else)],
+  ["finally", reserved(TokenType.Finally)],
+  ["for", reserved(TokenType.For)],
+  ["function", reserved(TokenType.Function)],
+  ["if", reserved(TokenType.If)],
+  ["in", reserved(TokenType.In)],
+  ["instanceof", reserved(TokenType.Instanceof)],
+  ["new", reserved(TokenType.New)],
+  ["return", reserved(TokenType.Return)],
+  ["switch", reserved(TokenType.Switch)],
+  ["this", reserved(TokenType.This)],
+  ["throw", reserved(TokenType.Throw)],
+  ["try", reserved(TokenType.Try)],
+  ["typeof", reserved(TokenType.Typeof)],
+  ["var", reserved(TokenType.Var)],
+  ["void", reserved(TokenType.Void)],
+  ["while", reserved(TokenType.While)],
+  ["with", reserved(TokenType.With)],
+
+  // ES6+ reserved keywords
+  ["class", reserved(TokenType.Class)],
+  ["const", reserved(TokenType.Const)],
+  ["export", reserved(TokenType.Export)],
+  ["extends", reserved(TokenType.Extends)],
+  ["import", reserved(TokenType.Import)],
+  ["super", reserved(TokenType.Super)],
+
+  // Literal keywords (reserved)
+  ["true", reserved(TokenType.True)],
+  ["false", reserved(TokenType.False)],
+  ["null", reserved(TokenType.Null)],
+
+  // Contextual keywords
+  ["async", contextual(TokenType.Async)],
+  ["await", contextual(TokenType.Await)],
+  ["of", contextual(TokenType.Of)],
+  ["from", contextual(TokenType.From)],
+  ["as", contextual(TokenType.As)],
+  ["get", contextual(TokenType.Get)],
+  ["set", contextual(TokenType.Set)],
+
+  // Strict-mode reserved words
+  // These use their own token types where available; otherwise they
+  // map to Identifier (0 is not used — they have dedicated types).
+  ["yield", strictReserved(TokenType.Yield)],
+  ["let", strictReserved(TokenType.Let)],
+  ["static", strictReserved(TokenType.Static)],
+  ["implements", strictReserved(TokenType.Identifier)],
+  ["interface", strictReserved(TokenType.Identifier)],
+  ["package", strictReserved(TokenType.Identifier)],
+  ["private", strictReserved(TokenType.Identifier)],
+  ["protected", strictReserved(TokenType.Identifier)],
+  ["public", strictReserved(TokenType.Identifier)],
+]);
+
+/**
+ * Look up a word in the keyword map.
+ *
+ * @param word - The identifier string to look up.
+ * @returns The {@link KeywordInfo} for the word, or `undefined` if it
+ *   is not a keyword.
+ */
+export const lookupKeyword = (word: string): KeywordInfo | undefined => {
+  return keywordMap.get(word);
+};
+
+/**
+ * Check whether a word is any kind of keyword (reserved, contextual,
+ * or strict-mode reserved).
+ *
+ * @param word - The identifier string to check.
+ * @returns `true` if the word is a keyword.
+ */
+export const isKeyword = (word: string): boolean => {
+  return keywordMap.has(word);
+};
+
+/**
+ * Check whether a word is a reserved keyword in all contexts.
+ *
+ * @param word - The identifier string to check.
+ * @returns `true` if the word is unconditionally reserved.
+ */
+export const isReservedWord = (word: string): boolean => {
+  const info = keywordMap.get(word);
+  return info?.isReserved === true;
+};
+
+/**
+ * Check whether a word is reserved only in strict mode.
+ *
+ * @param word - The identifier string to check.
+ * @returns `true` if the word is a strict-mode reserved word.
+ */
+export const isStrictReservedWord = (word: string): boolean => {
+  const info = keywordMap.get(word);
+  return info?.isStrictReserved === true;
+};
+
+/**
+ * Check whether a word is a contextual keyword.
+ *
+ * @param word - The identifier string to check.
+ * @returns `true` if the word is a contextual keyword.
+ */
+export const isContextualKeyword = (word: string): boolean => {
+  const info = keywordMap.get(word);
+  return info?.isContextual === true;
+};

--- a/src/parser/token-types.ts
+++ b/src/parser/token-types.ts
@@ -1,0 +1,198 @@
+/**
+ * Token type definitions for the Steamroller lexer.
+ *
+ * Each token type is assigned a unique numeric value, grouped by category
+ * with intentional gaps between groups to allow future additions without
+ * renumbering existing types.
+ *
+ * @module parser/token-types
+ */
+
+/**
+ * Enumeration of all lexer token types.
+ *
+ * Groups:
+ * - 0: Special (EOF)
+ * - 1-9: Identifiers and literals
+ * - 10-35: Reserved keywords (ES5)
+ * - 36-41: ES6+ keywords
+ * - 42-51: Contextual keywords
+ * - 52-54: Literal keywords
+ * - 60-75: Punctuators
+ * - 80-95: Assignment operators
+ * - 100-116: Binary/unary operators
+ * - 120-127: Comparison operators
+ * - 130-131: Increment/decrement
+ * - 140-142: Comments and template literals
+ * - 150-151: JSX tokens
+ */
+export const TokenType = {
+  // Special
+  EOF: 0,
+
+  // Identifiers and literals
+  Identifier: 1,
+  NumericLiteral: 2,
+  StringLiteral: 3,
+  RegExpLiteral: 4,
+  TemplateLiteral: 5,
+  TemplateHead: 6,
+  TemplateMiddle: 7,
+  TemplateTail: 8,
+  BigIntLiteral: 9,
+
+  // Keywords (reserved)
+  Break: 10,
+  Case: 11,
+  Catch: 12,
+  Continue: 13,
+  Debugger: 14,
+  Default: 15,
+  Delete: 16,
+  Do: 17,
+  Else: 18,
+  Finally: 19,
+  For: 20,
+  Function: 21,
+  If: 22,
+  In: 23,
+  Instanceof: 24,
+  New: 25,
+  Return: 26,
+  Switch: 27,
+  This: 28,
+  Throw: 29,
+  Try: 30,
+  Typeof: 31,
+  Var: 32,
+  Void: 33,
+  While: 34,
+  With: 35,
+
+  // ES6+ keywords
+  Class: 36,
+  Const: 37,
+  Export: 38,
+  Extends: 39,
+  Import: 40,
+  Super: 41,
+
+  // Contextual keywords
+  Async: 42,
+  Await: 43,
+  Yield: 44,
+  Let: 45,
+  Of: 46,
+  From: 47,
+  As: 48,
+  Get: 49,
+  Set: 50,
+  Static: 51,
+
+  // Literal keywords
+  True: 52,
+  False: 53,
+  Null: 54,
+
+  // Punctuators
+  LeftBrace: 60,
+  RightBrace: 61,
+  LeftParen: 62,
+  RightParen: 63,
+  LeftBracket: 64,
+  RightBracket: 65,
+  Dot: 66,
+  Ellipsis: 67,
+  Semicolon: 68,
+  Comma: 69,
+  Colon: 70,
+  QuestionMark: 71,
+  QuestionDot: 72,
+  Arrow: 73,
+  Hash: 74,
+  At: 75,
+
+  // Assignment operators
+  Equals: 80,
+  PlusEquals: 81,
+  MinusEquals: 82,
+  StarEquals: 83,
+  SlashEquals: 84,
+  PercentEquals: 85,
+  StarStarEquals: 86,
+  AmpersandEquals: 87,
+  PipeEquals: 88,
+  CaretEquals: 89,
+  LeftShiftEquals: 90,
+  RightShiftEquals: 91,
+  UnsignedRightShiftEquals: 92,
+  AmpersandAmpersandEquals: 93,
+  PipePipeEquals: 94,
+  QuestionQuestionEquals: 95,
+
+  // Binary/unary operators
+  Plus: 100,
+  Minus: 101,
+  Star: 102,
+  Slash: 103,
+  Percent: 104,
+  StarStar: 105,
+  Ampersand: 106,
+  Pipe: 107,
+  Caret: 108,
+  Tilde: 109,
+  LeftShift: 110,
+  RightShift: 111,
+  UnsignedRightShift: 112,
+  AmpersandAmpersand: 113,
+  PipePipe: 114,
+  QuestionQuestion: 115,
+  Exclamation: 116,
+
+  // Comparison
+  EqualsEquals: 120,
+  ExclamationEquals: 121,
+  EqualsEqualsEquals: 122,
+  ExclamationEqualsEquals: 123,
+  LessThan: 124,
+  GreaterThan: 125,
+  LessThanEquals: 126,
+  GreaterThanEquals: 127,
+
+  // Increment/decrement
+  PlusPlus: 130,
+  MinusMinus: 131,
+
+  // Comment
+  LineComment: 140,
+  BlockComment: 141,
+
+  // Template
+  TemplateNoSub: 142,
+
+  // JSX
+  JSXText: 150,
+  JSXIdentifier: 151,
+} as const;
+
+/** Union type of all valid token type numeric values. */
+export type TokenTypeValue = typeof TokenType[keyof typeof TokenType];
+
+/**
+ * Returns the name of a token type given its numeric value.
+ *
+ * Uses an iterative scan of the TokenType object entries.
+ *
+ * @param value - The numeric token type value to look up.
+ * @returns The string name of the token type, or "Unknown" if not found.
+ */
+export const tokenTypeName = (value: number): string => {
+  const entries = Object.entries(TokenType);
+  for (let i = 0; i < entries.length; i++) {
+    const [name, v] = entries[i];
+    if (v === value) {
+      return name;
+    }
+  }
+  return "Unknown";
+};

--- a/src/parser/token.ts
+++ b/src/parser/token.ts
@@ -1,0 +1,46 @@
+/**
+ * Token interface for the Steamroller lexer.
+ *
+ * Represents a single lexical token produced by the scanner, with
+ * positional information and the parsed value.
+ *
+ * @module parser/token
+ */
+
+/**
+ * A single lexical token produced by the lexer.
+ *
+ * All properties are readonly to enforce immutability after creation.
+ */
+export interface Token {
+  /** The numeric token type (see {@link TokenType}). */
+  readonly type: number;
+  /** Byte offset of the first character (inclusive). */
+  readonly start: number;
+  /** Byte offset past the last character (exclusive). */
+  readonly end: number;
+  /** The parsed semantic value of the token. */
+  readonly value: string | number | boolean | null | RegExp | bigint;
+  /** The original source text of the token. */
+  readonly raw: string;
+}
+
+/**
+ * Create a new Token object.
+ *
+ * @param type  - The numeric token type.
+ * @param start - Start offset in the source.
+ * @param end   - End offset in the source.
+ * @param value - The parsed value.
+ * @param raw   - The raw source text.
+ * @returns A frozen Token object.
+ */
+export const createToken = (
+  type: number,
+  start: number,
+  end: number,
+  value: string | number | boolean | null | RegExp | bigint,
+  raw: string,
+): Token => {
+  return Object.freeze({ type, start, end, value, raw });
+};

--- a/tests/unit/parser/keywords.test.ts
+++ b/tests/unit/parser/keywords.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from "vitest";
+import {
+  lookupKeyword,
+  isKeyword,
+  isReservedWord,
+  isStrictReservedWord,
+  isContextualKeyword,
+} from "../../../src/parser/keywords.js";
+import type { KeywordInfo } from "../../../src/parser/keywords.js";
+import { TokenType } from "../../../src/parser/token-types.js";
+
+describe("lookupKeyword", () => {
+  describe("reserved keywords", () => {
+    const reservedWords: ReadonlyArray<[string, number]> = [
+      ["break", TokenType.Break],
+      ["case", TokenType.Case],
+      ["catch", TokenType.Catch],
+      ["continue", TokenType.Continue],
+      ["debugger", TokenType.Debugger],
+      ["default", TokenType.Default],
+      ["delete", TokenType.Delete],
+      ["do", TokenType.Do],
+      ["else", TokenType.Else],
+      ["finally", TokenType.Finally],
+      ["for", TokenType.For],
+      ["function", TokenType.Function],
+      ["if", TokenType.If],
+      ["in", TokenType.In],
+      ["instanceof", TokenType.Instanceof],
+      ["new", TokenType.New],
+      ["return", TokenType.Return],
+      ["switch", TokenType.Switch],
+      ["this", TokenType.This],
+      ["throw", TokenType.Throw],
+      ["try", TokenType.Try],
+      ["typeof", TokenType.Typeof],
+      ["var", TokenType.Var],
+      ["void", TokenType.Void],
+      ["while", TokenType.While],
+      ["with", TokenType.With],
+    ];
+
+    for (let i = 0; i < reservedWords.length; i++) {
+      const [word, expectedType] = reservedWords[i];
+      it(`should return reserved info for "${word}"`, () => {
+        const info = lookupKeyword(word);
+        expect(info).toBeDefined();
+        expect(info!.tokenType).toBe(expectedType);
+        expect(info!.isReserved).toBe(true);
+        expect(info!.isStrictReserved).toBe(false);
+        expect(info!.isContextual).toBe(false);
+      });
+    }
+  });
+
+  describe("ES6+ reserved keywords", () => {
+    const es6Words: ReadonlyArray<[string, number]> = [
+      ["class", TokenType.Class],
+      ["const", TokenType.Const],
+      ["export", TokenType.Export],
+      ["extends", TokenType.Extends],
+      ["import", TokenType.Import],
+      ["super", TokenType.Super],
+    ];
+
+    for (let i = 0; i < es6Words.length; i++) {
+      const [word, expectedType] = es6Words[i];
+      it(`should return reserved info for "${word}"`, () => {
+        const info = lookupKeyword(word);
+        expect(info).toBeDefined();
+        expect(info!.tokenType).toBe(expectedType);
+        expect(info!.isReserved).toBe(true);
+        expect(info!.isStrictReserved).toBe(false);
+        expect(info!.isContextual).toBe(false);
+      });
+    }
+  });
+
+  describe("literal keywords", () => {
+    const literals: ReadonlyArray<[string, number]> = [
+      ["true", TokenType.True],
+      ["false", TokenType.False],
+      ["null", TokenType.Null],
+    ];
+
+    for (let i = 0; i < literals.length; i++) {
+      const [word, expectedType] = literals[i];
+      it(`should return reserved info for "${word}"`, () => {
+        const info = lookupKeyword(word);
+        expect(info).toBeDefined();
+        expect(info!.tokenType).toBe(expectedType);
+        expect(info!.isReserved).toBe(true);
+        expect(info!.isStrictReserved).toBe(false);
+        expect(info!.isContextual).toBe(false);
+      });
+    }
+  });
+
+  describe("contextual keywords", () => {
+    const contextualWords: ReadonlyArray<[string, number]> = [
+      ["async", TokenType.Async],
+      ["await", TokenType.Await],
+      ["of", TokenType.Of],
+      ["from", TokenType.From],
+      ["as", TokenType.As],
+      ["get", TokenType.Get],
+      ["set", TokenType.Set],
+    ];
+
+    for (let i = 0; i < contextualWords.length; i++) {
+      const [word, expectedType] = contextualWords[i];
+      it(`should return contextual info for "${word}"`, () => {
+        const info = lookupKeyword(word);
+        expect(info).toBeDefined();
+        expect(info!.tokenType).toBe(expectedType);
+        expect(info!.isReserved).toBe(false);
+        expect(info!.isStrictReserved).toBe(false);
+        expect(info!.isContextual).toBe(true);
+      });
+    }
+  });
+
+  describe("strict-mode reserved words", () => {
+    const strictWords: ReadonlyArray<[string, number]> = [
+      ["yield", TokenType.Yield],
+      ["let", TokenType.Let],
+      ["static", TokenType.Static],
+      ["implements", TokenType.Identifier],
+      ["interface", TokenType.Identifier],
+      ["package", TokenType.Identifier],
+      ["private", TokenType.Identifier],
+      ["protected", TokenType.Identifier],
+      ["public", TokenType.Identifier],
+    ];
+
+    for (let i = 0; i < strictWords.length; i++) {
+      const [word, expectedType] = strictWords[i];
+      it(`should return strict-reserved info for "${word}"`, () => {
+        const info = lookupKeyword(word);
+        expect(info).toBeDefined();
+        expect(info!.tokenType).toBe(expectedType);
+        expect(info!.isReserved).toBe(false);
+        expect(info!.isStrictReserved).toBe(true);
+        expect(info!.isContextual).toBe(false);
+      });
+    }
+  });
+
+  describe("non-keywords", () => {
+    const nonKeywords: ReadonlyArray<string> = [
+      "foo",
+      "bar",
+      "myVariable",
+      "console",
+      "Math",
+      "undefined",
+      "NaN",
+      "Infinity",
+      "arguments",
+      "eval",
+      "",
+      " ",
+      "IF",
+      "BREAK",
+      "True",
+      "False",
+      "NULL",
+      "Class",
+    ];
+
+    for (let i = 0; i < nonKeywords.length; i++) {
+      const word = nonKeywords[i];
+      it(`should return undefined for "${word}"`, () => {
+        expect(lookupKeyword(word)).toBeUndefined();
+      });
+    }
+  });
+});
+
+describe("isKeyword", () => {
+  it("should return true for reserved words", () => {
+    expect(isKeyword("break")).toBe(true);
+    expect(isKeyword("if")).toBe(true);
+    expect(isKeyword("return")).toBe(true);
+  });
+
+  it("should return true for contextual keywords", () => {
+    expect(isKeyword("async")).toBe(true);
+    expect(isKeyword("await")).toBe(true);
+    expect(isKeyword("get")).toBe(true);
+  });
+
+  it("should return true for strict-mode reserved words", () => {
+    expect(isKeyword("yield")).toBe(true);
+    expect(isKeyword("let")).toBe(true);
+    expect(isKeyword("implements")).toBe(true);
+  });
+
+  it("should return true for literal keywords", () => {
+    expect(isKeyword("true")).toBe(true);
+    expect(isKeyword("false")).toBe(true);
+    expect(isKeyword("null")).toBe(true);
+  });
+
+  it("should return false for non-keywords", () => {
+    expect(isKeyword("foo")).toBe(false);
+    expect(isKeyword("")).toBe(false);
+    expect(isKeyword("IF")).toBe(false);
+    expect(isKeyword("undefined")).toBe(false);
+  });
+});
+
+describe("isReservedWord", () => {
+  it("should return true for reserved words", () => {
+    expect(isReservedWord("break")).toBe(true);
+    expect(isReservedWord("class")).toBe(true);
+    expect(isReservedWord("true")).toBe(true);
+    expect(isReservedWord("null")).toBe(true);
+  });
+
+  it("should return false for contextual keywords", () => {
+    expect(isReservedWord("async")).toBe(false);
+    expect(isReservedWord("await")).toBe(false);
+    expect(isReservedWord("get")).toBe(false);
+  });
+
+  it("should return false for strict-mode reserved words", () => {
+    expect(isReservedWord("yield")).toBe(false);
+    expect(isReservedWord("let")).toBe(false);
+    expect(isReservedWord("implements")).toBe(false);
+  });
+
+  it("should return false for non-keywords", () => {
+    expect(isReservedWord("foo")).toBe(false);
+    expect(isReservedWord("")).toBe(false);
+  });
+});
+
+describe("isStrictReservedWord", () => {
+  it("should return true for strict-mode reserved words", () => {
+    expect(isStrictReservedWord("yield")).toBe(true);
+    expect(isStrictReservedWord("let")).toBe(true);
+    expect(isStrictReservedWord("static")).toBe(true);
+    expect(isStrictReservedWord("implements")).toBe(true);
+    expect(isStrictReservedWord("interface")).toBe(true);
+    expect(isStrictReservedWord("package")).toBe(true);
+    expect(isStrictReservedWord("private")).toBe(true);
+    expect(isStrictReservedWord("protected")).toBe(true);
+    expect(isStrictReservedWord("public")).toBe(true);
+  });
+
+  it("should return false for reserved words", () => {
+    expect(isStrictReservedWord("break")).toBe(false);
+    expect(isStrictReservedWord("class")).toBe(false);
+  });
+
+  it("should return false for contextual keywords", () => {
+    expect(isStrictReservedWord("async")).toBe(false);
+    expect(isStrictReservedWord("get")).toBe(false);
+  });
+
+  it("should return false for non-keywords", () => {
+    expect(isStrictReservedWord("foo")).toBe(false);
+    expect(isStrictReservedWord("")).toBe(false);
+  });
+});
+
+describe("isContextualKeyword", () => {
+  it("should return true for contextual keywords", () => {
+    expect(isContextualKeyword("async")).toBe(true);
+    expect(isContextualKeyword("await")).toBe(true);
+    expect(isContextualKeyword("of")).toBe(true);
+    expect(isContextualKeyword("from")).toBe(true);
+    expect(isContextualKeyword("as")).toBe(true);
+    expect(isContextualKeyword("get")).toBe(true);
+    expect(isContextualKeyword("set")).toBe(true);
+  });
+
+  it("should return false for reserved words", () => {
+    expect(isContextualKeyword("break")).toBe(false);
+    expect(isContextualKeyword("class")).toBe(false);
+    expect(isContextualKeyword("true")).toBe(false);
+  });
+
+  it("should return false for strict-mode reserved words", () => {
+    expect(isContextualKeyword("yield")).toBe(false);
+    expect(isContextualKeyword("let")).toBe(false);
+    expect(isContextualKeyword("static")).toBe(false);
+  });
+
+  it("should return false for non-keywords", () => {
+    expect(isContextualKeyword("foo")).toBe(false);
+    expect(isContextualKeyword("")).toBe(false);
+  });
+});
+
+describe("KeywordInfo interface", () => {
+  it("should have all required properties", () => {
+    const info: KeywordInfo = {
+      tokenType: TokenType.Break,
+      isReserved: true,
+      isStrictReserved: false,
+      isContextual: false,
+    };
+    expect(info.tokenType).toBe(TokenType.Break);
+    expect(info.isReserved).toBe(true);
+    expect(info.isStrictReserved).toBe(false);
+    expect(info.isContextual).toBe(false);
+  });
+});

--- a/tests/unit/parser/token-types.test.ts
+++ b/tests/unit/parser/token-types.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from "vitest";
+import { TokenType, tokenTypeName } from "../../../src/parser/token-types.js";
+import type { TokenTypeValue } from "../../../src/parser/token-types.js";
+
+describe("TokenType", () => {
+  it("should be a frozen (const) object", () => {
+    // `as const` makes the object readonly at the type level;
+    // verify the values are plain numbers.
+    expect(typeof TokenType.EOF).toBe("number");
+  });
+
+  it("should have EOF equal to 0", () => {
+    expect(TokenType.EOF).toBe(0);
+  });
+
+  it("should assign unique numeric values to every token type", () => {
+    const values = Object.values(TokenType);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+  });
+
+  it("should contain only number values", () => {
+    const values = Object.values(TokenType);
+    for (let i = 0; i < values.length; i++) {
+      expect(typeof values[i]).toBe("number");
+    }
+  });
+
+  describe("identifier and literal range (1-9)", () => {
+    const expected: ReadonlyArray<[string, number]> = [
+      ["Identifier", 1],
+      ["NumericLiteral", 2],
+      ["StringLiteral", 3],
+      ["RegExpLiteral", 4],
+      ["TemplateLiteral", 5],
+      ["TemplateHead", 6],
+      ["TemplateMiddle", 7],
+      ["TemplateTail", 8],
+      ["BigIntLiteral", 9],
+    ];
+
+    for (let i = 0; i < expected.length; i++) {
+      const [name, value] = expected[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("reserved keyword range (10-35)", () => {
+    const reserved: ReadonlyArray<[string, number]> = [
+      ["Break", 10],
+      ["Case", 11],
+      ["Catch", 12],
+      ["Continue", 13],
+      ["Debugger", 14],
+      ["Default", 15],
+      ["Delete", 16],
+      ["Do", 17],
+      ["Else", 18],
+      ["Finally", 19],
+      ["For", 20],
+      ["Function", 21],
+      ["If", 22],
+      ["In", 23],
+      ["Instanceof", 24],
+      ["New", 25],
+      ["Return", 26],
+      ["Switch", 27],
+      ["This", 28],
+      ["Throw", 29],
+      ["Try", 30],
+      ["Typeof", 31],
+      ["Var", 32],
+      ["Void", 33],
+      ["While", 34],
+      ["With", 35],
+    ];
+
+    for (let i = 0; i < reserved.length; i++) {
+      const [name, value] = reserved[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("ES6+ keyword range (36-41)", () => {
+    const es6: ReadonlyArray<[string, number]> = [
+      ["Class", 36],
+      ["Const", 37],
+      ["Export", 38],
+      ["Extends", 39],
+      ["Import", 40],
+      ["Super", 41],
+    ];
+
+    for (let i = 0; i < es6.length; i++) {
+      const [name, value] = es6[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("contextual keyword range (42-51)", () => {
+    const contextual: ReadonlyArray<[string, number]> = [
+      ["Async", 42],
+      ["Await", 43],
+      ["Yield", 44],
+      ["Let", 45],
+      ["Of", 46],
+      ["From", 47],
+      ["As", 48],
+      ["Get", 49],
+      ["Set", 50],
+      ["Static", 51],
+    ];
+
+    for (let i = 0; i < contextual.length; i++) {
+      const [name, value] = contextual[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("literal keyword range (52-54)", () => {
+    it("should map True to 52", () => {
+      expect(TokenType.True).toBe(52);
+    });
+    it("should map False to 53", () => {
+      expect(TokenType.False).toBe(53);
+    });
+    it("should map Null to 54", () => {
+      expect(TokenType.Null).toBe(54);
+    });
+  });
+
+  describe("punctuator range (60-75)", () => {
+    const punctuators: ReadonlyArray<[string, number]> = [
+      ["LeftBrace", 60],
+      ["RightBrace", 61],
+      ["LeftParen", 62],
+      ["RightParen", 63],
+      ["LeftBracket", 64],
+      ["RightBracket", 65],
+      ["Dot", 66],
+      ["Ellipsis", 67],
+      ["Semicolon", 68],
+      ["Comma", 69],
+      ["Colon", 70],
+      ["QuestionMark", 71],
+      ["QuestionDot", 72],
+      ["Arrow", 73],
+      ["Hash", 74],
+      ["At", 75],
+    ];
+
+    for (let i = 0; i < punctuators.length; i++) {
+      const [name, value] = punctuators[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("assignment operator range (80-95)", () => {
+    const assignments: ReadonlyArray<[string, number]> = [
+      ["Equals", 80],
+      ["PlusEquals", 81],
+      ["MinusEquals", 82],
+      ["StarEquals", 83],
+      ["SlashEquals", 84],
+      ["PercentEquals", 85],
+      ["StarStarEquals", 86],
+      ["AmpersandEquals", 87],
+      ["PipeEquals", 88],
+      ["CaretEquals", 89],
+      ["LeftShiftEquals", 90],
+      ["RightShiftEquals", 91],
+      ["UnsignedRightShiftEquals", 92],
+      ["AmpersandAmpersandEquals", 93],
+      ["PipePipeEquals", 94],
+      ["QuestionQuestionEquals", 95],
+    ];
+
+    for (let i = 0; i < assignments.length; i++) {
+      const [name, value] = assignments[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("binary/unary operator range (100-116)", () => {
+    const operators: ReadonlyArray<[string, number]> = [
+      ["Plus", 100],
+      ["Minus", 101],
+      ["Star", 102],
+      ["Slash", 103],
+      ["Percent", 104],
+      ["StarStar", 105],
+      ["Ampersand", 106],
+      ["Pipe", 107],
+      ["Caret", 108],
+      ["Tilde", 109],
+      ["LeftShift", 110],
+      ["RightShift", 111],
+      ["UnsignedRightShift", 112],
+      ["AmpersandAmpersand", 113],
+      ["PipePipe", 114],
+      ["QuestionQuestion", 115],
+      ["Exclamation", 116],
+    ];
+
+    for (let i = 0; i < operators.length; i++) {
+      const [name, value] = operators[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("comparison operator range (120-127)", () => {
+    const comparisons: ReadonlyArray<[string, number]> = [
+      ["EqualsEquals", 120],
+      ["ExclamationEquals", 121],
+      ["EqualsEqualsEquals", 122],
+      ["ExclamationEqualsEquals", 123],
+      ["LessThan", 124],
+      ["GreaterThan", 125],
+      ["LessThanEquals", 126],
+      ["GreaterThanEquals", 127],
+    ];
+
+    for (let i = 0; i < comparisons.length; i++) {
+      const [name, value] = comparisons[i];
+      it(`should map ${name} to ${value}`, () => {
+        expect(TokenType[name as keyof typeof TokenType]).toBe(value);
+      });
+    }
+  });
+
+  describe("increment/decrement (130-131)", () => {
+    it("should map PlusPlus to 130", () => {
+      expect(TokenType.PlusPlus).toBe(130);
+    });
+    it("should map MinusMinus to 131", () => {
+      expect(TokenType.MinusMinus).toBe(131);
+    });
+  });
+
+  describe("comment and template (140-142)", () => {
+    it("should map LineComment to 140", () => {
+      expect(TokenType.LineComment).toBe(140);
+    });
+    it("should map BlockComment to 141", () => {
+      expect(TokenType.BlockComment).toBe(141);
+    });
+    it("should map TemplateNoSub to 142", () => {
+      expect(TokenType.TemplateNoSub).toBe(142);
+    });
+  });
+
+  describe("JSX tokens (150-151)", () => {
+    it("should map JSXText to 150", () => {
+      expect(TokenType.JSXText).toBe(150);
+    });
+    it("should map JSXIdentifier to 151", () => {
+      expect(TokenType.JSXIdentifier).toBe(151);
+    });
+  });
+});
+
+describe("TokenTypeValue", () => {
+  it("should accept valid token type values", () => {
+    const value: TokenTypeValue = TokenType.EOF;
+    expect(value).toBe(0);
+  });
+
+  it("should accept any member of the TokenType object", () => {
+    const values: ReadonlyArray<TokenTypeValue> = [
+      TokenType.Identifier,
+      TokenType.Break,
+      TokenType.LeftBrace,
+      TokenType.Plus,
+      TokenType.EqualsEquals,
+      TokenType.JSXText,
+    ];
+    expect(values.length).toBe(6);
+  });
+});
+
+describe("tokenTypeName", () => {
+  it("should return 'EOF' for value 0", () => {
+    expect(tokenTypeName(0)).toBe("EOF");
+  });
+
+  it("should return 'Identifier' for value 1", () => {
+    expect(tokenTypeName(1)).toBe("Identifier");
+  });
+
+  it("should return the correct name for every token type", () => {
+    const entries = Object.entries(TokenType);
+    for (let i = 0; i < entries.length; i++) {
+      const [name, value] = entries[i];
+      expect(tokenTypeName(value)).toBe(name);
+    }
+  });
+
+  it("should return 'Unknown' for a value that does not exist", () => {
+    expect(tokenTypeName(-1)).toBe("Unknown");
+    expect(tokenTypeName(999)).toBe("Unknown");
+    expect(tokenTypeName(55)).toBe("Unknown");
+  });
+
+  it("should return 'Unknown' for NaN", () => {
+    expect(tokenTypeName(NaN)).toBe("Unknown");
+  });
+});

--- a/tests/unit/parser/token.test.ts
+++ b/tests/unit/parser/token.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import { createToken } from "../../../src/parser/token.js";
+import type { Token } from "../../../src/parser/token.js";
+import { TokenType } from "../../../src/parser/token-types.js";
+
+describe("Token interface", () => {
+  it("should represent an identifier token", () => {
+    const token: Token = {
+      type: TokenType.Identifier,
+      start: 0,
+      end: 3,
+      value: "foo",
+      raw: "foo",
+    };
+    expect(token.type).toBe(TokenType.Identifier);
+    expect(token.start).toBe(0);
+    expect(token.end).toBe(3);
+    expect(token.value).toBe("foo");
+    expect(token.raw).toBe("foo");
+  });
+
+  it("should represent a numeric literal token", () => {
+    const token: Token = {
+      type: TokenType.NumericLiteral,
+      start: 4,
+      end: 6,
+      value: 42,
+      raw: "42",
+    };
+    expect(token.type).toBe(TokenType.NumericLiteral);
+    expect(token.value).toBe(42);
+  });
+
+  it("should represent a string literal token", () => {
+    const token: Token = {
+      type: TokenType.StringLiteral,
+      start: 0,
+      end: 7,
+      value: "hello",
+      raw: '"hello"',
+    };
+    expect(token.type).toBe(TokenType.StringLiteral);
+    expect(token.value).toBe("hello");
+    expect(token.raw).toBe('"hello"');
+  });
+
+  it("should represent a boolean literal token (true)", () => {
+    const token: Token = {
+      type: TokenType.True,
+      start: 0,
+      end: 4,
+      value: true,
+      raw: "true",
+    };
+    expect(token.type).toBe(TokenType.True);
+    expect(token.value).toBe(true);
+  });
+
+  it("should represent a boolean literal token (false)", () => {
+    const token: Token = {
+      type: TokenType.False,
+      start: 0,
+      end: 5,
+      value: false,
+      raw: "false",
+    };
+    expect(token.type).toBe(TokenType.False);
+    expect(token.value).toBe(false);
+  });
+
+  it("should represent a null literal token", () => {
+    const token: Token = {
+      type: TokenType.Null,
+      start: 0,
+      end: 4,
+      value: null,
+      raw: "null",
+    };
+    expect(token.type).toBe(TokenType.Null);
+    expect(token.value).toBeNull();
+  });
+
+  it("should represent a regexp literal token", () => {
+    const regex = /abc/gi;
+    const token: Token = {
+      type: TokenType.RegExpLiteral,
+      start: 0,
+      end: 8,
+      value: regex,
+      raw: "/abc/gi",
+    };
+    expect(token.type).toBe(TokenType.RegExpLiteral);
+    expect(token.value).toBe(regex);
+  });
+
+  it("should represent a bigint literal token", () => {
+    const token: Token = {
+      type: TokenType.BigIntLiteral,
+      start: 0,
+      end: 4,
+      value: BigInt(123),
+      raw: "123n",
+    };
+    expect(token.type).toBe(TokenType.BigIntLiteral);
+    expect(token.value).toBe(BigInt(123));
+  });
+
+  it("should represent an EOF token", () => {
+    const token: Token = {
+      type: TokenType.EOF,
+      start: 100,
+      end: 100,
+      value: "",
+      raw: "",
+    };
+    expect(token.type).toBe(TokenType.EOF);
+    expect(token.start).toBe(100);
+    expect(token.end).toBe(100);
+  });
+
+  it("should represent a punctuator token", () => {
+    const token: Token = {
+      type: TokenType.LeftBrace,
+      start: 5,
+      end: 6,
+      value: "{",
+      raw: "{",
+    };
+    expect(token.type).toBe(TokenType.LeftBrace);
+    expect(token.value).toBe("{");
+  });
+
+  it("should represent a keyword token", () => {
+    const token: Token = {
+      type: TokenType.Function,
+      start: 0,
+      end: 8,
+      value: "function",
+      raw: "function",
+    };
+    expect(token.type).toBe(TokenType.Function);
+    expect(token.value).toBe("function");
+  });
+
+  it("should represent an operator token", () => {
+    const token: Token = {
+      type: TokenType.PlusEquals,
+      start: 10,
+      end: 12,
+      value: "+=",
+      raw: "+=",
+    };
+    expect(token.type).toBe(TokenType.PlusEquals);
+    expect(token.value).toBe("+=");
+  });
+
+  it("should represent a comment token", () => {
+    const token: Token = {
+      type: TokenType.LineComment,
+      start: 0,
+      end: 12,
+      value: " a comment",
+      raw: "// a comment",
+    };
+    expect(token.type).toBe(TokenType.LineComment);
+    expect(token.raw).toBe("// a comment");
+  });
+
+  it("should represent a template literal token", () => {
+    const token: Token = {
+      type: TokenType.TemplateHead,
+      start: 0,
+      end: 8,
+      value: "hello ",
+      raw: "`hello ${",
+    };
+    expect(token.type).toBe(TokenType.TemplateHead);
+  });
+});
+
+describe("createToken", () => {
+  it("should create a token with the given properties", () => {
+    const token = createToken(TokenType.Identifier, 0, 3, "foo", "foo");
+    expect(token.type).toBe(TokenType.Identifier);
+    expect(token.start).toBe(0);
+    expect(token.end).toBe(3);
+    expect(token.value).toBe("foo");
+    expect(token.raw).toBe("foo");
+  });
+
+  it("should create a frozen token", () => {
+    const token = createToken(TokenType.NumericLiteral, 0, 2, 42, "42");
+    expect(Object.isFrozen(token)).toBe(true);
+  });
+
+  it("should reject modifications to a frozen token", () => {
+    const token = createToken(TokenType.Identifier, 0, 3, "foo", "foo");
+    expect(() => {
+      (token as { type: number }).type = TokenType.NumericLiteral;
+    }).toThrow();
+  });
+
+  it("should create an EOF token", () => {
+    const token = createToken(TokenType.EOF, 50, 50, "", "");
+    expect(token.type).toBe(TokenType.EOF);
+    expect(token.start).toBe(50);
+    expect(token.end).toBe(50);
+  });
+
+  it("should create a token with null value", () => {
+    const token = createToken(TokenType.Null, 0, 4, null, "null");
+    expect(token.value).toBeNull();
+  });
+
+  it("should create a token with boolean value", () => {
+    const tokenTrue = createToken(TokenType.True, 0, 4, true, "true");
+    expect(tokenTrue.value).toBe(true);
+
+    const tokenFalse = createToken(TokenType.False, 0, 5, false, "false");
+    expect(tokenFalse.value).toBe(false);
+  });
+
+  it("should create a token with RegExp value", () => {
+    const regex = /test/i;
+    const token = createToken(TokenType.RegExpLiteral, 0, 7, regex, "/test/i");
+    expect(token.value).toBe(regex);
+  });
+
+  it("should create a token with bigint value", () => {
+    const token = createToken(TokenType.BigIntLiteral, 0, 2, BigInt(9), "9n");
+    expect(token.value).toBe(BigInt(9));
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/parser/token-types.ts` with a comprehensive `TokenType` const object (80+ token types covering identifiers, literals, keywords, punctuators, operators, comments, and JSX) plus a `tokenTypeName` reverse-lookup utility
- Add `src/parser/keywords.ts` with O(1) keyword detection via `Map`, classifying words as reserved, contextual, or strict-mode reserved, with helper functions (`lookupKeyword`, `isKeyword`, `isReservedWord`, `isStrictReservedWord`, `isContextualKeyword`)
- Add `src/parser/token.ts` with a `Token` interface and `createToken` factory producing frozen token objects
- Add 238 unit tests across 3 test files with 100% coverage on all new code

Closes #8

## Test plan

- [x] All 238 new parser tests pass (`npx vitest run tests/unit/parser/`)
- [x] Full test suite (1157 tests) passes
- [x] TypeScript strict-mode compilation passes (`npx tsc --noEmit`)
- [x] 100% statement/branch/function/line coverage on new `src/parser/` files
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)