### PR TITLE
feat: implement parser core (Lexer class and Program node)

### DIFF
--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -1,0 +1,471 @@
+/**
+ * Core Lexer class for the Steamroller parser.
+ *
+ * Orchestrates all scanning modules (numeric, string, regex, punctuator,
+ * whitespace) into a unified token stream. Provides lookahead via
+ * save/restore state, and convenience methods for token consumption.
+ *
+ * Internal state is mutable (documented exception for parser state machine).
+ *
+ * @module parser/lexer
+ */
+
+import type { Token } from './token.js';
+import { createToken } from './token.js';
+import { TokenType } from './token-types.js';
+import { lookupKeyword } from './keywords.js';
+import { scanNumericLiteral } from './lexer-numeric.js';
+import { scanStringLiteral, scanTemplateLiteral } from './lexer-string.js';
+import { isRegExpStart, scanRegExpLiteral } from './lexer-regex.js';
+import { scanPunctuator } from './lexer-punctuator.js';
+import {
+  skipWhitespace,
+  scanLineComment,
+  scanBlockComment,
+  scanHashbang,
+  isLineTerminator,
+} from './lexer-whitespace.js';
+import { tokenTypeName } from './token-types.js';
+
+/**
+ * Snapshot of lexer state for save/restore lookahead.
+ */
+export interface LexerState {
+  readonly pos: number;
+  readonly token: Token;
+  readonly hadLineTerminatorBefore: boolean;
+  readonly previousTokenType: number;
+  readonly templateDepth: number;
+}
+
+/**
+ * Returns true if the character code can start an identifier.
+ *
+ * Covers ASCII letters, underscore, dollar sign, and common Unicode
+ * identifier start characters (basic multilingual plane letters).
+ *
+ * @param code - The character code to test.
+ * @returns True if the code can start an identifier.
+ */
+const isIdentifierStart = (code: number): boolean => {
+  // $ (0x24), _ (0x5F), A-Z (0x41-0x5A), a-z (0x61-0x7A)
+  if (code === 0x24 || code === 0x5f) {
+    return true;
+  }
+  if (code >= 0x41 && code <= 0x5a) {
+    return true;
+  }
+  if (code >= 0x61 && code <= 0x7a) {
+    return true;
+  }
+  // Basic Unicode letter detection (Latin Extended, Greek, Cyrillic, etc.)
+  if (code >= 0xc0 && code !== 0xd7 && code !== 0xf7) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Returns true if the character code can continue an identifier.
+ *
+ * Includes identifier start characters plus digits and zero-width
+ * joiners/non-joiners.
+ *
+ * @param code - The character code to test.
+ * @returns True if the code can continue an identifier.
+ */
+const isIdentifierPart = (code: number): boolean => {
+  if (isIdentifierStart(code)) {
+    return true;
+  }
+  // 0-9 (0x30-0x39)
+  if (code >= 0x30 && code <= 0x39) {
+    return true;
+  }
+  // Zero-width non-joiner (0x200C) and zero-width joiner (0x200D)
+  if (code === 0x200c || code === 0x200d) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Returns true if the character code is an ASCII digit (0-9).
+ *
+ * @param code - The character code to test.
+ * @returns True if 0-9.
+ */
+const isDigit = (code: number): boolean => {
+  return code >= 0x30 && code <= 0x39;
+};
+
+/**
+ * Create an EOF token at the given position.
+ *
+ * @param pos - The position in source at EOF.
+ * @returns A frozen EOF token.
+ */
+const createEofToken = (pos: number): Token => {
+  return createToken(TokenType.EOF, pos, pos, '', '');
+};
+
+/**
+ * The core Lexer class that produces a token stream from source text.
+ *
+ * All internal state fields are mutable (documented exception for
+ * parser state machine pattern). External consumers interact only
+ * through the public API which returns immutable Token objects.
+ */
+export class Lexer {
+  /** The full source text being lexed. */
+  private source: string;
+  /** Current byte offset in source. */
+  private pos: number;
+  /** The current (most recently scanned) token. */
+  private currentToken: Token;
+  /** Whether a line terminator was encountered before the current token. */
+  private hadLineTerminator: boolean;
+  /** Whether strict mode is active. */
+  private strict: boolean;
+  /** Nesting depth of template literal substitutions. */
+  private templateDepth: number;
+  /** The token type of the previous token (for regex disambiguation). */
+  private previousTokenType: number;
+  /** Whether the hashbang at source start has been processed. */
+  private hashbangProcessed: boolean;
+
+  /**
+   * Create a new Lexer for the given source text.
+   *
+   * @param source - The source text to lex.
+   * @param strict - Whether strict mode is active (e.g., module mode).
+   * @param allowHashBang - Whether to allow a hashbang (#!) at source start.
+   */
+  constructor(source: string, strict: boolean, allowHashBang: boolean = false) {
+    this.source = source;
+    this.pos = 0;
+    this.hadLineTerminator = false;
+    this.strict = strict;
+    this.templateDepth = 0;
+    this.previousTokenType = -1;
+    this.hashbangProcessed = false;
+
+    // Handle hashbang if allowed and present
+    if (allowHashBang) {
+      const hashbangResult = scanHashbang(source);
+      if (hashbangResult !== null) {
+        this.pos = hashbangResult.end;
+        this.hashbangProcessed = true;
+      }
+    }
+
+    // Scan the first token
+    this.currentToken = this.scan();
+  }
+
+  /**
+   * Get the current token without advancing.
+   */
+  get token(): Token {
+    return this.currentToken;
+  }
+
+  /**
+   * Whether a line terminator was encountered before the current token.
+   */
+  get hadLineTerminatorBefore(): boolean {
+    return this.hadLineTerminator;
+  }
+
+  /**
+   * Advance to the next token and return the previous one.
+   *
+   * @returns The token that was current before advancing.
+   */
+  next(): Token {
+    const previous = this.currentToken;
+    this.previousTokenType = previous.type;
+    this.currentToken = this.scan();
+    return previous;
+  }
+
+  /**
+   * Expect the current token to be a specific type, consume it, and
+   * return it. Throws a SyntaxError if the token type does not match.
+   *
+   * @param type - The expected token type number.
+   * @returns The consumed token.
+   * @throws {SyntaxError} If the current token type does not match.
+   */
+  expect(type: number): Token {
+    if (this.currentToken.type !== type) {
+      const expected = tokenTypeName(type);
+      const actual = tokenTypeName(this.currentToken.type);
+      throw new SyntaxError(
+        `Expected ${expected} but found ${actual} at position ${this.currentToken.start}`,
+      );
+    }
+    return this.next();
+  }
+
+  /**
+   * Check if the current token is a specific type.
+   *
+   * @param type - The token type to check.
+   * @returns True if the current token matches the type.
+   */
+  is(type: number): boolean {
+    return this.currentToken.type === type;
+  }
+
+  /**
+   * Consume the current token if it matches the given type.
+   *
+   * @param type - The token type to try to consume.
+   * @returns True if the token was consumed, false otherwise.
+   */
+  eat(type: number): boolean {
+    if (this.currentToken.type === type) {
+      this.next();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Save the current lexer state for lookahead.
+   *
+   * @returns A frozen snapshot of the current state.
+   */
+  saveState(): LexerState {
+    return Object.freeze({
+      pos: this.pos,
+      token: this.currentToken,
+      hadLineTerminatorBefore: this.hadLineTerminator,
+      previousTokenType: this.previousTokenType,
+      templateDepth: this.templateDepth,
+    });
+  }
+
+  /**
+   * Restore the lexer to a previously saved state.
+   *
+   * @param state - The state snapshot to restore.
+   */
+  restoreState(state: LexerState): void {
+    this.pos = state.pos;
+    this.currentToken = state.token;
+    this.hadLineTerminator = state.hadLineTerminatorBefore;
+    this.previousTokenType = state.previousTokenType;
+    this.templateDepth = state.templateDepth;
+  }
+
+  /**
+   * The main scanning method. Skips whitespace and comments, then
+   * dispatches to the appropriate scanner based on the next character.
+   *
+   * @returns The next token in the source.
+   */
+  private scan(): Token {
+    // Skip whitespace and comments iteratively
+    const skipResult = this.skipWhitespaceAndComments();
+    this.hadLineTerminator = skipResult;
+
+    // Check for EOF
+    if (this.pos >= this.source.length) {
+      return createEofToken(this.pos);
+    }
+
+    // Handle template continuation when inside ${...}
+    // When we see a } and templateDepth > 0, we scan the rest of the template
+    const code = this.source.charCodeAt(this.pos);
+
+    // Dispatch based on the first character
+    // Identifiers and keywords: a-z, A-Z, _, $, and Unicode
+    if (isIdentifierStart(code)) {
+      return this.scanIdentifierOrKeyword();
+    }
+
+    // Numeric literals: 0-9 or . followed by digit
+    if (isDigit(code)) {
+      const result = scanNumericLiteral(this.source, this.pos, this.strict);
+      this.pos = result.end;
+      return result.token;
+    }
+
+    // String literals: ' or "
+    if (code === 0x27 || code === 0x22) {
+      const result = scanStringLiteral(this.source, this.pos, this.strict);
+      this.pos = result.end;
+      return result.token;
+    }
+
+    // Template literals: `
+    if (code === 0x60) {
+      const result = scanTemplateLiteral(this.source, this.pos, true);
+      this.pos = result.end;
+      // If we got a TemplateHead, increment template depth
+      if (result.token.type === TokenType.TemplateHead) {
+        this.templateDepth++;
+      }
+      return result.token;
+    }
+
+    // Dot followed by digit is a numeric literal (.5)
+    if (code === 0x2e) {
+      const nextCode = this.pos + 1 < this.source.length
+        ? this.source.charCodeAt(this.pos + 1)
+        : -1;
+      if (isDigit(nextCode)) {
+        const result = scanNumericLiteral(this.source, this.pos, this.strict);
+        this.pos = result.end;
+        return result.token;
+      }
+    }
+
+    // Slash: could be division, regex, or already handled as comment
+    if (code === 0x2f) {
+      // Check if this is a regex
+      if (isRegExpStart(this.previousTokenType)) {
+        const result = scanRegExpLiteral(this.source, this.pos);
+        this.pos = result.end;
+        return result.token;
+      }
+      // Otherwise fall through to punctuator scanner (handles / and /=)
+    }
+
+    // Right brace inside template: continue scanning the template
+    if (code === 0x7d && this.templateDepth > 0) {
+      this.templateDepth--;
+      const result = scanTemplateLiteral(this.source, this.pos, false);
+      this.pos = result.end;
+      // If we got a TemplateMiddle, increment depth back
+      if (result.token.type === TokenType.TemplateMiddle) {
+        this.templateDepth++;
+      }
+      return result.token;
+    }
+
+    // Punctuators and operators
+    const punctResult = scanPunctuator(this.source, this.pos);
+    if (punctResult !== null) {
+      this.pos = punctResult.end;
+      return punctResult.token;
+    }
+
+    // Unknown character
+    throw new SyntaxError(
+      `Unexpected character '${this.source[this.pos]}' at position ${this.pos}`,
+    );
+  }
+
+  /**
+   * Scan an identifier or keyword token.
+   *
+   * Reads identifier characters, then checks if the result is a keyword.
+   *
+   * @returns The identifier or keyword token.
+   */
+  private scanIdentifierOrKeyword(): Token {
+    const start = this.pos;
+    this.pos++;
+
+    while (this.pos < this.source.length) {
+      const code = this.source.charCodeAt(this.pos);
+      if (isIdentifierPart(code)) {
+        this.pos++;
+      } else {
+        break;
+      }
+    }
+
+    const raw = this.source.slice(start, this.pos);
+    const keywordInfo = lookupKeyword(raw);
+
+    if (keywordInfo !== undefined) {
+      // In strict mode, strict-reserved words use their dedicated token type
+      if (keywordInfo.isStrictReserved && this.strict) {
+        return createToken(keywordInfo.tokenType, start, this.pos, raw, raw);
+      }
+      // Reserved keywords and contextual keywords
+      if (keywordInfo.isReserved || keywordInfo.isContextual) {
+        // Special handling for literal keywords
+        if (keywordInfo.tokenType === TokenType.True) {
+          return createToken(TokenType.True, start, this.pos, true, raw);
+        }
+        if (keywordInfo.tokenType === TokenType.False) {
+          return createToken(TokenType.False, start, this.pos, false, raw);
+        }
+        if (keywordInfo.tokenType === TokenType.Null) {
+          return createToken(TokenType.Null, start, this.pos, null, raw);
+        }
+        return createToken(keywordInfo.tokenType, start, this.pos, raw, raw);
+      }
+      // Strict-reserved words in non-strict mode are identifiers
+      // (but still with their special token type when available)
+      if (keywordInfo.isStrictReserved) {
+        return createToken(keywordInfo.tokenType, start, this.pos, raw, raw);
+      }
+    }
+
+    return createToken(TokenType.Identifier, start, this.pos, raw, raw);
+  }
+
+  /**
+   * Skip whitespace and comments iteratively, tracking whether any
+   * line terminators were encountered.
+   *
+   * @returns True if a line terminator was encountered.
+   */
+  private skipWhitespaceAndComments(): boolean {
+    let hadLT = false;
+
+    while (this.pos < this.source.length) {
+      // Skip whitespace (including line terminators)
+      const wsResult = skipWhitespace(this.source, this.pos);
+      if (wsResult.hadLineTerminator) {
+        hadLT = true;
+      }
+      this.pos = wsResult.end;
+
+      // Check if at a comment
+      if (this.pos >= this.source.length) {
+        break;
+      }
+
+      const c0 = this.source.charCodeAt(this.pos);
+      if (c0 !== 0x2f) {
+        // Not a slash, done skipping
+        break;
+      }
+
+      const c1 = this.pos + 1 < this.source.length
+        ? this.source.charCodeAt(this.pos + 1)
+        : -1;
+
+      if (c1 === 0x2f) {
+        // Line comment //
+        const result = scanLineComment(this.source, this.pos);
+        this.pos = result.end;
+        // The line terminator after the comment will be caught by the next
+        // whitespace skip iteration
+        continue;
+      }
+
+      if (c1 === 0x2a) {
+        // Block comment /* */
+        const result = scanBlockComment(this.source, this.pos);
+        if (result.hadLineTerminator) {
+          hadLT = true;
+        }
+        this.pos = result.end;
+        continue;
+      }
+
+      // Just a slash, not a comment
+      break;
+    }
+
+    return hadLT;
+  }
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,0 +1,127 @@
+/**
+ * Core Parser class for the Steamroller JavaScript parser.
+ *
+ * Consumes a token stream from the Lexer and produces an ESTree-compatible
+ * AST. Currently implements Program node with module/script source type
+ * selection. Statement parsing will be expanded by subsequent issues.
+ *
+ * @module parser/parser
+ */
+
+import type * as AST from '../ast/types.js';
+import { Lexer } from './lexer.js';
+import { TokenType } from './token-types.js';
+import { tokenTypeName } from './token-types.js';
+
+/**
+ * Options for the parser.
+ */
+export interface ParseOptions {
+  /** Whether to parse as module or script. Defaults to 'module'. */
+  readonly sourceType?: 'module' | 'script';
+  /** Whether to allow a hashbang (#!) at the start of the source. */
+  readonly allowHashBang?: boolean;
+  /** The ECMAScript version to target. Defaults to 2024. */
+  readonly ecmaVersion?: number;
+}
+
+/**
+ * The core Parser class that transforms source text into an AST.
+ *
+ * Internal state fields are mutable (documented exception for parser
+ * state machine pattern).
+ */
+export class Parser {
+  /** The lexer producing the token stream. */
+  private lexer: Lexer;
+  /** Whether parsing as module or script. */
+  private sourceType: 'module' | 'script';
+
+  /**
+   * Create a new Parser for the given source text.
+   *
+   * @param source - The source text to parse.
+   * @param options - Optional parse configuration.
+   */
+  constructor(source: string, options?: ParseOptions) {
+    const sourceType = options?.sourceType ?? 'module';
+    const allowHashBang = options?.allowHashBang ?? false;
+    const isStrict = sourceType === 'module';
+
+    this.sourceType = sourceType;
+    this.lexer = new Lexer(source, isStrict, allowHashBang);
+  }
+
+  /**
+   * Parse the complete program.
+   *
+   * Iteratively parses statements and declarations until EOF is reached,
+   * producing a Program AST node.
+   *
+   * @returns The root Program AST node.
+   */
+  parseProgram(): AST.Program {
+    const start = this.lexer.token.start;
+    const body: Array<AST.Statement | AST.ModuleDeclaration> = [];
+
+    // Parse statements/declarations until EOF
+    while (!this.lexer.is(TokenType.EOF)) {
+      const stmt = this.parseStatement();
+      body.push(stmt);
+    }
+
+    const end = this.lexer.token.end;
+
+    return Object.freeze({
+      type: 'Program' as const,
+      start,
+      end,
+      body: Object.freeze(body),
+      sourceType: this.sourceType,
+    });
+  }
+
+  /**
+   * Parse a single statement or module declaration.
+   *
+   * This is a placeholder that handles only semicolons (empty statements)
+   * for now. Full statement parsing will be implemented by issues #19,
+   * #22, and #24.
+   *
+   * @returns The parsed statement or module declaration AST node.
+   * @throws {SyntaxError} For unrecognized tokens (statement parsing not
+   *   yet implemented).
+   */
+  parseStatement(): AST.Statement | AST.ModuleDeclaration {
+    const token = this.lexer.token;
+
+    // Handle empty statements (bare semicolons)
+    if (token.type === TokenType.Semicolon) {
+      this.lexer.next();
+      return Object.freeze({
+        type: 'EmptyStatement' as const,
+        start: token.start,
+        end: token.end,
+      });
+    }
+
+    const typeName = tokenTypeName(token.type);
+    throw new SyntaxError(
+      `Statement parsing not yet implemented for ${typeName} at position ${token.start}`,
+    );
+  }
+}
+
+/**
+ * Parse source text into an AST Program node.
+ *
+ * This is the primary public API for parsing JavaScript source code.
+ *
+ * @param source - The source text to parse.
+ * @param options - Optional parse configuration.
+ * @returns The root Program AST node.
+ */
+export const parse = (source: string, options?: ParseOptions): AST.Program => {
+  const parser = new Parser(source, options);
+  return parser.parseProgram();
+};

--- a/tests/unit/parser/lexer.test.ts
+++ b/tests/unit/parser/lexer.test.ts
@@ -1,0 +1,756 @@
+import { describe, it, expect } from 'vitest';
+import { Lexer } from '../../../src/parser/lexer.js';
+import { TokenType } from '../../../src/parser/token-types.js';
+
+describe('Lexer', () => {
+  describe('constructor', () => {
+    it('should produce EOF for empty source', () => {
+      const lexer = new Lexer('', false);
+      expect(lexer.token.type).toBe(TokenType.EOF);
+      expect(lexer.token.start).toBe(0);
+      expect(lexer.token.end).toBe(0);
+    });
+
+    it('should produce EOF for whitespace-only source', () => {
+      const lexer = new Lexer('   \t\n  ', false);
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should accept strict mode flag', () => {
+      const lexer = new Lexer('', true);
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should handle hashbang when allowed', () => {
+      const lexer = new Lexer('#!/usr/bin/env node\nfoo', false, true);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('foo');
+    });
+
+    it('should not skip hashbang when not allowed', () => {
+      // When allowHashBang is false, # is treated as a Hash punctuator
+      const lexer = new Lexer('#!/usr/bin/env node\nfoo', false, false);
+      expect(lexer.token.type).toBe(TokenType.Hash);
+    });
+
+    it('should handle hashbang with no subsequent code', () => {
+      const lexer = new Lexer('#!/usr/bin/env node', false, true);
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should not treat non-hashbang as hashbang even if allowed', () => {
+      const lexer = new Lexer('foo', false, true);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('foo');
+    });
+  });
+
+  describe('token getter', () => {
+    it('should return the current token', () => {
+      const lexer = new Lexer('abc', false);
+      const token = lexer.token;
+      expect(token.type).toBe(TokenType.Identifier);
+      expect(token.value).toBe('abc');
+    });
+  });
+
+  describe('hadLineTerminatorBefore getter', () => {
+    it('should be false when no line terminator preceded current token', () => {
+      const lexer = new Lexer('a b', false);
+      expect(lexer.hadLineTerminatorBefore).toBe(false);
+    });
+
+    it('should be true when line terminator preceded current token', () => {
+      const lexer = new Lexer('\na', false);
+      expect(lexer.hadLineTerminatorBefore).toBe(true);
+    });
+
+    it('should update after advancing', () => {
+      const lexer = new Lexer('a\nb', false);
+      expect(lexer.hadLineTerminatorBefore).toBe(false);
+      lexer.next();
+      expect(lexer.hadLineTerminatorBefore).toBe(true);
+    });
+  });
+
+  describe('next()', () => {
+    it('should return the previous token and advance', () => {
+      const lexer = new Lexer('a b', false);
+      const first = lexer.next();
+      expect(first.type).toBe(TokenType.Identifier);
+      expect(first.value).toBe('a');
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('b');
+    });
+
+    it('should advance to EOF', () => {
+      const lexer = new Lexer('x', false);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should return EOF when already at EOF', () => {
+      const lexer = new Lexer('', false);
+      const token = lexer.next();
+      expect(token.type).toBe(TokenType.EOF);
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+  });
+
+  describe('expect()', () => {
+    it('should consume and return the token when type matches', () => {
+      const lexer = new Lexer('abc;', false);
+      const token = lexer.expect(TokenType.Identifier);
+      expect(token.type).toBe(TokenType.Identifier);
+      expect(token.value).toBe('abc');
+      expect(lexer.token.type).toBe(TokenType.Semicolon);
+    });
+
+    it('should throw SyntaxError when type does not match', () => {
+      const lexer = new Lexer('abc', false);
+      expect(() => lexer.expect(TokenType.NumericLiteral)).toThrow(SyntaxError);
+    });
+
+    it('should include expected and actual type names in error message', () => {
+      const lexer = new Lexer('abc', false);
+      expect(() => lexer.expect(TokenType.NumericLiteral)).toThrow(
+        /Expected NumericLiteral but found Identifier/,
+      );
+    });
+
+    it('should include position in error message', () => {
+      const lexer = new Lexer('  abc', false);
+      expect(() => lexer.expect(TokenType.Semicolon)).toThrow(/position 2/);
+    });
+  });
+
+  describe('is()', () => {
+    it('should return true when current token matches', () => {
+      const lexer = new Lexer('abc', false);
+      expect(lexer.is(TokenType.Identifier)).toBe(true);
+    });
+
+    it('should return false when current token does not match', () => {
+      const lexer = new Lexer('abc', false);
+      expect(lexer.is(TokenType.NumericLiteral)).toBe(false);
+    });
+
+    it('should return true for EOF at end of source', () => {
+      const lexer = new Lexer('', false);
+      expect(lexer.is(TokenType.EOF)).toBe(true);
+    });
+  });
+
+  describe('eat()', () => {
+    it('should consume token and return true when type matches', () => {
+      const lexer = new Lexer('abc 123', false);
+      const result = lexer.eat(TokenType.Identifier);
+      expect(result).toBe(true);
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+    });
+
+    it('should not consume and return false when type does not match', () => {
+      const lexer = new Lexer('abc', false);
+      const result = lexer.eat(TokenType.NumericLiteral);
+      expect(result).toBe(false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+    });
+
+    it('should handle eating EOF', () => {
+      const lexer = new Lexer('', false);
+      const result = lexer.eat(TokenType.EOF);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('saveState() and restoreState()', () => {
+    it('should save and restore lexer position', () => {
+      const lexer = new Lexer('a b c', false);
+      const state = lexer.saveState();
+
+      lexer.next(); // advance to 'b'
+      lexer.next(); // advance to 'c'
+      expect(lexer.token.value).toBe('c');
+
+      lexer.restoreState(state);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('a');
+    });
+
+    it('should restore hadLineTerminatorBefore', () => {
+      const lexer = new Lexer('a\nb', false);
+      const state = lexer.saveState();
+      expect(lexer.hadLineTerminatorBefore).toBe(false);
+
+      lexer.next(); // advance past newline to 'b'
+      expect(lexer.hadLineTerminatorBefore).toBe(true);
+
+      lexer.restoreState(state);
+      expect(lexer.hadLineTerminatorBefore).toBe(false);
+    });
+
+    it('should return a frozen state object', () => {
+      const lexer = new Lexer('a', false);
+      const state = lexer.saveState();
+      expect(Object.isFrozen(state)).toBe(true);
+    });
+
+    it('should restore template depth', () => {
+      const lexer = new Lexer('`a${b}c`', false);
+      // token is TemplateHead `a${
+      expect(lexer.token.type).toBe(TokenType.TemplateHead);
+
+      const state = lexer.saveState();
+      lexer.next(); // identifier b
+      lexer.next(); // TemplateTail }c`
+      expect(lexer.token.type).toBe(TokenType.TemplateTail);
+
+      lexer.restoreState(state);
+      expect(lexer.token.type).toBe(TokenType.TemplateHead);
+    });
+  });
+
+  describe('scanning identifiers', () => {
+    it('should scan simple identifiers', () => {
+      const lexer = new Lexer('foo', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('foo');
+      expect(lexer.token.raw).toBe('foo');
+      expect(lexer.token.start).toBe(0);
+      expect(lexer.token.end).toBe(3);
+    });
+
+    it('should scan identifiers with underscores', () => {
+      const lexer = new Lexer('_private', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('_private');
+    });
+
+    it('should scan identifiers with dollar signs', () => {
+      const lexer = new Lexer('$element', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('$element');
+    });
+
+    it('should scan identifiers with digits', () => {
+      const lexer = new Lexer('abc123', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('abc123');
+    });
+
+    it('should scan single-character identifiers', () => {
+      const lexer = new Lexer('x', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('x');
+    });
+
+    it('should scan multiple identifiers', () => {
+      const lexer = new Lexer('a b c', false);
+      expect(lexer.token.value).toBe('a');
+      lexer.next();
+      expect(lexer.token.value).toBe('b');
+      lexer.next();
+      expect(lexer.token.value).toBe('c');
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+  });
+
+  describe('scanning keywords', () => {
+    it('should scan reserved keywords', () => {
+      const lexer = new Lexer('return', false);
+      expect(lexer.token.type).toBe(TokenType.Return);
+      expect(lexer.token.value).toBe('return');
+    });
+
+    it('should scan if keyword', () => {
+      const lexer = new Lexer('if', false);
+      expect(lexer.token.type).toBe(TokenType.If);
+    });
+
+    it('should scan function keyword', () => {
+      const lexer = new Lexer('function', false);
+      expect(lexer.token.type).toBe(TokenType.Function);
+    });
+
+    it('should scan class keyword', () => {
+      const lexer = new Lexer('class', false);
+      expect(lexer.token.type).toBe(TokenType.Class);
+    });
+
+    it('should scan const keyword', () => {
+      const lexer = new Lexer('const', false);
+      expect(lexer.token.type).toBe(TokenType.Const);
+    });
+
+    it('should scan contextual keywords', () => {
+      const lexer = new Lexer('async', false);
+      expect(lexer.token.type).toBe(TokenType.Async);
+    });
+
+    it('should scan true as boolean literal', () => {
+      const lexer = new Lexer('true', false);
+      expect(lexer.token.type).toBe(TokenType.True);
+      expect(lexer.token.value).toBe(true);
+    });
+
+    it('should scan false as boolean literal', () => {
+      const lexer = new Lexer('false', false);
+      expect(lexer.token.type).toBe(TokenType.False);
+      expect(lexer.token.value).toBe(false);
+    });
+
+    it('should scan null as null literal', () => {
+      const lexer = new Lexer('null', false);
+      expect(lexer.token.type).toBe(TokenType.Null);
+      expect(lexer.token.value).toBe(null);
+    });
+
+    it('should scan strict-reserved words in strict mode', () => {
+      const lexer = new Lexer('yield', true);
+      expect(lexer.token.type).toBe(TokenType.Yield);
+    });
+
+    it('should scan strict-reserved words in non-strict mode', () => {
+      const lexer = new Lexer('yield', false);
+      // Still gets its token type in non-strict mode
+      expect(lexer.token.type).toBe(TokenType.Yield);
+    });
+
+    it('should scan let in strict mode', () => {
+      const lexer = new Lexer('let', true);
+      expect(lexer.token.type).toBe(TokenType.Let);
+    });
+
+    it('should scan static in strict mode', () => {
+      const lexer = new Lexer('static', true);
+      expect(lexer.token.type).toBe(TokenType.Static);
+    });
+
+    it('should scan strict-only reserved words that map to Identifier type in non-strict', () => {
+      // 'implements' maps to Identifier token type (not a dedicated type)
+      const lexer = new Lexer('implements', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+    });
+
+    it('should scan strict-only reserved words that map to Identifier type in strict', () => {
+      const lexer = new Lexer('implements', true);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+    });
+
+    it('should scan multiple keywords and identifiers', () => {
+      const lexer = new Lexer('if foo else bar', false);
+      expect(lexer.token.type).toBe(TokenType.If);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('foo');
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Else);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('bar');
+    });
+  });
+
+  describe('scanning numbers', () => {
+    it('should scan integer literals', () => {
+      const lexer = new Lexer('42', false);
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+      expect(lexer.token.value).toBe(42);
+    });
+
+    it('should scan decimal literals', () => {
+      const lexer = new Lexer('3.14', false);
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+      expect(lexer.token.value).toBe(3.14);
+    });
+
+    it('should scan dot-prefixed decimals', () => {
+      const lexer = new Lexer('.5', false);
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+      expect(lexer.token.value).toBe(0.5);
+    });
+
+    it('should scan hex literals', () => {
+      const lexer = new Lexer('0xff', false);
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+      expect(lexer.token.value).toBe(255);
+    });
+
+    it('should scan bigint literals', () => {
+      const lexer = new Lexer('123n', false);
+      expect(lexer.token.type).toBe(TokenType.BigIntLiteral);
+      expect(lexer.token.value).toBe(BigInt(123));
+    });
+  });
+
+  describe('scanning strings', () => {
+    it('should scan single-quoted strings', () => {
+      const lexer = new Lexer("'hello'", false);
+      expect(lexer.token.type).toBe(TokenType.StringLiteral);
+      expect(lexer.token.value).toBe('hello');
+    });
+
+    it('should scan double-quoted strings', () => {
+      const lexer = new Lexer('"world"', false);
+      expect(lexer.token.type).toBe(TokenType.StringLiteral);
+      expect(lexer.token.value).toBe('world');
+    });
+
+    it('should scan strings with escapes', () => {
+      const lexer = new Lexer('"a\\nb"', false);
+      expect(lexer.token.type).toBe(TokenType.StringLiteral);
+      expect(lexer.token.value).toBe('a\nb');
+    });
+
+    it('should scan empty strings', () => {
+      const lexer = new Lexer('""', false);
+      expect(lexer.token.type).toBe(TokenType.StringLiteral);
+      expect(lexer.token.value).toBe('');
+    });
+  });
+
+  describe('scanning template literals', () => {
+    it('should scan simple template literal (no substitutions)', () => {
+      const lexer = new Lexer('`hello`', false);
+      expect(lexer.token.type).toBe(TokenType.TemplateNoSub);
+      expect(lexer.token.value).toBe('hello');
+    });
+
+    it('should scan template with substitution', () => {
+      const lexer = new Lexer('`a${b}c`', false);
+      expect(lexer.token.type).toBe(TokenType.TemplateHead);
+      expect(lexer.token.value).toBe('a');
+
+      lexer.next(); // identifier b
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('b');
+
+      lexer.next(); // template tail }c`
+      expect(lexer.token.type).toBe(TokenType.TemplateTail);
+      expect(lexer.token.value).toBe('c');
+    });
+
+    it('should scan template with multiple substitutions', () => {
+      const lexer = new Lexer('`${a}${b}`', false);
+      expect(lexer.token.type).toBe(TokenType.TemplateHead);
+      lexer.next(); // a
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      lexer.next(); // middle
+      expect(lexer.token.type).toBe(TokenType.TemplateMiddle);
+      lexer.next(); // b
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      lexer.next(); // tail
+      expect(lexer.token.type).toBe(TokenType.TemplateTail);
+    });
+
+    it('should scan empty template literal', () => {
+      const lexer = new Lexer('``', false);
+      expect(lexer.token.type).toBe(TokenType.TemplateNoSub);
+      expect(lexer.token.value).toBe('');
+    });
+  });
+
+  describe('scanning operators and punctuators', () => {
+    it('should scan semicolons', () => {
+      const lexer = new Lexer(';', false);
+      expect(lexer.token.type).toBe(TokenType.Semicolon);
+    });
+
+    it('should scan braces', () => {
+      const lexer = new Lexer('{}', false);
+      expect(lexer.token.type).toBe(TokenType.LeftBrace);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.RightBrace);
+    });
+
+    it('should scan parentheses', () => {
+      const lexer = new Lexer('()', false);
+      expect(lexer.token.type).toBe(TokenType.LeftParen);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.RightParen);
+    });
+
+    it('should scan arrow', () => {
+      const lexer = new Lexer('=>', false);
+      expect(lexer.token.type).toBe(TokenType.Arrow);
+    });
+
+    it('should scan comparison operators', () => {
+      const lexer = new Lexer('===', false);
+      expect(lexer.token.type).toBe(TokenType.EqualsEqualsEquals);
+    });
+
+    it('should scan assignment operators', () => {
+      const lexer = new Lexer('+=', false);
+      expect(lexer.token.type).toBe(TokenType.PlusEquals);
+    });
+
+    it('should scan dot (not followed by digit)', () => {
+      const lexer = new Lexer('.x', false);
+      expect(lexer.token.type).toBe(TokenType.Dot);
+    });
+
+    it('should scan ellipsis', () => {
+      const lexer = new Lexer('...', false);
+      expect(lexer.token.type).toBe(TokenType.Ellipsis);
+    });
+  });
+
+  describe('scanning regex literals', () => {
+    it('should scan regex at start of input', () => {
+      const lexer = new Lexer('/abc/g', false);
+      expect(lexer.token.type).toBe(TokenType.RegExpLiteral);
+    });
+
+    it('should scan regex after operator', () => {
+      const lexer = new Lexer('= /abc/g', false);
+      lexer.next(); // advance past =
+      expect(lexer.token.type).toBe(TokenType.RegExpLiteral);
+    });
+
+    it('should scan division after identifier', () => {
+      const lexer = new Lexer('a / b', false);
+      lexer.next(); // advance past identifier
+      expect(lexer.token.type).toBe(TokenType.Slash);
+    });
+
+    it('should scan /= after identifier as SlashEquals', () => {
+      const lexer = new Lexer('a /= b', false);
+      lexer.next(); // advance past identifier
+      expect(lexer.token.type).toBe(TokenType.SlashEquals);
+    });
+  });
+
+  describe('skipping whitespace and comments', () => {
+    it('should skip single spaces', () => {
+      const lexer = new Lexer('a b', false);
+      expect(lexer.token.value).toBe('a');
+      lexer.next();
+      expect(lexer.token.value).toBe('b');
+    });
+
+    it('should skip tabs', () => {
+      const lexer = new Lexer('a\tb', false);
+      expect(lexer.token.value).toBe('a');
+      lexer.next();
+      expect(lexer.token.value).toBe('b');
+    });
+
+    it('should skip newlines', () => {
+      const lexer = new Lexer('a\nb', false);
+      expect(lexer.token.value).toBe('a');
+      lexer.next();
+      expect(lexer.token.value).toBe('b');
+    });
+
+    it('should skip line comments', () => {
+      const lexer = new Lexer('a // comment\nb', false);
+      expect(lexer.token.value).toBe('a');
+      lexer.next();
+      expect(lexer.token.value).toBe('b');
+    });
+
+    it('should skip block comments', () => {
+      const lexer = new Lexer('a /* comment */ b', false);
+      expect(lexer.token.value).toBe('a');
+      lexer.next();
+      expect(lexer.token.value).toBe('b');
+    });
+
+    it('should track line terminators through block comments', () => {
+      const lexer = new Lexer('a /*\n*/ b', false);
+      lexer.next();
+      expect(lexer.hadLineTerminatorBefore).toBe(true);
+    });
+
+    it('should not track line terminators through single-line block comments', () => {
+      const lexer = new Lexer('a /* inline */ b', false);
+      lexer.next();
+      expect(lexer.hadLineTerminatorBefore).toBe(false);
+    });
+
+    it('should skip multiple consecutive comments', () => {
+      const lexer = new Lexer('// first\n// second\na', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('a');
+    });
+
+    it('should skip comment-only source to EOF', () => {
+      const lexer = new Lexer('// just a comment', false);
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should handle block comment followed by line comment', () => {
+      const lexer = new Lexer('/* block */ // line\na', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('a');
+    });
+  });
+
+  describe('line terminator tracking', () => {
+    it('should track LF', () => {
+      const lexer = new Lexer('a\nb', false);
+      lexer.next();
+      expect(lexer.hadLineTerminatorBefore).toBe(true);
+    });
+
+    it('should track CR', () => {
+      const lexer = new Lexer('a\rb', false);
+      lexer.next();
+      expect(lexer.hadLineTerminatorBefore).toBe(true);
+    });
+
+    it('should track CRLF', () => {
+      const lexer = new Lexer('a\r\nb', false);
+      lexer.next();
+      expect(lexer.hadLineTerminatorBefore).toBe(true);
+    });
+
+    it('should not have line terminator for same-line tokens', () => {
+      const lexer = new Lexer('a b', false);
+      lexer.next();
+      expect(lexer.hadLineTerminatorBefore).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw on unexpected characters', () => {
+      // Unicode characters that are not valid identifier starts or punctuators
+      // Use a character that the lexer genuinely cannot handle
+      expect(() => new Lexer('\x00', false)).toThrow(SyntaxError);
+    });
+
+    it('should throw on unterminated string', () => {
+      expect(() => new Lexer('"unclosed', false)).toThrow(SyntaxError);
+    });
+
+    it('should throw on unterminated template', () => {
+      expect(() => new Lexer('`unclosed', false)).toThrow(SyntaxError);
+    });
+
+    it('should throw on unterminated block comment', () => {
+      expect(() => new Lexer('/* unclosed', false)).toThrow();
+    });
+
+    it('should throw on legacy octal in strict mode', () => {
+      expect(() => new Lexer('077', true)).toThrow(SyntaxError);
+    });
+  });
+
+  describe('complex token sequences', () => {
+    it('should tokenize a simple expression', () => {
+      const lexer = new Lexer('a + b', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('a');
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Plus);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('b');
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should tokenize a function call', () => {
+      const lexer = new Lexer('foo(1, 2)', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.LeftParen);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+      expect(lexer.token.value).toBe(1);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Comma);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+      expect(lexer.token.value).toBe(2);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.RightParen);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should tokenize variable declaration with string', () => {
+      const lexer = new Lexer("const x = 'hello';", false);
+      expect(lexer.token.type).toBe(TokenType.Const);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('x');
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Equals);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.StringLiteral);
+      expect(lexer.token.value).toBe('hello');
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Semicolon);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it('should tokenize arrow function', () => {
+      const lexer = new Lexer('(x) => x', false);
+      expect(lexer.token.type).toBe(TokenType.LeftParen);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.RightParen);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Arrow);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+    });
+
+    it('should tokenize object literal', () => {
+      const lexer = new Lexer('{ a: 1 }', false);
+      expect(lexer.token.type).toBe(TokenType.LeftBrace);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.Colon);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.NumericLiteral);
+      lexer.next();
+      expect(lexer.token.type).toBe(TokenType.RightBrace);
+    });
+  });
+
+  describe('Unicode identifiers', () => {
+    it('should scan identifiers starting with Unicode letters', () => {
+      const lexer = new Lexer('\u00e9value', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('\u00e9value');
+    });
+
+    it('should scan identifiers with zero-width joiner', () => {
+      const lexer = new Lexer('a\u200db', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('a\u200db');
+    });
+
+    it('should scan identifiers with zero-width non-joiner', () => {
+      const lexer = new Lexer('a\u200cb', false);
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+      expect(lexer.token.value).toBe('a\u200cb');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle dot at end of source', () => {
+      const lexer = new Lexer('.', false);
+      expect(lexer.token.type).toBe(TokenType.Dot);
+    });
+
+    it('should handle slash at end of source as regex start', () => {
+      // At start of input, / is regex start, but /EOF is invalid regex
+      expect(() => new Lexer('/', false)).toThrow();
+    });
+
+    it('should handle slash at end of source after identifier', () => {
+      // After an identifier, / is division
+      const lexer = new Lexer('a /', false);
+      lexer.next(); // consume 'a'
+      expect(lexer.token.type).toBe(TokenType.Slash);
+    });
+  });
+});

--- a/tests/unit/parser/parser.test.ts
+++ b/tests/unit/parser/parser.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { Parser, parse } from '../../../src/parser/parser.js';
+import type { ParseOptions } from '../../../src/parser/parser.js';
+
+describe('Parser', () => {
+  describe('constructor', () => {
+    it('should create a parser with default options', () => {
+      const parser = new Parser('');
+      expect(parser).toBeInstanceOf(Parser);
+    });
+
+    it('should create a parser with module sourceType', () => {
+      const parser = new Parser('', { sourceType: 'module' });
+      expect(parser).toBeInstanceOf(Parser);
+    });
+
+    it('should create a parser with script sourceType', () => {
+      const parser = new Parser('', { sourceType: 'script' });
+      expect(parser).toBeInstanceOf(Parser);
+    });
+
+    it('should create a parser with allowHashBang option', () => {
+      const parser = new Parser('#!/usr/bin/env node\n', {
+        allowHashBang: true,
+      });
+      expect(parser).toBeInstanceOf(Parser);
+    });
+
+    it('should create a parser with ecmaVersion option', () => {
+      const parser = new Parser('', { ecmaVersion: 2024 });
+      expect(parser).toBeInstanceOf(Parser);
+    });
+
+    it('should accept undefined options', () => {
+      const parser = new Parser('', undefined);
+      expect(parser).toBeInstanceOf(Parser);
+    });
+  });
+
+  describe('parseProgram()', () => {
+    it('should return a Program node for empty source', () => {
+      const parser = new Parser('');
+      const program = parser.parseProgram();
+      expect(program.type).toBe('Program');
+      expect(program.body).toEqual([]);
+      expect(program.sourceType).toBe('module');
+      expect(program.start).toBe(0);
+      expect(program.end).toBe(0);
+    });
+
+    it('should return module sourceType by default', () => {
+      const parser = new Parser('');
+      const program = parser.parseProgram();
+      expect(program.sourceType).toBe('module');
+    });
+
+    it('should return script sourceType when specified', () => {
+      const parser = new Parser('', { sourceType: 'script' });
+      const program = parser.parseProgram();
+      expect(program.sourceType).toBe('script');
+    });
+
+    it('should return a frozen Program node', () => {
+      const parser = new Parser('');
+      const program = parser.parseProgram();
+      expect(Object.isFrozen(program)).toBe(true);
+    });
+
+    it('should return a frozen body array', () => {
+      const parser = new Parser('');
+      const program = parser.parseProgram();
+      expect(Object.isFrozen(program.body)).toBe(true);
+    });
+
+    it('should parse empty statements (semicolons)', () => {
+      const parser = new Parser(';');
+      const program = parser.parseProgram();
+      expect(program.body.length).toBe(1);
+      expect(program.body[0].type).toBe('EmptyStatement');
+    });
+
+    it('should parse multiple empty statements', () => {
+      const parser = new Parser(';;;');
+      const program = parser.parseProgram();
+      expect(program.body.length).toBe(3);
+      expect(program.body[0].type).toBe('EmptyStatement');
+      expect(program.body[1].type).toBe('EmptyStatement');
+      expect(program.body[2].type).toBe('EmptyStatement');
+    });
+
+    it('should set correct positions for empty statements', () => {
+      const parser = new Parser(';');
+      const program = parser.parseProgram();
+      expect(program.body[0].start).toBe(0);
+      expect(program.body[0].end).toBe(1);
+    });
+
+    it('should set correct end position for program with content', () => {
+      const parser = new Parser('  ;  ');
+      const program = parser.parseProgram();
+      expect(program.end).toBe(5);
+    });
+
+    it('should handle whitespace-only source', () => {
+      const parser = new Parser('   \n\t  ');
+      const program = parser.parseProgram();
+      expect(program.body).toEqual([]);
+      expect(program.type).toBe('Program');
+    });
+
+    it('should handle comment-only source', () => {
+      const parser = new Parser('// just a comment');
+      const program = parser.parseProgram();
+      expect(program.body).toEqual([]);
+    });
+
+    it('should handle hashbang source when allowed', () => {
+      const parser = new Parser('#!/usr/bin/env node\n;', {
+        allowHashBang: true,
+      });
+      const program = parser.parseProgram();
+      expect(program.body.length).toBe(1);
+      expect(program.body[0].type).toBe('EmptyStatement');
+    });
+
+    it('should throw for unimplemented statement types', () => {
+      const parser = new Parser('foo');
+      expect(() => parser.parseProgram()).toThrow(SyntaxError);
+    });
+
+    it('should include token type name in error for unimplemented statements', () => {
+      const parser = new Parser('foo');
+      expect(() => parser.parseProgram()).toThrow(/Identifier/);
+    });
+
+    it('should include position in error for unimplemented statements', () => {
+      const parser = new Parser('  foo');
+      expect(() => parser.parseProgram()).toThrow(/position 2/);
+    });
+  });
+});
+
+describe('parse() function', () => {
+  it('should parse empty source to Program', () => {
+    const program = parse('');
+    expect(program.type).toBe('Program');
+    expect(program.body).toEqual([]);
+    expect(program.sourceType).toBe('module');
+  });
+
+  it('should accept options', () => {
+    const program = parse('', { sourceType: 'script' });
+    expect(program.sourceType).toBe('script');
+  });
+
+  it('should default to module sourceType', () => {
+    const program = parse('');
+    expect(program.sourceType).toBe('module');
+  });
+
+  it('should parse semicolons as empty statements', () => {
+    const program = parse(';');
+    expect(program.body.length).toBe(1);
+    expect(program.body[0].type).toBe('EmptyStatement');
+  });
+
+  it('should throw on unimplemented statements', () => {
+    expect(() => parse('x')).toThrow(SyntaxError);
+  });
+
+  it('should accept allowHashBang option', () => {
+    const program = parse('#!/usr/bin/env node\n', { allowHashBang: true });
+    expect(program.body).toEqual([]);
+  });
+
+  it('should handle ParseOptions interface types correctly', () => {
+    const opts: ParseOptions = {
+      sourceType: 'module',
+      allowHashBang: false,
+      ecmaVersion: 2024,
+    };
+    const program = parse('', opts);
+    expect(program.type).toBe('Program');
+  });
+
+  it('should handle undefined options', () => {
+    const program = parse('', undefined);
+    expect(program.type).toBe('Program');
+    expect(program.sourceType).toBe('module');
+  });
+
+  it('should handle empty options object', () => {
+    const program = parse('', {});
+    expect(program.type).toBe('Program');
+    expect(program.sourceType).toBe('module');
+  });
+});


### PR DESCRIPTION
## Summary

- Implements core `Lexer` class (`src/parser/lexer.ts`) that orchestrates all existing scanning modules (numeric, string, regex, punctuator, whitespace) into a unified token stream with identifier/keyword scanning, comment skipping, template literal depth tracking, regex disambiguation, and save/restore state for lookahead
- Implements `Parser` class and `parse()` public API (`src/parser/parser.ts`) with Program node production, module/script source type selection, hashbang support, and empty statement parsing (full statement parsing deferred to #19, #22, #24)
- 135 new tests across `tests/unit/parser/lexer.test.ts` (105 tests) and `tests/unit/parser/parser.test.ts` (30 tests) covering happy and sad paths with >=98% coverage on both new files

Closes #52

## Test plan

- [x] All 1808 tests pass (including 135 new)
- [x] `lexer.ts` coverage: 98.4% statements, 98.18% branches, 100% functions, 98.4% lines
- [x] `parser.ts` coverage: 100% across all metrics
- [x] No new TypeScript compilation errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)