### PR TITLE
feat: implement lexer punctuators and operators

### DIFF
--- a/src/parser/lexer-punctuator.ts
+++ b/src/parser/lexer-punctuator.ts
@@ -1,0 +1,219 @@
+/**
+ * Punctuator and operator scanner for the Steamroller lexer.
+ *
+ * Scans all JavaScript punctuators and operators from source text at a
+ * given position using greedy/longest-match semantics: for example,
+ * `>>>` is scanned as a single UnsignedRightShift token, not three
+ * separate GreaterThan tokens.
+ *
+ * @module parser/lexer-punctuator
+ */
+
+import type { Token } from './token.js';
+import { TokenType } from './token-types.js';
+import { createToken } from './token.js';
+
+/**
+ * Result of scanning a punctuator or operator from source text.
+ */
+export interface ScanResult {
+  /** The produced token. */
+  readonly token: Token;
+  /** Byte offset immediately after the last character of the token. */
+  readonly end: number;
+}
+
+/**
+ * Build a ScanResult from the given parameters.
+ *
+ * @param type  - The token type value.
+ * @param start - Start offset in source.
+ * @param end   - End offset in source.
+ * @param raw   - The raw source text of the token.
+ * @returns A frozen ScanResult.
+ */
+const result = (type: number, start: number, end: number, raw: string): ScanResult =>
+  Object.freeze({
+    token: createToken(type, start, end, raw, raw),
+    end,
+  });
+
+/**
+ * Scan a punctuator or operator starting at `start` in `source`.
+ *
+ * Uses greedy/longest-match: `>>>` before `>>` before `>`, etc.
+ * Returns null if the character at `start` is not a punctuator.
+ *
+ * @param source - The full source text.
+ * @param start  - The byte offset to begin scanning.
+ * @returns A ScanResult if a punctuator was found, or null otherwise.
+ */
+export const scanPunctuator = (source: string, start: number): ScanResult | null => {
+  const c0 = source.charCodeAt(start);
+  const c1 = start + 1 < source.length ? source.charCodeAt(start + 1) : -1;
+  const c2 = start + 2 < source.length ? source.charCodeAt(start + 2) : -1;
+  const c3 = start + 3 < source.length ? source.charCodeAt(start + 3) : -1;
+
+  switch (c0) {
+    // + ++ +=
+    case 0x2B: {
+      if (c1 === 0x2B) return result(TokenType.PlusPlus, start, start + 2, '++');
+      if (c1 === 0x3D) return result(TokenType.PlusEquals, start, start + 2, '+=');
+      return result(TokenType.Plus, start, start + 1, '+');
+    }
+
+    // - -- -=
+    case 0x2D: {
+      if (c1 === 0x2D) return result(TokenType.MinusMinus, start, start + 2, '--');
+      if (c1 === 0x3D) return result(TokenType.MinusEquals, start, start + 2, '-=');
+      return result(TokenType.Minus, start, start + 1, '-');
+    }
+
+    // * ** *= **=
+    case 0x2A: {
+      if (c1 === 0x2A) {
+        if (c2 === 0x3D) return result(TokenType.StarStarEquals, start, start + 3, '**=');
+        return result(TokenType.StarStar, start, start + 2, '**');
+      }
+      if (c1 === 0x3D) return result(TokenType.StarEquals, start, start + 2, '*=');
+      return result(TokenType.Star, start, start + 1, '*');
+    }
+
+    // / /=
+    case 0x2F: {
+      if (c1 === 0x3D) return result(TokenType.SlashEquals, start, start + 2, '/=');
+      return result(TokenType.Slash, start, start + 1, '/');
+    }
+
+    // % %=
+    case 0x25: {
+      if (c1 === 0x3D) return result(TokenType.PercentEquals, start, start + 2, '%=');
+      return result(TokenType.Percent, start, start + 1, '%');
+    }
+
+    // = == === =>
+    case 0x3D: {
+      if (c1 === 0x3D) {
+        if (c2 === 0x3D) return result(TokenType.EqualsEqualsEquals, start, start + 3, '===');
+        return result(TokenType.EqualsEquals, start, start + 2, '==');
+      }
+      if (c1 === 0x3E) return result(TokenType.Arrow, start, start + 2, '=>');
+      return result(TokenType.Equals, start, start + 1, '=');
+    }
+
+    // ! != !==
+    case 0x21: {
+      if (c1 === 0x3D) {
+        if (c2 === 0x3D) return result(TokenType.ExclamationEqualsEquals, start, start + 3, '!==');
+        return result(TokenType.ExclamationEquals, start, start + 2, '!=');
+      }
+      return result(TokenType.Exclamation, start, start + 1, '!');
+    }
+
+    // < <= << <<=
+    case 0x3C: {
+      if (c1 === 0x3C) {
+        if (c2 === 0x3D) return result(TokenType.LeftShiftEquals, start, start + 3, '<<=');
+        return result(TokenType.LeftShift, start, start + 2, '<<');
+      }
+      if (c1 === 0x3D) return result(TokenType.LessThanEquals, start, start + 2, '<=');
+      return result(TokenType.LessThan, start, start + 1, '<');
+    }
+
+    // > >= >> >>> >>= >>>=
+    case 0x3E: {
+      if (c1 === 0x3E) {
+        if (c2 === 0x3E) {
+          if (c3 === 0x3D) return result(TokenType.UnsignedRightShiftEquals, start, start + 4, '>>>=');
+          return result(TokenType.UnsignedRightShift, start, start + 3, '>>>');
+        }
+        if (c2 === 0x3D) return result(TokenType.RightShiftEquals, start, start + 3, '>>=');
+        return result(TokenType.RightShift, start, start + 2, '>>');
+      }
+      if (c1 === 0x3D) return result(TokenType.GreaterThanEquals, start, start + 2, '>=');
+      return result(TokenType.GreaterThan, start, start + 1, '>');
+    }
+
+    // & && &= &&=
+    case 0x26: {
+      if (c1 === 0x26) {
+        if (c2 === 0x3D) return result(TokenType.AmpersandAmpersandEquals, start, start + 3, '&&=');
+        return result(TokenType.AmpersandAmpersand, start, start + 2, '&&');
+      }
+      if (c1 === 0x3D) return result(TokenType.AmpersandEquals, start, start + 2, '&=');
+      return result(TokenType.Ampersand, start, start + 1, '&');
+    }
+
+    // | || |= ||=
+    case 0x7C: {
+      if (c1 === 0x7C) {
+        if (c2 === 0x3D) return result(TokenType.PipePipeEquals, start, start + 3, '||=');
+        return result(TokenType.PipePipe, start, start + 2, '||');
+      }
+      if (c1 === 0x3D) return result(TokenType.PipeEquals, start, start + 2, '|=');
+      return result(TokenType.Pipe, start, start + 1, '|');
+    }
+
+    // ^ ^=
+    case 0x5E: {
+      if (c1 === 0x3D) return result(TokenType.CaretEquals, start, start + 2, '^=');
+      return result(TokenType.Caret, start, start + 1, '^');
+    }
+
+    // ~
+    case 0x7E:
+      return result(TokenType.Tilde, start, start + 1, '~');
+
+    // ? ?. ?? ??=
+    case 0x3F: {
+      if (c1 === 0x3F) {
+        if (c2 === 0x3D) return result(TokenType.QuestionQuestionEquals, start, start + 3, '??=');
+        return result(TokenType.QuestionQuestion, start, start + 2, '??');
+      }
+      if (c1 === 0x2E) {
+        // ?. is QuestionDot only if the next char is NOT a digit
+        // (to avoid treating ?.5 as optional chaining)
+        if (c2 >= 0x30 && c2 <= 0x39) {
+          return result(TokenType.QuestionMark, start, start + 1, '?');
+        }
+        return result(TokenType.QuestionDot, start, start + 2, '?.');
+      }
+      return result(TokenType.QuestionMark, start, start + 1, '?');
+    }
+
+    // . ...
+    case 0x2E: {
+      if (c1 === 0x2E && c2 === 0x2E) return result(TokenType.Ellipsis, start, start + 3, '...');
+      return result(TokenType.Dot, start, start + 1, '.');
+    }
+
+    // ( ) [ ] { }
+    case 0x28:
+      return result(TokenType.LeftParen, start, start + 1, '(');
+    case 0x29:
+      return result(TokenType.RightParen, start, start + 1, ')');
+    case 0x5B:
+      return result(TokenType.LeftBracket, start, start + 1, '[');
+    case 0x5D:
+      return result(TokenType.RightBracket, start, start + 1, ']');
+    case 0x7B:
+      return result(TokenType.LeftBrace, start, start + 1, '{');
+    case 0x7D:
+      return result(TokenType.RightBrace, start, start + 1, '}');
+
+    // , ; : # @
+    case 0x2C:
+      return result(TokenType.Comma, start, start + 1, ',');
+    case 0x3B:
+      return result(TokenType.Semicolon, start, start + 1, ';');
+    case 0x3A:
+      return result(TokenType.Colon, start, start + 1, ':');
+    case 0x23:
+      return result(TokenType.Hash, start, start + 1, '#');
+    case 0x40:
+      return result(TokenType.At, start, start + 1, '@');
+
+    default:
+      return null;
+  }
+};

--- a/tests/unit/parser/lexer-punctuator.test.ts
+++ b/tests/unit/parser/lexer-punctuator.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for the punctuator and operator scanner.
+ *
+ * Covers all single-char punctuators, two-char operators, three-char
+ * operators, four-char operators (>>>=), greedy/longest-match behaviour,
+ * and non-punctuator rejection.
+ *
+ * @module tests/unit/parser/lexer-punctuator
+ */
+
+import { describe, it, expect } from 'vitest';
+import { scanPunctuator } from '../../../src/parser/lexer-punctuator.js';
+import type { ScanResult } from '../../../src/parser/lexer-punctuator.js';
+import { TokenType } from '../../../src/parser/token-types.js';
+
+/** Helper: assert a scan result matches expectations. */
+const expectToken = (
+  result: ScanResult | null,
+  type: number,
+  raw: string,
+  start: number,
+  end: number,
+): void => {
+  expect(result).not.toBeNull();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const r = result!;
+  expect(r.token.type).toBe(type);
+  expect(r.token.raw).toBe(raw);
+  expect(r.token.value).toBe(raw);
+  expect(r.token.start).toBe(start);
+  expect(r.token.end).toBe(end);
+  expect(r.end).toBe(end);
+};
+
+describe('scanPunctuator', () => {
+  // ── Single-char punctuators ──────────────────────────────────────
+
+  describe('single-char punctuators', () => {
+    const singles: ReadonlyArray<readonly [string, number]> = [
+      ['(', TokenType.LeftParen],
+      [')', TokenType.RightParen],
+      ['[', TokenType.LeftBracket],
+      [']', TokenType.RightBracket],
+      ['{', TokenType.LeftBrace],
+      ['}', TokenType.RightBrace],
+      [',', TokenType.Comma],
+      [';', TokenType.Semicolon],
+      [':', TokenType.Colon],
+      ['#', TokenType.Hash],
+      ['@', TokenType.At],
+      ['~', TokenType.Tilde],
+      ['.', TokenType.Dot],
+      ['?', TokenType.QuestionMark],
+      ['+', TokenType.Plus],
+      ['-', TokenType.Minus],
+      ['*', TokenType.Star],
+      ['/', TokenType.Slash],
+      ['%', TokenType.Percent],
+      ['=', TokenType.Equals],
+      ['!', TokenType.Exclamation],
+      ['<', TokenType.LessThan],
+      ['>', TokenType.GreaterThan],
+      ['&', TokenType.Ampersand],
+      ['|', TokenType.Pipe],
+      ['^', TokenType.Caret],
+    ];
+
+    for (let i = 0; i < singles.length; i++) {
+      const [raw, type] = singles[i];
+      it(`scans "${raw}" as a single-char token`, () => {
+        expectToken(scanPunctuator(raw, 0), type, raw, 0, 1);
+      });
+    }
+  });
+
+  // ── Two-char operators ───────────────────────────────────────────
+
+  describe('two-char operators', () => {
+    const doubles: ReadonlyArray<readonly [string, number]> = [
+      ['++', TokenType.PlusPlus],
+      ['+=', TokenType.PlusEquals],
+      ['--', TokenType.MinusMinus],
+      ['-=', TokenType.MinusEquals],
+      ['**', TokenType.StarStar],
+      ['*=', TokenType.StarEquals],
+      ['/=', TokenType.SlashEquals],
+      ['%=', TokenType.PercentEquals],
+      ['==', TokenType.EqualsEquals],
+      ['=>', TokenType.Arrow],
+      ['!=', TokenType.ExclamationEquals],
+      ['<=', TokenType.LessThanEquals],
+      ['<<', TokenType.LeftShift],
+      ['>=', TokenType.GreaterThanEquals],
+      ['>>', TokenType.RightShift],
+      ['&&', TokenType.AmpersandAmpersand],
+      ['&=', TokenType.AmpersandEquals],
+      ['||', TokenType.PipePipe],
+      ['|=', TokenType.PipeEquals],
+      ['^=', TokenType.CaretEquals],
+      ['?.', TokenType.QuestionDot],
+      ['??', TokenType.QuestionQuestion],
+    ];
+
+    for (let i = 0; i < doubles.length; i++) {
+      const [raw, type] = doubles[i];
+      it(`scans "${raw}"`, () => {
+        expectToken(scanPunctuator(raw, 0), type, raw, 0, 2);
+      });
+    }
+  });
+
+  // ── Three-char operators ─────────────────────────────────────────
+
+  describe('three-char operators', () => {
+    const triples: ReadonlyArray<readonly [string, number]> = [
+      ['===', TokenType.EqualsEqualsEquals],
+      ['!==', TokenType.ExclamationEqualsEquals],
+      ['>>>', TokenType.UnsignedRightShift],
+      ['<<=', TokenType.LeftShiftEquals],
+      ['>>=', TokenType.RightShiftEquals],
+      ['**=', TokenType.StarStarEquals],
+      ['&&=', TokenType.AmpersandAmpersandEquals],
+      ['||=', TokenType.PipePipeEquals],
+      ['??=', TokenType.QuestionQuestionEquals],
+      ['...', TokenType.Ellipsis],
+    ];
+
+    for (let i = 0; i < triples.length; i++) {
+      const [raw, type] = triples[i];
+      it(`scans "${raw}"`, () => {
+        expectToken(scanPunctuator(raw, 0), type, raw, 0, 3);
+      });
+    }
+  });
+
+  // ── Four-char operator ───────────────────────────────────────────
+
+  describe('four-char operator', () => {
+    it('scans ">>>="', () => {
+      expectToken(scanPunctuator('>>>=', 0), TokenType.UnsignedRightShiftEquals, '>>>=', 0, 4);
+    });
+  });
+
+  // ── Greedy / longest-match ───────────────────────────────────────
+
+  describe('greedy matching', () => {
+    it('scans ">>>" as UnsignedRightShift, not GreaterThan + RightShift', () => {
+      const r = scanPunctuator('>>>x', 0);
+      expectToken(r, TokenType.UnsignedRightShift, '>>>', 0, 3);
+    });
+
+    it('scans ">>>=" as UnsignedRightShiftEquals, not UnsignedRightShift + Equals', () => {
+      const r = scanPunctuator('>>>=x', 0);
+      expectToken(r, TokenType.UnsignedRightShiftEquals, '>>>=', 0, 4);
+    });
+
+    it('scans ">>" as RightShift, not two GreaterThan', () => {
+      const r = scanPunctuator('>>x', 0);
+      expectToken(r, TokenType.RightShift, '>>', 0, 2);
+    });
+
+    it('scans "===" as StrictEquals, not EqualsEquals + Equals', () => {
+      const r = scanPunctuator('===x', 0);
+      expectToken(r, TokenType.EqualsEqualsEquals, '===', 0, 3);
+    });
+
+    it('scans "!==" as StrictNotEquals, not ExclamationEquals + Equals', () => {
+      const r = scanPunctuator('!==x', 0);
+      expectToken(r, TokenType.ExclamationEqualsEquals, '!==', 0, 3);
+    });
+
+    it('scans "**=" as StarStarEquals, not StarStar + Equals', () => {
+      const r = scanPunctuator('**=x', 0);
+      expectToken(r, TokenType.StarStarEquals, '**=', 0, 3);
+    });
+
+    it('scans "&&=" as AmpersandAmpersandEquals', () => {
+      const r = scanPunctuator('&&=x', 0);
+      expectToken(r, TokenType.AmpersandAmpersandEquals, '&&=', 0, 3);
+    });
+
+    it('scans "||=" as PipePipeEquals', () => {
+      const r = scanPunctuator('||=x', 0);
+      expectToken(r, TokenType.PipePipeEquals, '||=', 0, 3);
+    });
+
+    it('scans "??=" as QuestionQuestionEquals', () => {
+      const r = scanPunctuator('??=x', 0);
+      expectToken(r, TokenType.QuestionQuestionEquals, '??=', 0, 3);
+    });
+
+    it('scans "..." as Ellipsis, not three Dots', () => {
+      const r = scanPunctuator('...x', 0);
+      expectToken(r, TokenType.Ellipsis, '...', 0, 3);
+    });
+
+    it('scans ".." as a single Dot (no two-dot operator)', () => {
+      const r = scanPunctuator('..x', 0);
+      expectToken(r, TokenType.Dot, '.', 0, 1);
+    });
+  });
+
+  // ── QuestionDot vs QuestionMark + Dot ────────────────────────────
+
+  describe('?. disambiguation', () => {
+    it('scans "?." as QuestionDot', () => {
+      expectToken(scanPunctuator('?.x', 0), TokenType.QuestionDot, '?.', 0, 2);
+    });
+
+    it('scans "?." at end of source as QuestionDot', () => {
+      expectToken(scanPunctuator('?.', 0), TokenType.QuestionDot, '?.', 0, 2);
+    });
+
+    it('scans "?.5" as QuestionMark (not QuestionDot before digit)', () => {
+      const r = scanPunctuator('?.5', 0);
+      expectToken(r, TokenType.QuestionMark, '?', 0, 1);
+    });
+
+    it('scans "?.0" as QuestionMark (not QuestionDot before digit)', () => {
+      const r = scanPunctuator('?.0', 0);
+      expectToken(r, TokenType.QuestionMark, '?', 0, 1);
+    });
+
+    it('scans "?.9" as QuestionMark (not QuestionDot before digit)', () => {
+      const r = scanPunctuator('?.9', 0);
+      expectToken(r, TokenType.QuestionMark, '?', 0, 1);
+    });
+  });
+
+  // ── Non-punctuator returns null ──────────────────────────────────
+
+  describe('non-punctuator input', () => {
+    it('returns null for alphabetic character', () => {
+      expect(scanPunctuator('abc', 0)).toBeNull();
+    });
+
+    it('returns null for digit', () => {
+      expect(scanPunctuator('123', 0)).toBeNull();
+    });
+
+    it('returns null for whitespace', () => {
+      expect(scanPunctuator(' ', 0)).toBeNull();
+    });
+
+    it('returns null for newline', () => {
+      expect(scanPunctuator('\n', 0)).toBeNull();
+    });
+
+    it('returns null for tab', () => {
+      expect(scanPunctuator('\t', 0)).toBeNull();
+    });
+
+    it('returns null for underscore', () => {
+      expect(scanPunctuator('_foo', 0)).toBeNull();
+    });
+
+    it('returns null for dollar sign', () => {
+      expect(scanPunctuator('$foo', 0)).toBeNull();
+    });
+
+    it('returns null for double-quote', () => {
+      expect(scanPunctuator('"hello"', 0)).toBeNull();
+    });
+
+    it('returns null for single-quote', () => {
+      expect(scanPunctuator("'hello'", 0)).toBeNull();
+    });
+
+    it('returns null for backtick', () => {
+      expect(scanPunctuator('`hello`', 0)).toBeNull();
+    });
+  });
+
+  // ── Start position tracking ──────────────────────────────────────
+
+  describe('start position tracking', () => {
+    it('scans from a non-zero start position', () => {
+      const source = 'abc + def';
+      expectToken(scanPunctuator(source, 4), TokenType.Plus, '+', 4, 5);
+    });
+
+    it('scans multi-char operator from a non-zero start', () => {
+      const source = 'x === y';
+      expectToken(scanPunctuator(source, 2), TokenType.EqualsEqualsEquals, '===', 2, 5);
+    });
+
+    it('scans four-char operator from a non-zero start', () => {
+      const source = 'a >>>= b';
+      expectToken(scanPunctuator(source, 2), TokenType.UnsignedRightShiftEquals, '>>>=', 2, 6);
+    });
+
+    it('returns null when start is at a non-punctuator character', () => {
+      const source = '+ abc';
+      expect(scanPunctuator(source, 2)).toBeNull();
+    });
+
+    it('scans single-char at end of source', () => {
+      const source = 'x+';
+      expectToken(scanPunctuator(source, 1), TokenType.Plus, '+', 1, 2);
+    });
+
+    it('handles operator at very end of source (no lookahead available)', () => {
+      const source = 'x>';
+      expectToken(scanPunctuator(source, 1), TokenType.GreaterThan, '>', 1, 2);
+    });
+  });
+
+  // ── Token immutability ───────────────────────────────────────────
+
+  describe('token immutability', () => {
+    it('produces frozen tokens', () => {
+      const r = scanPunctuator('+', 0);
+      expect(r).not.toBeNull();
+      expect(Object.isFrozen(r!.token)).toBe(true);
+    });
+
+    it('produces frozen scan results', () => {
+      const r = scanPunctuator('+', 0);
+      expect(r).not.toBeNull();
+      expect(Object.isFrozen(r)).toBe(true);
+    });
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles single > at end of source', () => {
+      expectToken(scanPunctuator('>', 0), TokenType.GreaterThan, '>', 0, 1);
+    });
+
+    it('handles >> at end of source', () => {
+      expectToken(scanPunctuator('>>', 0), TokenType.RightShift, '>>', 0, 2);
+    });
+
+    it('handles >>> at end of source', () => {
+      expectToken(scanPunctuator('>>>', 0), TokenType.UnsignedRightShift, '>>>', 0, 3);
+    });
+
+    it('handles single < at end of source', () => {
+      expectToken(scanPunctuator('<', 0), TokenType.LessThan, '<', 0, 1);
+    });
+
+    it('handles single = at end of source', () => {
+      expectToken(scanPunctuator('=', 0), TokenType.Equals, '=', 0, 1);
+    });
+
+    it('handles single ! at end of source', () => {
+      expectToken(scanPunctuator('!', 0), TokenType.Exclamation, '!', 0, 1);
+    });
+
+    it('handles single ? at end of source', () => {
+      expectToken(scanPunctuator('?', 0), TokenType.QuestionMark, '?', 0, 1);
+    });
+
+    it('handles single & at end of source', () => {
+      expectToken(scanPunctuator('&', 0), TokenType.Ampersand, '&', 0, 1);
+    });
+
+    it('handles single | at end of source', () => {
+      expectToken(scanPunctuator('|', 0), TokenType.Pipe, '|', 0, 1);
+    });
+
+    it('handles single ^ at end of source', () => {
+      expectToken(scanPunctuator('^', 0), TokenType.Caret, '^', 0, 1);
+    });
+
+    it('handles == followed by non-= char', () => {
+      expectToken(scanPunctuator('==x', 0), TokenType.EqualsEquals, '==', 0, 2);
+    });
+
+    it('handles != followed by non-= char', () => {
+      expectToken(scanPunctuator('!=x', 0), TokenType.ExclamationEquals, '!=', 0, 2);
+    });
+
+    it('handles ** followed by non-= char', () => {
+      expectToken(scanPunctuator('**x', 0), TokenType.StarStar, '**', 0, 2);
+    });
+
+    it('handles && followed by non-= char', () => {
+      expectToken(scanPunctuator('&&x', 0), TokenType.AmpersandAmpersand, '&&', 0, 2);
+    });
+
+    it('handles || followed by non-= char', () => {
+      expectToken(scanPunctuator('||x', 0), TokenType.PipePipe, '||', 0, 2);
+    });
+
+    it('handles ?? followed by non-= char', () => {
+      expectToken(scanPunctuator('??x', 0), TokenType.QuestionQuestion, '??', 0, 2);
+    });
+
+    it('handles << followed by non-= char', () => {
+      expectToken(scanPunctuator('<<x', 0), TokenType.LeftShift, '<<', 0, 2);
+    });
+
+    it('handles >> followed by non-= and non-> char', () => {
+      expectToken(scanPunctuator('>>x', 0), TokenType.RightShift, '>>', 0, 2);
+    });
+
+    it('handles >>=', () => {
+      expectToken(scanPunctuator('>>=', 0), TokenType.RightShiftEquals, '>>=', 0, 3);
+    });
+
+    it('returns null for empty string at start 0', () => {
+      expect(scanPunctuator('', 0)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements greedy/longest-match punctuator and operator scanning in `src/parser/lexer-punctuator.ts`
- Covers all JS punctuators (brackets, parens, braces, comma, semicolon, colon, hash, at) and operators (+, -, *, /, %, =, !, <, >, &, |, ^, ~, ?, .) including all multi-character variants up to 4 chars (>>>=)
- Handles modern operators: optional chaining (?.), nullish coalescing (??), logical assignment (&&=, ||=, ??=), exponentiation assignment (**=)
- Correctly disambiguates ?. from ?.digit (conditional + decimal literal)
- 113 unit tests with 100% coverage on the new module

## Test plan

- [x] All single-char punctuators scan correctly
- [x] All two-char operators scan correctly
- [x] All three-char operators scan correctly
- [x] Four-char operator (>>>=) scans correctly
- [x] Greedy matching verified (>>> is one token, not three)
- [x] ?. vs ? + .digit disambiguation verified
- [x] ... vs . + . + . disambiguation verified
- [x] Non-punctuator input returns null
- [x] Start position tracking works at non-zero offsets
- [x] Token and result immutability verified

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)