### PR TITLE
feat: implement parser declaration types

### DIFF
--- a/src/parser/declarations.ts
+++ b/src/parser/declarations.ts
@@ -1,0 +1,1071 @@
+/**
+ * Parser module for declaration statements.
+ *
+ * Handles parsing of function declarations, class declarations,
+ * import declarations, and export declarations into ESTree-compatible
+ * AST nodes.
+ *
+ * @module parser/declarations
+ */
+
+import type * as AST from '../ast/types.js';
+import type { Lexer } from './lexer.js';
+import { TokenType } from './token-types.js';
+
+/**
+ * Extended ImportDeclaration that supports import attributes.
+ * ESTree hasn't standardized this yet, so we extend the base type.
+ */
+export interface ImportAttribute {
+  readonly type: 'ImportAttribute';
+  readonly key: AST.Identifier | AST.Literal;
+  readonly value: AST.Literal;
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * ImportDeclaration with optional attributes for `import ... with { ... }`.
+ */
+export interface ImportDeclarationWithAttributes extends AST.ImportDeclaration {
+  readonly attributes: ReadonlyArray<ImportAttribute>;
+}
+
+/**
+ * Parser context providing access to the lexer and sub-parsers.
+ *
+ * This interface decouples the declarations parser from the full Parser class,
+ * enabling testability and avoiding circular dependencies.
+ */
+export interface ParserContext {
+  readonly lexer: Lexer;
+  readonly sourceType: 'module' | 'script';
+  parseExpression(): AST.Expression;
+  parseStatement(): AST.Statement | AST.ModuleDeclaration;
+  parseBlockStatement(): AST.BlockStatement;
+}
+
+/**
+ * Parse a function declaration.
+ *
+ * Handles: function name(params) { body }
+ *          function* name(params) { body }
+ *          async function name(params) { body }
+ *          async function* name(params) { body }
+ *
+ * @param ctx - The parser context.
+ * @param isAsync - Whether the function is async.
+ * @returns The FunctionDeclaration AST node.
+ */
+export const parseFunctionDeclaration = (
+  ctx: ParserContext,
+  isAsync: boolean = false,
+): AST.FunctionDeclaration => {
+  const start = isAsync
+    ? ctx.lexer.token.start - 6 // 'async ' length approximation; we use saved start
+    : ctx.lexer.token.start;
+
+  // Consume 'function' keyword
+  ctx.lexer.expect(TokenType.Function);
+
+  // Check for generator
+  let generator = false;
+  if (ctx.lexer.is(TokenType.Star)) {
+    generator = true;
+    ctx.lexer.next();
+  }
+
+  // Parse function name (required for declarations, optional for export default)
+  let id: AST.Identifier | null = null;
+  if (ctx.lexer.is(TokenType.Identifier)) {
+    const nameToken = ctx.lexer.next();
+    id = Object.freeze({
+      type: 'Identifier' as const,
+      name: nameToken.value as string,
+      start: nameToken.start,
+      end: nameToken.end,
+    });
+  }
+
+  // Parse parameters
+  const params = parseParameters(ctx);
+
+  // Parse body
+  const body = ctx.parseBlockStatement();
+
+  return Object.freeze({
+    type: 'FunctionDeclaration' as const,
+    id,
+    params: Object.freeze(params),
+    body,
+    generator,
+    async: isAsync,
+    start,
+    end: body.end,
+  });
+};
+
+/**
+ * Parse function parameters.
+ *
+ * Handles simple identifiers, rest elements (...args), and default values.
+ *
+ * @param ctx - The parser context.
+ * @returns Array of Pattern nodes.
+ */
+const parseParameters = (ctx: ParserContext): Array<AST.Pattern> => {
+  ctx.lexer.expect(TokenType.LeftParen);
+
+  const params: Array<AST.Pattern> = [];
+
+  while (!ctx.lexer.is(TokenType.RightParen) && !ctx.lexer.is(TokenType.EOF)) {
+    if (params.length > 0) {
+      ctx.lexer.expect(TokenType.Comma);
+    }
+
+    // Check for rest element
+    if (ctx.lexer.is(TokenType.Ellipsis)) {
+      const restStart = ctx.lexer.token.start;
+      ctx.lexer.next();
+      const argToken = ctx.lexer.expect(TokenType.Identifier);
+      const argument: AST.Identifier = Object.freeze({
+        type: 'Identifier' as const,
+        name: argToken.value as string,
+        start: argToken.start,
+        end: argToken.end,
+      });
+      params.push(Object.freeze({
+        type: 'RestElement' as const,
+        argument,
+        start: restStart,
+        end: argument.end,
+      }));
+      // Rest must be last parameter
+      break;
+    }
+
+    // Simple identifier
+    const paramToken = ctx.lexer.expect(TokenType.Identifier);
+    const paramId: AST.Identifier = Object.freeze({
+      type: 'Identifier' as const,
+      name: paramToken.value as string,
+      start: paramToken.start,
+      end: paramToken.end,
+    });
+
+    // Check for default value
+    if (ctx.lexer.is(TokenType.Equals)) {
+      const assignStart = paramId.start;
+      ctx.lexer.next();
+      const right = ctx.parseExpression();
+      params.push(Object.freeze({
+        type: 'AssignmentPattern' as const,
+        left: paramId,
+        right,
+        start: assignStart,
+        end: right.end,
+      }));
+    } else {
+      params.push(paramId);
+    }
+  }
+
+  ctx.lexer.expect(TokenType.RightParen);
+  return params;
+};
+
+/**
+ * Parse a class declaration.
+ *
+ * Handles: class Name { ... }
+ *          class Name extends SuperClass { ... }
+ *
+ * @param ctx - The parser context.
+ * @returns The ClassDeclaration AST node.
+ */
+export const parseClassDeclaration = (
+  ctx: ParserContext,
+): AST.ClassDeclaration => {
+  const start = ctx.lexer.token.start;
+
+  // Consume 'class' keyword
+  ctx.lexer.expect(TokenType.Class);
+
+  // Parse class name (optional for export default)
+  let id: AST.Identifier | null = null;
+  if (ctx.lexer.is(TokenType.Identifier)) {
+    const nameToken = ctx.lexer.next();
+    id = Object.freeze({
+      type: 'Identifier' as const,
+      name: nameToken.value as string,
+      start: nameToken.start,
+      end: nameToken.end,
+    });
+  }
+
+  // Parse extends clause
+  let superClass: AST.Expression | null = null;
+  if (ctx.lexer.is(TokenType.Extends)) {
+    ctx.lexer.next();
+    const superToken = ctx.lexer.expect(TokenType.Identifier);
+    superClass = Object.freeze({
+      type: 'Identifier' as const,
+      name: superToken.value as string,
+      start: superToken.start,
+      end: superToken.end,
+    });
+  }
+
+  // Parse class body
+  const body = parseClassBody(ctx);
+
+  return Object.freeze({
+    type: 'ClassDeclaration' as const,
+    id,
+    superClass,
+    body,
+    start,
+    end: body.end,
+  });
+};
+
+/**
+ * Parse a class body enclosed in braces.
+ *
+ * Handles methods, properties, static members, private fields, and static blocks.
+ *
+ * @param ctx - The parser context.
+ * @returns The ClassBody AST node.
+ */
+const parseClassBody = (
+  ctx: ParserContext,
+): AST.ClassBody => {
+  const start = ctx.lexer.token.start;
+  ctx.lexer.expect(TokenType.LeftBrace);
+
+  const members: Array<AST.MethodDefinition | AST.PropertyDefinition | AST.StaticBlock> = [];
+
+  while (!ctx.lexer.is(TokenType.RightBrace) && !ctx.lexer.is(TokenType.EOF)) {
+    // Skip semicolons in class body
+    if (ctx.lexer.is(TokenType.Semicolon)) {
+      ctx.lexer.next();
+      continue;
+    }
+
+    const member = parseClassMember(ctx);
+    members.push(member);
+  }
+
+  const endToken = ctx.lexer.expect(TokenType.RightBrace);
+
+  return Object.freeze({
+    type: 'ClassBody' as const,
+    body: Object.freeze(members),
+    start,
+    end: endToken.end,
+  });
+};
+
+/**
+ * Parse a single class member (method, property, or static block).
+ *
+ * @param ctx - The parser context.
+ * @returns A MethodDefinition, PropertyDefinition, or StaticBlock node.
+ */
+const parseClassMember = (
+  ctx: ParserContext,
+): AST.MethodDefinition | AST.PropertyDefinition | AST.StaticBlock => {
+  const memberStart = ctx.lexer.token.start;
+  let isStatic = false;
+  let kind: 'constructor' | 'method' | 'get' | 'set' = 'method';
+
+  // Check for static keyword
+  if (ctx.lexer.is(TokenType.Static)) {
+    const staticToken = ctx.lexer.next();
+
+    // Static block: static { ... }
+    if (ctx.lexer.is(TokenType.LeftBrace)) {
+      return parseStaticBlock(ctx, staticToken.start);
+    }
+
+    isStatic = true;
+  }
+
+  // Check for get/set
+  if (ctx.lexer.is(TokenType.Get)) {
+    const saved = ctx.lexer.saveState();
+    ctx.lexer.next();
+    // If next token is ( then 'get' is the method name, not a getter prefix
+    if (!ctx.lexer.is(TokenType.LeftParen) && !ctx.lexer.is(TokenType.Equals) &&
+        !ctx.lexer.is(TokenType.Semicolon)) {
+      kind = 'get';
+    } else {
+      ctx.lexer.restoreState(saved);
+    }
+  } else if (ctx.lexer.is(TokenType.Set)) {
+    const saved = ctx.lexer.saveState();
+    ctx.lexer.next();
+    if (!ctx.lexer.is(TokenType.LeftParen) && !ctx.lexer.is(TokenType.Equals) &&
+        !ctx.lexer.is(TokenType.Semicolon)) {
+      kind = 'set';
+    } else {
+      ctx.lexer.restoreState(saved);
+    }
+  }
+
+  // Parse the key (identifier or private name)
+  let key: AST.Expression;
+  let computed = false;
+
+  if (ctx.lexer.is(TokenType.Hash)) {
+    // Private field/method: #name
+    const hashStart = ctx.lexer.token.start;
+    ctx.lexer.next();
+    const nameToken = ctx.lexer.expect(TokenType.Identifier);
+    key = Object.freeze({
+      type: 'Identifier' as const,
+      name: `#${nameToken.value as string}`,
+      start: hashStart,
+      end: nameToken.end,
+    });
+  } else if (ctx.lexer.is(TokenType.LeftBracket)) {
+    // Computed key: [expr]
+    computed = true;
+    ctx.lexer.next();
+    key = ctx.parseExpression();
+    ctx.lexer.expect(TokenType.RightBracket);
+  } else if (ctx.lexer.is(TokenType.Identifier) || isKeywordToken(ctx.lexer.token.type)) {
+    const keyToken = ctx.lexer.next();
+    const keyName = keyToken.value as string;
+    // Check if this is the constructor
+    if (keyName === 'constructor' && !isStatic) {
+      kind = 'constructor';
+    }
+    key = Object.freeze({
+      type: 'Identifier' as const,
+      name: keyName,
+      start: keyToken.start,
+      end: keyToken.end,
+    });
+  } else if (ctx.lexer.is(TokenType.NumericLiteral) || ctx.lexer.is(TokenType.StringLiteral)) {
+    const litToken = ctx.lexer.next();
+    key = Object.freeze({
+      type: 'Literal' as const,
+      value: litToken.value as string | number,
+      raw: litToken.raw,
+      start: litToken.start,
+      end: litToken.end,
+    });
+  } else {
+    throw new SyntaxError(
+      `Unexpected token in class member at position ${ctx.lexer.token.start}`,
+    );
+  }
+
+  // Determine if this is a method or property
+  if (ctx.lexer.is(TokenType.LeftParen)) {
+    // Method definition
+    const params = parseParameters(ctx);
+    const body = ctx.parseBlockStatement();
+
+    const value: AST.FunctionExpression = Object.freeze({
+      type: 'FunctionExpression' as const,
+      id: null,
+      params: Object.freeze(params),
+      body,
+      generator: false,
+      async: false,
+      start: params.length > 0 ? (params[0] as AST.BaseNode).start : body.start,
+      end: body.end,
+    });
+
+    return Object.freeze({
+      type: 'MethodDefinition' as const,
+      key,
+      value,
+      kind,
+      computed,
+      static: isStatic,
+      start: memberStart,
+      end: body.end,
+    });
+  }
+
+  // Property definition
+  let propValue: AST.Expression | null = null;
+  if (ctx.lexer.is(TokenType.Equals)) {
+    ctx.lexer.next();
+    propValue = ctx.parseExpression();
+  }
+
+  const propEnd = propValue ? propValue.end : key.end;
+
+  // Consume optional semicolon
+  if (ctx.lexer.is(TokenType.Semicolon)) {
+    ctx.lexer.next();
+  }
+
+  return Object.freeze({
+    type: 'PropertyDefinition' as const,
+    key,
+    value: propValue,
+    computed,
+    static: isStatic,
+    start: memberStart,
+    end: propEnd,
+  });
+};
+
+/**
+ * Parse a static initialization block.
+ *
+ * @param ctx - The parser context.
+ * @param start - The start position of the 'static' keyword.
+ * @returns The StaticBlock AST node.
+ */
+const parseStaticBlock = (
+  ctx: ParserContext,
+  start: number,
+): AST.StaticBlock => {
+  const block = ctx.parseBlockStatement();
+  return Object.freeze({
+    type: 'StaticBlock' as const,
+    body: block.body as unknown as ReadonlyArray<AST.Statement>,
+    start,
+    end: block.end,
+  });
+};
+
+/**
+ * Parse an import declaration.
+ *
+ * Handles: import name from 'module'
+ *          import { a, b as c } from 'module'
+ *          import * as ns from 'module'
+ *          import 'module'
+ *          import name, { a } from 'module'
+ *          import x from 'y' with { type: 'json' }
+ *
+ * @param ctx - The parser context.
+ * @returns The ImportDeclaration AST node.
+ */
+export const parseImportDeclaration = (
+  ctx: ParserContext,
+): ImportDeclarationWithAttributes => {
+  const start = ctx.lexer.token.start;
+  ctx.lexer.expect(TokenType.Import);
+
+  const specifiers: Array<
+    AST.ImportSpecifier | AST.ImportDefaultSpecifier | AST.ImportNamespaceSpecifier
+  > = [];
+
+  // Side-effect import: import 'module'
+  if (ctx.lexer.is(TokenType.StringLiteral)) {
+    const sourceToken = ctx.lexer.next();
+    const source = createLiteralFromToken(sourceToken);
+    const attributes = parseImportAttributes(ctx);
+    consumeSemicolon(ctx);
+    return Object.freeze({
+      type: 'ImportDeclaration' as const,
+      specifiers: Object.freeze(specifiers),
+      source,
+      attributes: Object.freeze(attributes),
+      start,
+      end: sourceToken.end,
+    });
+  }
+
+  // Check for namespace import: import * as ns from 'module'
+  if (ctx.lexer.is(TokenType.Star)) {
+    ctx.lexer.next();
+    ctx.lexer.expect(TokenType.As);
+    const localToken = ctx.lexer.expect(TokenType.Identifier);
+    const local: AST.Identifier = Object.freeze({
+      type: 'Identifier' as const,
+      name: localToken.value as string,
+      start: localToken.start,
+      end: localToken.end,
+    });
+    specifiers.push(Object.freeze({
+      type: 'ImportNamespaceSpecifier' as const,
+      local,
+      start: local.start,
+      end: local.end,
+    }));
+  } else if (ctx.lexer.is(TokenType.LeftBrace)) {
+    // Named imports: import { a, b as c } from 'module'
+    parseNamedImports(ctx, specifiers);
+  } else if (ctx.lexer.is(TokenType.Identifier)) {
+    // Default import: import name from 'module'
+    const defaultToken = ctx.lexer.next();
+    const local: AST.Identifier = Object.freeze({
+      type: 'Identifier' as const,
+      name: defaultToken.value as string,
+      start: defaultToken.start,
+      end: defaultToken.end,
+    });
+    specifiers.push(Object.freeze({
+      type: 'ImportDefaultSpecifier' as const,
+      local,
+      start: local.start,
+      end: local.end,
+    }));
+
+    // Combined: import name, { a } from 'module' OR import name, * as ns from 'module'
+    if (ctx.lexer.is(TokenType.Comma)) {
+      ctx.lexer.next();
+      if (ctx.lexer.is(TokenType.LeftBrace)) {
+        parseNamedImports(ctx, specifiers);
+      } else if (ctx.lexer.is(TokenType.Star)) {
+        ctx.lexer.next();
+        ctx.lexer.expect(TokenType.As);
+        const nsToken = ctx.lexer.expect(TokenType.Identifier);
+        const nsLocal: AST.Identifier = Object.freeze({
+          type: 'Identifier' as const,
+          name: nsToken.value as string,
+          start: nsToken.start,
+          end: nsToken.end,
+        });
+        specifiers.push(Object.freeze({
+          type: 'ImportNamespaceSpecifier' as const,
+          local: nsLocal,
+          start: nsLocal.start,
+          end: nsLocal.end,
+        }));
+      }
+    }
+  }
+
+  // Expect 'from' keyword
+  ctx.lexer.expect(TokenType.From);
+
+  // Parse module source
+  if (!ctx.lexer.is(TokenType.StringLiteral)) {
+    throw new SyntaxError(
+      `Expected module source string at position ${ctx.lexer.token.start}`,
+    );
+  }
+  const sourceToken = ctx.lexer.next();
+  const source = createLiteralFromToken(sourceToken);
+
+  // Parse import attributes
+  const attributes = parseImportAttributes(ctx);
+
+  consumeSemicolon(ctx);
+
+  return Object.freeze({
+    type: 'ImportDeclaration' as const,
+    specifiers: Object.freeze(specifiers),
+    source,
+    attributes: Object.freeze(attributes),
+    start,
+    end: sourceToken.end,
+  });
+};
+
+/**
+ * Parse named import specifiers: { a, b as c }
+ *
+ * @param ctx - The parser context.
+ * @param specifiers - Array to push specifiers into.
+ */
+const parseNamedImports = (
+  ctx: ParserContext,
+  specifiers: Array<AST.ImportSpecifier | AST.ImportDefaultSpecifier | AST.ImportNamespaceSpecifier>,
+): void => {
+  ctx.lexer.expect(TokenType.LeftBrace);
+
+  while (!ctx.lexer.is(TokenType.RightBrace) && !ctx.lexer.is(TokenType.EOF)) {
+    if (specifiers.length > 0 && specifiers[specifiers.length - 1].type === 'ImportSpecifier') {
+      // Only expect comma between named specifiers
+    }
+
+    const importedToken = ctx.lexer.token;
+    if (!ctx.lexer.is(TokenType.Identifier) && !isKeywordToken(importedToken.type)) {
+      break;
+    }
+    ctx.lexer.next();
+
+    const imported: AST.Identifier = Object.freeze({
+      type: 'Identifier' as const,
+      name: importedToken.value as string,
+      start: importedToken.start,
+      end: importedToken.end,
+    });
+
+    let local: AST.Identifier = imported;
+
+    // Check for 'as' alias
+    if (ctx.lexer.is(TokenType.As)) {
+      ctx.lexer.next();
+      const localToken = ctx.lexer.expect(TokenType.Identifier);
+      local = Object.freeze({
+        type: 'Identifier' as const,
+        name: localToken.value as string,
+        start: localToken.start,
+        end: localToken.end,
+      });
+    }
+
+    specifiers.push(Object.freeze({
+      type: 'ImportSpecifier' as const,
+      imported,
+      local,
+      start: imported.start,
+      end: local.end,
+    }));
+
+    if (ctx.lexer.is(TokenType.Comma)) {
+      ctx.lexer.next();
+    }
+  }
+
+  ctx.lexer.expect(TokenType.RightBrace);
+};
+
+/**
+ * Parse import attributes: with { type: 'json' }
+ *
+ * @param ctx - The parser context.
+ * @returns Array of ImportAttribute nodes.
+ */
+const parseImportAttributes = (
+  ctx: ParserContext,
+): Array<ImportAttribute> => {
+  const attributes: Array<ImportAttribute> = [];
+
+  // Check for 'with' keyword (TokenType.With)
+  if (!ctx.lexer.is(TokenType.With)) {
+    return attributes;
+  }
+
+  ctx.lexer.next(); // consume 'with'
+  ctx.lexer.expect(TokenType.LeftBrace);
+
+  while (!ctx.lexer.is(TokenType.RightBrace) && !ctx.lexer.is(TokenType.EOF)) {
+    const attrStart = ctx.lexer.token.start;
+
+    // Key can be identifier or string
+    let key: AST.Identifier | AST.Literal;
+    if (ctx.lexer.is(TokenType.Identifier)) {
+      const keyToken = ctx.lexer.next();
+      key = Object.freeze({
+        type: 'Identifier' as const,
+        name: keyToken.value as string,
+        start: keyToken.start,
+        end: keyToken.end,
+      });
+    } else if (ctx.lexer.is(TokenType.StringLiteral)) {
+      const keyToken = ctx.lexer.next();
+      key = createLiteralFromToken(keyToken);
+    } else {
+      throw new SyntaxError(
+        `Expected attribute key at position ${ctx.lexer.token.start}`,
+      );
+    }
+
+    ctx.lexer.expect(TokenType.Colon);
+
+    // Value must be a string literal
+    if (!ctx.lexer.is(TokenType.StringLiteral)) {
+      throw new SyntaxError(
+        `Expected string literal for import attribute value at position ${ctx.lexer.token.start}`,
+      );
+    }
+    const valueToken = ctx.lexer.next();
+    const value = createLiteralFromToken(valueToken);
+
+    attributes.push(Object.freeze({
+      type: 'ImportAttribute' as const,
+      key,
+      value,
+      start: attrStart,
+      end: value.end,
+    }));
+
+    if (ctx.lexer.is(TokenType.Comma)) {
+      ctx.lexer.next();
+    }
+  }
+
+  ctx.lexer.expect(TokenType.RightBrace);
+  return attributes;
+};
+
+/**
+ * Parse an export declaration.
+ *
+ * Handles: export { a, b as c }
+ *          export { a } from 'module'
+ *          export * from 'module'
+ *          export * as ns from 'module'
+ *          export default expression
+ *          export default function/class
+ *          export const/let/var x = ...
+ *          export function name() {}
+ *          export class Name {}
+ *
+ * @param ctx - The parser context.
+ * @returns The export declaration AST node.
+ */
+export const parseExportDeclaration = (
+  ctx: ParserContext,
+): AST.ExportNamedDeclaration | AST.ExportDefaultDeclaration | AST.ExportAllDeclaration => {
+  const start = ctx.lexer.token.start;
+  ctx.lexer.expect(TokenType.Export);
+
+  // export default ...
+  if (ctx.lexer.is(TokenType.Default)) {
+    ctx.lexer.next();
+    return parseExportDefault(ctx, start);
+  }
+
+  // export * from 'module' or export * as ns from 'module'
+  if (ctx.lexer.is(TokenType.Star)) {
+    ctx.lexer.next();
+
+    let exported: AST.Identifier | null = null;
+    if (ctx.lexer.is(TokenType.As)) {
+      ctx.lexer.next();
+      const nsToken = ctx.lexer.expect(TokenType.Identifier);
+      exported = Object.freeze({
+        type: 'Identifier' as const,
+        name: nsToken.value as string,
+        start: nsToken.start,
+        end: nsToken.end,
+      });
+    }
+
+    ctx.lexer.expect(TokenType.From);
+    if (!ctx.lexer.is(TokenType.StringLiteral)) {
+      throw new SyntaxError(
+        `Expected module source string at position ${ctx.lexer.token.start}`,
+      );
+    }
+    const sourceToken = ctx.lexer.next();
+    const source = createLiteralFromToken(sourceToken);
+    consumeSemicolon(ctx);
+
+    return Object.freeze({
+      type: 'ExportAllDeclaration' as const,
+      source,
+      exported,
+      start,
+      end: sourceToken.end,
+    });
+  }
+
+  // export { a, b as c } or export { a } from 'module'
+  if (ctx.lexer.is(TokenType.LeftBrace)) {
+    const specifiers = parseExportSpecifiers(ctx);
+
+    // Check for re-export: from 'module'
+    let source: AST.Literal | null = null;
+    if (ctx.lexer.is(TokenType.From)) {
+      ctx.lexer.next();
+      if (!ctx.lexer.is(TokenType.StringLiteral)) {
+        throw new SyntaxError(
+          `Expected module source string at position ${ctx.lexer.token.start}`,
+        );
+      }
+      const sourceToken = ctx.lexer.next();
+      source = createLiteralFromToken(sourceToken);
+    }
+
+    consumeSemicolon(ctx);
+
+    const end = source
+      ? source.end
+      : (specifiers.length > 0 ? specifiers[specifiers.length - 1].end : start);
+
+    return Object.freeze({
+      type: 'ExportNamedDeclaration' as const,
+      declaration: null,
+      specifiers: Object.freeze(specifiers),
+      source,
+      start,
+      end,
+    });
+  }
+
+  // export function name() {}
+  if (ctx.lexer.is(TokenType.Function)) {
+    const declaration = parseFunctionDeclaration(ctx, false);
+    return Object.freeze({
+      type: 'ExportNamedDeclaration' as const,
+      declaration,
+      specifiers: Object.freeze([]),
+      source: null,
+      start,
+      end: declaration.end,
+    });
+  }
+
+  // export async function name() {}
+  if (ctx.lexer.is(TokenType.Async)) {
+    ctx.lexer.next();
+    const declaration = parseFunctionDeclaration(ctx, true);
+    return Object.freeze({
+      type: 'ExportNamedDeclaration' as const,
+      declaration,
+      specifiers: Object.freeze([]),
+      source: null,
+      start,
+      end: declaration.end,
+    });
+  }
+
+  // export class Name {}
+  if (ctx.lexer.is(TokenType.Class)) {
+    const declaration = parseClassDeclaration(ctx);
+    return Object.freeze({
+      type: 'ExportNamedDeclaration' as const,
+      declaration,
+      specifiers: Object.freeze([]),
+      source: null,
+      start,
+      end: declaration.end,
+    });
+  }
+
+  // export const/let/var x = ...
+  if (ctx.lexer.is(TokenType.Const) || ctx.lexer.is(TokenType.Let) || ctx.lexer.is(TokenType.Var)) {
+    const declaration = parseVariableDeclaration(ctx);
+    return Object.freeze({
+      type: 'ExportNamedDeclaration' as const,
+      declaration,
+      specifiers: Object.freeze([]),
+      source: null,
+      start,
+      end: declaration.end,
+    });
+  }
+
+  throw new SyntaxError(
+    `Unexpected token after export at position ${ctx.lexer.token.start}`,
+  );
+};
+
+/**
+ * Parse export default declaration.
+ *
+ * @param ctx - The parser context.
+ * @param start - The start position of the 'export' keyword.
+ * @returns The ExportDefaultDeclaration AST node.
+ */
+const parseExportDefault = (
+  ctx: ParserContext,
+  start: number,
+): AST.ExportDefaultDeclaration => {
+  // export default function ...
+  if (ctx.lexer.is(TokenType.Function)) {
+    const declaration = parseFunctionDeclaration(ctx, false);
+    return Object.freeze({
+      type: 'ExportDefaultDeclaration' as const,
+      declaration,
+      start,
+      end: declaration.end,
+    });
+  }
+
+  // export default async function ...
+  if (ctx.lexer.is(TokenType.Async)) {
+    ctx.lexer.next();
+    const declaration = parseFunctionDeclaration(ctx, true);
+    return Object.freeze({
+      type: 'ExportDefaultDeclaration' as const,
+      declaration,
+      start,
+      end: declaration.end,
+    });
+  }
+
+  // export default class ...
+  if (ctx.lexer.is(TokenType.Class)) {
+    const declaration = parseClassDeclaration(ctx);
+    return Object.freeze({
+      type: 'ExportDefaultDeclaration' as const,
+      declaration,
+      start,
+      end: declaration.end,
+    });
+  }
+
+  // export default expression
+  const expression = ctx.parseExpression();
+  consumeSemicolon(ctx);
+  return Object.freeze({
+    type: 'ExportDefaultDeclaration' as const,
+    declaration: expression,
+    start,
+    end: expression.end,
+  });
+};
+
+/**
+ * Parse export specifiers: { a, b as c }
+ *
+ * @param ctx - The parser context.
+ * @returns Array of ExportSpecifier nodes.
+ */
+const parseExportSpecifiers = (
+  ctx: ParserContext,
+): Array<AST.ExportSpecifier> => {
+  ctx.lexer.expect(TokenType.LeftBrace);
+  const specifiers: Array<AST.ExportSpecifier> = [];
+
+  while (!ctx.lexer.is(TokenType.RightBrace) && !ctx.lexer.is(TokenType.EOF)) {
+    const localToken = ctx.lexer.token;
+    if (!ctx.lexer.is(TokenType.Identifier) && !isKeywordToken(localToken.type)) {
+      break;
+    }
+    ctx.lexer.next();
+
+    const local: AST.Identifier = Object.freeze({
+      type: 'Identifier' as const,
+      name: localToken.value as string,
+      start: localToken.start,
+      end: localToken.end,
+    });
+
+    let exported: AST.Identifier = local;
+
+    // Check for 'as' alias
+    if (ctx.lexer.is(TokenType.As)) {
+      ctx.lexer.next();
+      const exportedToken = ctx.lexer.token;
+      if (!ctx.lexer.is(TokenType.Identifier) && !isKeywordToken(exportedToken.type)) {
+        throw new SyntaxError(
+          `Expected identifier after 'as' at position ${exportedToken.start}`,
+        );
+      }
+      ctx.lexer.next();
+      exported = Object.freeze({
+        type: 'Identifier' as const,
+        name: exportedToken.value as string,
+        start: exportedToken.start,
+        end: exportedToken.end,
+      });
+    }
+
+    specifiers.push(Object.freeze({
+      type: 'ExportSpecifier' as const,
+      local,
+      exported,
+      start: local.start,
+      end: exported.end,
+    }));
+
+    if (ctx.lexer.is(TokenType.Comma)) {
+      ctx.lexer.next();
+    }
+  }
+
+  ctx.lexer.expect(TokenType.RightBrace);
+  return specifiers;
+};
+
+/**
+ * Parse a simple variable declaration (const/let/var x = expr).
+ *
+ * @param ctx - The parser context.
+ * @returns The VariableDeclaration AST node.
+ */
+const parseVariableDeclaration = (
+  ctx: ParserContext,
+): AST.VariableDeclaration => {
+  const start = ctx.lexer.token.start;
+  const kindToken = ctx.lexer.next();
+  const kind = kindToken.value as 'var' | 'let' | 'const';
+
+  const declarations: Array<AST.VariableDeclarator> = [];
+
+  // Parse declarators iteratively
+  let expectMore = true;
+  while (expectMore) {
+    const idToken = ctx.lexer.expect(TokenType.Identifier);
+    const id: AST.Identifier = Object.freeze({
+      type: 'Identifier' as const,
+      name: idToken.value as string,
+      start: idToken.start,
+      end: idToken.end,
+    });
+
+    let init: AST.Expression | null = null;
+    if (ctx.lexer.is(TokenType.Equals)) {
+      ctx.lexer.next();
+      init = ctx.parseExpression();
+    }
+
+    declarations.push(Object.freeze({
+      type: 'VariableDeclarator' as const,
+      id,
+      init,
+      start: id.start,
+      end: init ? init.end : id.end,
+    }));
+
+    if (ctx.lexer.is(TokenType.Comma)) {
+      ctx.lexer.next();
+    } else {
+      expectMore = false;
+    }
+  }
+
+  consumeSemicolon(ctx);
+
+  const lastDecl = declarations[declarations.length - 1];
+  return Object.freeze({
+    type: 'VariableDeclaration' as const,
+    declarations: Object.freeze(declarations),
+    kind,
+    start,
+    end: lastDecl.end,
+  });
+};
+
+/**
+ * Create a Literal AST node from a token.
+ *
+ * @param token - The string literal token.
+ * @returns A frozen Literal AST node.
+ */
+const createLiteralFromToken = (token: {
+  readonly value: unknown;
+  readonly raw: string;
+  readonly start: number;
+  readonly end: number;
+}): AST.Literal => {
+  return Object.freeze({
+    type: 'Literal' as const,
+    value: token.value as string,
+    raw: token.raw,
+    start: token.start,
+    end: token.end,
+  });
+};
+
+/**
+ * Consume an optional semicolon.
+ *
+ * @param ctx - The parser context.
+ */
+const consumeSemicolon = (ctx: ParserContext): void => {
+  if (ctx.lexer.is(TokenType.Semicolon)) {
+    ctx.lexer.next();
+  }
+};
+
+/**
+ * Check if a token type represents a keyword that can be used as an identifier
+ * in some contexts (e.g., as property names in imports/exports).
+ *
+ * @param type - The token type to check.
+ * @returns True if the token is a keyword that can serve as identifier.
+ */
+const isKeywordToken = (type: number): boolean => {
+  // Reserved keywords that can appear as export/import specifier names
+  return (type >= TokenType.Break && type <= TokenType.With) ||
+         (type >= TokenType.Class && type <= TokenType.Super) ||
+         (type >= TokenType.Async && type <= TokenType.Static);
+};

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -12,6 +12,13 @@ import type * as AST from '../ast/types.js';
 import { Lexer } from './lexer.js';
 import { TokenType } from './token-types.js';
 import { tokenTypeName } from './token-types.js';
+import {
+  parseFunctionDeclaration,
+  parseClassDeclaration,
+  parseImportDeclaration,
+  parseExportDeclaration,
+} from './declarations.js';
+import type { ParserContext } from './declarations.js';
 
 /**
  * Options for the parser.
@@ -31,11 +38,11 @@ export interface ParseOptions {
  * Internal state fields are mutable (documented exception for parser
  * state machine pattern).
  */
-export class Parser {
+export class Parser implements ParserContext {
   /** The lexer producing the token stream. */
-  private lexer: Lexer;
+  lexer: Lexer;
   /** Whether parsing as module or script. */
-  private sourceType: 'module' | 'script';
+  sourceType: 'module' | 'script';
 
   /**
    * Create a new Parser for the given source text.
@@ -84,9 +91,8 @@ export class Parser {
   /**
    * Parse a single statement or module declaration.
    *
-   * This is a placeholder that handles only semicolons (empty statements)
-   * for now. Full statement parsing will be implemented by issues #19,
-   * #22, and #24.
+   * Delegates to specialized parsers for declarations (function, class,
+   * import, export). Other statement types will be added by subsequent issues.
    *
    * @returns The parsed statement or module declaration AST node.
    * @throws {SyntaxError} For unrecognized tokens (statement parsing not
@@ -105,9 +111,122 @@ export class Parser {
       });
     }
 
+    // Function declaration
+    if (token.type === TokenType.Function) {
+      return parseFunctionDeclaration(this, false);
+    }
+
+    // Async function declaration
+    if (token.type === TokenType.Async) {
+      const saved = this.lexer.saveState();
+      this.lexer.next();
+      if (this.lexer.is(TokenType.Function)) {
+        return parseFunctionDeclaration(this, true);
+      }
+      this.lexer.restoreState(saved);
+    }
+
+    // Class declaration
+    if (token.type === TokenType.Class) {
+      return parseClassDeclaration(this);
+    }
+
+    // Import declaration (module only)
+    if (token.type === TokenType.Import) {
+      return parseImportDeclaration(this);
+    }
+
+    // Export declaration (module only)
+    if (token.type === TokenType.Export) {
+      return parseExportDeclaration(this);
+    }
+
     const typeName = tokenTypeName(token.type);
     throw new SyntaxError(
       `Statement parsing not yet implemented for ${typeName} at position ${token.start}`,
+    );
+  }
+
+  /**
+   * Parse a block statement: { ... }
+   *
+   * @returns The BlockStatement AST node.
+   */
+  parseBlockStatement(): AST.BlockStatement {
+    const start = this.lexer.token.start;
+    this.lexer.expect(TokenType.LeftBrace);
+
+    const body: Array<AST.Statement> = [];
+    while (!this.lexer.is(TokenType.RightBrace) && !this.lexer.is(TokenType.EOF)) {
+      const stmt = this.parseStatement() as AST.Statement;
+      body.push(stmt);
+    }
+
+    const endToken = this.lexer.expect(TokenType.RightBrace);
+
+    return Object.freeze({
+      type: 'BlockStatement' as const,
+      body: Object.freeze(body),
+      start,
+      end: endToken.end,
+    });
+  }
+
+  /**
+   * Parse an expression (placeholder for full expression parsing).
+   *
+   * Currently handles identifiers and literals for use by declaration parsers.
+   *
+   * @returns The Expression AST node.
+   */
+  parseExpression(): AST.Expression {
+    const token = this.lexer.token;
+
+    if (token.type === TokenType.Identifier) {
+      this.lexer.next();
+      return Object.freeze({
+        type: 'Identifier' as const,
+        name: token.value as string,
+        start: token.start,
+        end: token.end,
+      });
+    }
+
+    if (token.type === TokenType.NumericLiteral || token.type === TokenType.StringLiteral) {
+      this.lexer.next();
+      return Object.freeze({
+        type: 'Literal' as const,
+        value: token.value as string | number,
+        raw: token.raw,
+        start: token.start,
+        end: token.end,
+      });
+    }
+
+    if (token.type === TokenType.True || token.type === TokenType.False) {
+      this.lexer.next();
+      return Object.freeze({
+        type: 'Literal' as const,
+        value: token.value as boolean,
+        raw: token.raw,
+        start: token.start,
+        end: token.end,
+      });
+    }
+
+    if (token.type === TokenType.Null) {
+      this.lexer.next();
+      return Object.freeze({
+        type: 'Literal' as const,
+        value: null,
+        raw: token.raw,
+        start: token.start,
+        end: token.end,
+      });
+    }
+
+    throw new SyntaxError(
+      `Expression parsing not yet implemented for ${tokenTypeName(token.type)} at position ${token.start}`,
     );
   }
 }

--- a/tests/unit/parser/declarations.test.ts
+++ b/tests/unit/parser/declarations.test.ts
@@ -1,0 +1,603 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '../../../src/parser/parser.js';
+
+describe('Declaration Parsing', () => {
+  describe('Function Declarations', () => {
+    it('should parse a simple function declaration', () => {
+      const program = parse('function foo() {}');
+      expect(program.body.length).toBe(1);
+      const decl = program.body[0] as { type: string; id: { name: string }; generator: boolean; async: boolean };
+      expect(decl.type).toBe('FunctionDeclaration');
+      expect(decl.id.name).toBe('foo');
+      expect(decl.generator).toBe(false);
+      expect(decl.async).toBe(false);
+    });
+
+    it('should parse a generator function declaration', () => {
+      const program = parse('function* gen() {}');
+      const decl = program.body[0] as { type: string; id: { name: string }; generator: boolean; async: boolean };
+      expect(decl.type).toBe('FunctionDeclaration');
+      expect(decl.id.name).toBe('gen');
+      expect(decl.generator).toBe(true);
+      expect(decl.async).toBe(false);
+    });
+
+    it('should parse an async function declaration', () => {
+      const program = parse('async function fetchData() {}');
+      const decl = program.body[0] as { type: string; id: { name: string }; generator: boolean; async: boolean };
+      expect(decl.type).toBe('FunctionDeclaration');
+      expect(decl.id.name).toBe('fetchData');
+      expect(decl.generator).toBe(false);
+      expect(decl.async).toBe(true);
+    });
+
+    it('should parse an async generator function declaration', () => {
+      const program = parse('async function* asyncGen() {}');
+      const decl = program.body[0] as { type: string; id: { name: string }; generator: boolean; async: boolean };
+      expect(decl.type).toBe('FunctionDeclaration');
+      expect(decl.id.name).toBe('asyncGen');
+      expect(decl.generator).toBe(true);
+      expect(decl.async).toBe(true);
+    });
+
+    it('should parse function with parameters', () => {
+      const program = parse('function add(a, b) {}');
+      const decl = program.body[0] as { type: string; params: ReadonlyArray<{ type: string; name: string }> };
+      expect(decl.params.length).toBe(2);
+      expect(decl.params[0].type).toBe('Identifier');
+      expect(decl.params[0].name).toBe('a');
+      expect(decl.params[1].name).toBe('b');
+    });
+
+    it('should parse function with default parameter', () => {
+      const program = parse('function greet(name = "world") {}');
+      const decl = program.body[0] as { type: string; params: ReadonlyArray<{ type: string; left: { name: string }; right: { value: unknown } }> };
+      expect(decl.params.length).toBe(1);
+      expect(decl.params[0].type).toBe('AssignmentPattern');
+      expect(decl.params[0].left.name).toBe('name');
+      expect(decl.params[0].right.value).toBe('world');
+    });
+
+    it('should parse function with rest parameter', () => {
+      const program = parse('function collect(...args) {}');
+      const decl = program.body[0] as { type: string; params: ReadonlyArray<{ type: string; argument: { name: string } }> };
+      expect(decl.params.length).toBe(1);
+      expect(decl.params[0].type).toBe('RestElement');
+      expect(decl.params[0].argument.name).toBe('args');
+    });
+
+    it('should parse function with mixed parameters', () => {
+      const program = parse('function mixed(a, b = 1, ...rest) {}');
+      const decl = program.body[0] as { type: string; params: ReadonlyArray<{ type: string }> };
+      expect(decl.params.length).toBe(3);
+      expect(decl.params[0].type).toBe('Identifier');
+      expect(decl.params[1].type).toBe('AssignmentPattern');
+      expect(decl.params[2].type).toBe('RestElement');
+    });
+
+    it('should set correct positions for function declaration', () => {
+      const program = parse('function foo() {}');
+      const decl = program.body[0];
+      expect(decl.start).toBe(0);
+      expect(decl.end).toBe(17);
+    });
+
+    it('should produce a frozen FunctionDeclaration node', () => {
+      const program = parse('function foo() {}');
+      expect(Object.isFrozen(program.body[0])).toBe(true);
+    });
+  });
+
+  describe('Class Declarations', () => {
+    it('should parse an empty class', () => {
+      const program = parse('class Foo {}');
+      const decl = program.body[0] as { type: string; id: { name: string }; superClass: unknown; body: { type: string; body: ReadonlyArray<unknown> } };
+      expect(decl.type).toBe('ClassDeclaration');
+      expect(decl.id.name).toBe('Foo');
+      expect(decl.superClass).toBeNull();
+      expect(decl.body.type).toBe('ClassBody');
+      expect(decl.body.body.length).toBe(0);
+    });
+
+    it('should parse a class with extends', () => {
+      const program = parse('class Dog extends Animal {}');
+      const decl = program.body[0] as { type: string; id: { name: string }; superClass: { type: string; name: string } };
+      expect(decl.type).toBe('ClassDeclaration');
+      expect(decl.id.name).toBe('Dog');
+      expect(decl.superClass).not.toBeNull();
+      expect(decl.superClass.type).toBe('Identifier');
+      expect(decl.superClass.name).toBe('Animal');
+    });
+
+    it('should parse a class with constructor', () => {
+      const program = parse('class Foo { constructor() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; kind: string; key: { name: string } }> } };
+      expect(decl.body.body.length).toBe(1);
+      expect(decl.body.body[0].type).toBe('MethodDefinition');
+      expect(decl.body.body[0].kind).toBe('constructor');
+      expect(decl.body.body[0].key.name).toBe('constructor');
+    });
+
+    it('should parse a class with methods', () => {
+      const program = parse('class Foo { bar() {} baz() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; kind: string; key: { name: string } }> } };
+      expect(decl.body.body.length).toBe(2);
+      expect(decl.body.body[0].kind).toBe('method');
+      expect(decl.body.body[0].key.name).toBe('bar');
+      expect(decl.body.body[1].key.name).toBe('baz');
+    });
+
+    it('should parse a class with static methods', () => {
+      const program = parse('class Foo { static create() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; static: boolean; key: { name: string } }> } };
+      expect(decl.body.body.length).toBe(1);
+      expect(decl.body.body[0].static).toBe(true);
+      expect(decl.body.body[0].key.name).toBe('create');
+    });
+
+    it('should parse a class with getter', () => {
+      const program = parse('class Foo { get name() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; kind: string; key: { name: string } }> } };
+      expect(decl.body.body[0].kind).toBe('get');
+      expect(decl.body.body[0].key.name).toBe('name');
+    });
+
+    it('should parse a class with setter', () => {
+      const program = parse('class Foo { set name(value) {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; kind: string; key: { name: string } }> } };
+      expect(decl.body.body[0].kind).toBe('set');
+      expect(decl.body.body[0].key.name).toBe('name');
+    });
+
+    it('should parse a class with public field', () => {
+      const program = parse('class Foo { x = 1; }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; key: { name: string }; value: { value: unknown }; static: boolean }> } };
+      expect(decl.body.body[0].type).toBe('PropertyDefinition');
+      expect(decl.body.body[0].key.name).toBe('x');
+      expect(decl.body.body[0].value.value).toBe(1);
+      expect(decl.body.body[0].static).toBe(false);
+    });
+
+    it('should parse a class with static field', () => {
+      const program = parse('class Foo { static count = 0; }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; key: { name: string }; static: boolean }> } };
+      expect(decl.body.body[0].type).toBe('PropertyDefinition');
+      expect(decl.body.body[0].key.name).toBe('count');
+      expect(decl.body.body[0].static).toBe(true);
+    });
+
+    it('should parse a class with private field', () => {
+      const program = parse('class Foo { #secret = 42; }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; key: { name: string }; value: { value: unknown } }> } };
+      expect(decl.body.body[0].type).toBe('PropertyDefinition');
+      expect(decl.body.body[0].key.name).toBe('#secret');
+      expect(decl.body.body[0].value.value).toBe(42);
+    });
+
+    it('should parse a class with private method', () => {
+      const program = parse('class Foo { #doWork() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; key: { name: string } }> } };
+      expect(decl.body.body[0].type).toBe('MethodDefinition');
+      expect(decl.body.body[0].key.name).toBe('#doWork');
+    });
+
+    it('should parse a class with static block', () => {
+      const program = parse('class Foo { static {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; body: ReadonlyArray<unknown> }> } };
+      expect(decl.body.body[0].type).toBe('StaticBlock');
+      expect(decl.body.body[0].body.length).toBe(0);
+    });
+
+    it('should parse a class with field without initializer', () => {
+      const program = parse('class Foo { x; }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; key: { name: string }; value: unknown }> } };
+      expect(decl.body.body[0].type).toBe('PropertyDefinition');
+      expect(decl.body.body[0].key.name).toBe('x');
+      expect(decl.body.body[0].value).toBeNull();
+    });
+
+    it('should produce frozen ClassDeclaration node', () => {
+      const program = parse('class Foo {}');
+      expect(Object.isFrozen(program.body[0])).toBe(true);
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('class Foo {}');
+      expect(program.body[0].start).toBe(0);
+      expect(program.body[0].end).toBe(12);
+    });
+  });
+
+  describe('Import Declarations', () => {
+    it('should parse default import', () => {
+      const program = parse('import foo from "bar";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ type: string; local: { name: string } }>; source: { value: unknown } };
+      expect(decl.type).toBe('ImportDeclaration');
+      expect(decl.specifiers.length).toBe(1);
+      expect(decl.specifiers[0].type).toBe('ImportDefaultSpecifier');
+      expect(decl.specifiers[0].local.name).toBe('foo');
+      expect(decl.source.value).toBe('bar');
+    });
+
+    it('should parse named imports', () => {
+      const program = parse('import { a, b } from "mod";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ type: string; imported: { name: string }; local: { name: string } }> };
+      expect(decl.specifiers.length).toBe(2);
+      expect(decl.specifiers[0].type).toBe('ImportSpecifier');
+      expect(decl.specifiers[0].imported.name).toBe('a');
+      expect(decl.specifiers[1].imported.name).toBe('b');
+    });
+
+    it('should parse named imports with aliases', () => {
+      const program = parse('import { a as x, b as y } from "mod";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ type: string; imported: { name: string }; local: { name: string } }> };
+      expect(decl.specifiers[0].imported.name).toBe('a');
+      expect(decl.specifiers[0].local.name).toBe('x');
+      expect(decl.specifiers[1].imported.name).toBe('b');
+      expect(decl.specifiers[1].local.name).toBe('y');
+    });
+
+    it('should parse namespace import', () => {
+      const program = parse('import * as ns from "mod";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ type: string; local: { name: string } }> };
+      expect(decl.specifiers.length).toBe(1);
+      expect(decl.specifiers[0].type).toBe('ImportNamespaceSpecifier');
+      expect(decl.specifiers[0].local.name).toBe('ns');
+    });
+
+    it('should parse side-effect import', () => {
+      const program = parse('import "polyfill";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<unknown>; source: { value: unknown } };
+      expect(decl.type).toBe('ImportDeclaration');
+      expect(decl.specifiers.length).toBe(0);
+      expect(decl.source.value).toBe('polyfill');
+    });
+
+    it('should parse combined default and named imports', () => {
+      const program = parse('import React, { useState } from "react";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ type: string; local: { name: string } }> };
+      expect(decl.specifiers.length).toBe(2);
+      expect(decl.specifiers[0].type).toBe('ImportDefaultSpecifier');
+      expect(decl.specifiers[0].local.name).toBe('React');
+      expect(decl.specifiers[1].type).toBe('ImportSpecifier');
+      expect(decl.specifiers[1].local.name).toBe('useState');
+    });
+
+    it('should parse combined default and namespace imports', () => {
+      const program = parse('import def, * as all from "mod";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ type: string; local: { name: string } }> };
+      expect(decl.specifiers.length).toBe(2);
+      expect(decl.specifiers[0].type).toBe('ImportDefaultSpecifier');
+      expect(decl.specifiers[0].local.name).toBe('def');
+      expect(decl.specifiers[1].type).toBe('ImportNamespaceSpecifier');
+      expect(decl.specifiers[1].local.name).toBe('all');
+    });
+
+    it('should parse import with attributes', () => {
+      const program = parse('import data from "data.json" with { type: "json" };');
+      const decl = program.body[0] as { type: string; attributes: ReadonlyArray<{ type: string; key: { name: string }; value: { value: unknown } }> };
+      expect(decl.attributes.length).toBe(1);
+      expect(decl.attributes[0].type).toBe('ImportAttribute');
+      expect(decl.attributes[0].key.name).toBe('type');
+      expect(decl.attributes[0].value.value).toBe('json');
+    });
+
+    it('should parse import with multiple attributes', () => {
+      const program = parse('import data from "data.json" with { type: "json", integrity: "sha256" };');
+      const decl = program.body[0] as { type: string; attributes: ReadonlyArray<{ type: string; key: { name: string }; value: { value: unknown } }> };
+      expect(decl.attributes.length).toBe(2);
+      expect(decl.attributes[0].key.name).toBe('type');
+      expect(decl.attributes[0].value.value).toBe('json');
+      expect(decl.attributes[1].key.name).toBe('integrity');
+      expect(decl.attributes[1].value.value).toBe('sha256');
+    });
+
+    it('should parse import with string literal attribute key', () => {
+      const program = parse('import data from "data.json" with { "type": "json" };');
+      const decl = program.body[0] as { type: string; attributes: ReadonlyArray<{ key: { type: string; value: unknown } }> };
+      expect(decl.attributes[0].key.type).toBe('Literal');
+      expect(decl.attributes[0].key.value).toBe('type');
+    });
+
+    it('should parse import without semicolon', () => {
+      const program = parse('import foo from "bar"');
+      const decl = program.body[0] as { type: string };
+      expect(decl.type).toBe('ImportDeclaration');
+    });
+
+    it('should produce frozen ImportDeclaration node', () => {
+      const program = parse('import foo from "bar";');
+      expect(Object.isFrozen(program.body[0])).toBe(true);
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('import foo from "bar";');
+      expect(program.body[0].start).toBe(0);
+    });
+
+    it('should parse empty named imports', () => {
+      const program = parse('import {} from "mod";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<unknown> };
+      expect(decl.specifiers.length).toBe(0);
+    });
+
+    it('should parse named imports with trailing comma', () => {
+      const program = parse('import { a, b, } from "mod";');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<unknown> };
+      expect(decl.specifiers.length).toBe(2);
+    });
+  });
+
+  describe('Export Declarations', () => {
+    it('should parse named exports', () => {
+      const program = parse('export { a, b };');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ type: string; local: { name: string }; exported: { name: string } }>; source: unknown; declaration: unknown };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+      expect(decl.specifiers.length).toBe(2);
+      expect(decl.specifiers[0].local.name).toBe('a');
+      expect(decl.specifiers[0].exported.name).toBe('a');
+      expect(decl.specifiers[1].local.name).toBe('b');
+      expect(decl.source).toBeNull();
+      expect(decl.declaration).toBeNull();
+    });
+
+    it('should parse named exports with aliases', () => {
+      const program = parse('export { a as x, b as y };');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<{ local: { name: string }; exported: { name: string } }> };
+      expect(decl.specifiers[0].local.name).toBe('a');
+      expect(decl.specifiers[0].exported.name).toBe('x');
+      expect(decl.specifiers[1].local.name).toBe('b');
+      expect(decl.specifiers[1].exported.name).toBe('y');
+    });
+
+    it('should parse re-exports', () => {
+      const program = parse('export { a } from "mod";');
+      const decl = program.body[0] as { type: string; source: { value: unknown }; specifiers: ReadonlyArray<{ local: { name: string } }> };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+      expect(decl.source).not.toBeNull();
+      expect(decl.source.value).toBe('mod');
+      expect(decl.specifiers[0].local.name).toBe('a');
+    });
+
+    it('should parse export all', () => {
+      const program = parse('export * from "mod";');
+      const decl = program.body[0] as { type: string; source: { value: unknown }; exported: unknown };
+      expect(decl.type).toBe('ExportAllDeclaration');
+      expect(decl.source.value).toBe('mod');
+      expect(decl.exported).toBeNull();
+    });
+
+    it('should parse export all with alias', () => {
+      const program = parse('export * as ns from "mod";');
+      const decl = program.body[0] as { type: string; source: { value: unknown }; exported: { name: string } };
+      expect(decl.type).toBe('ExportAllDeclaration');
+      expect(decl.exported).not.toBeNull();
+      expect(decl.exported.name).toBe('ns');
+    });
+
+    it('should parse export default expression (identifier)', () => {
+      const program = parse('export default foo;');
+      const decl = program.body[0] as { type: string; declaration: { type: string; name: string } };
+      expect(decl.type).toBe('ExportDefaultDeclaration');
+      expect(decl.declaration.type).toBe('Identifier');
+      expect(decl.declaration.name).toBe('foo');
+    });
+
+    it('should parse export default function', () => {
+      const program = parse('export default function foo() {}');
+      const decl = program.body[0] as { type: string; declaration: { type: string; id: { name: string } } };
+      expect(decl.type).toBe('ExportDefaultDeclaration');
+      expect(decl.declaration.type).toBe('FunctionDeclaration');
+      expect(decl.declaration.id.name).toBe('foo');
+    });
+
+    it('should parse export default async function', () => {
+      const program = parse('export default async function foo() {}');
+      const decl = program.body[0] as { type: string; declaration: { type: string; async: boolean } };
+      expect(decl.type).toBe('ExportDefaultDeclaration');
+      expect(decl.declaration.type).toBe('FunctionDeclaration');
+      expect(decl.declaration.async).toBe(true);
+    });
+
+    it('should parse export default class', () => {
+      const program = parse('export default class Foo {}');
+      const decl = program.body[0] as { type: string; declaration: { type: string; id: { name: string } } };
+      expect(decl.type).toBe('ExportDefaultDeclaration');
+      expect(decl.declaration.type).toBe('ClassDeclaration');
+      expect(decl.declaration.id.name).toBe('Foo');
+    });
+
+    it('should parse export function declaration', () => {
+      const program = parse('export function foo() {}');
+      const decl = program.body[0] as { type: string; declaration: { type: string; id: { name: string } }; specifiers: ReadonlyArray<unknown> };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+      expect(decl.declaration).not.toBeNull();
+      expect(decl.declaration.type).toBe('FunctionDeclaration');
+      expect(decl.declaration.id.name).toBe('foo');
+      expect(decl.specifiers.length).toBe(0);
+    });
+
+    it('should parse export async function declaration', () => {
+      const program = parse('export async function foo() {}');
+      const decl = program.body[0] as { type: string; declaration: { type: string; async: boolean; id: { name: string } } };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+      expect(decl.declaration.type).toBe('FunctionDeclaration');
+      expect(decl.declaration.async).toBe(true);
+    });
+
+    it('should parse export class declaration', () => {
+      const program = parse('export class Foo {}');
+      const decl = program.body[0] as { type: string; declaration: { type: string; id: { name: string } } };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+      expect(decl.declaration.type).toBe('ClassDeclaration');
+      expect(decl.declaration.id.name).toBe('Foo');
+    });
+
+    it('should parse export const declaration', () => {
+      const program = parse('export const x = 1;');
+      const decl = program.body[0] as { type: string; declaration: { type: string; kind: string; declarations: ReadonlyArray<{ id: { name: string }; init: { value: unknown } }> } };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+      expect(decl.declaration.type).toBe('VariableDeclaration');
+      expect(decl.declaration.kind).toBe('const');
+      expect(decl.declaration.declarations[0].id.name).toBe('x');
+      expect(decl.declaration.declarations[0].init.value).toBe(1);
+    });
+
+    it('should parse export without semicolon', () => {
+      const program = parse('export { a }');
+      const decl = program.body[0] as { type: string };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+    });
+
+    it('should produce frozen ExportNamedDeclaration node', () => {
+      const program = parse('export { a };');
+      expect(Object.isFrozen(program.body[0])).toBe(true);
+    });
+
+    it('should parse empty named exports', () => {
+      const program = parse('export {};');
+      const decl = program.body[0] as { type: string; specifiers: ReadonlyArray<unknown> };
+      expect(decl.type).toBe('ExportNamedDeclaration');
+      expect(decl.specifiers.length).toBe(0);
+    });
+
+    it('should parse export default literal', () => {
+      const program = parse('export default 42;');
+      const decl = program.body[0] as { type: string; declaration: { type: string; value: unknown } };
+      expect(decl.type).toBe('ExportDefaultDeclaration');
+      expect(decl.declaration.type).toBe('Literal');
+      expect(decl.declaration.value).toBe(42);
+    });
+  });
+
+  describe('Variable Declarations (via export)', () => {
+    it('should parse export with multiple declarators', () => {
+      const program = parse('export const a = 1, b = 2;');
+      const decl = program.body[0] as { type: string; declaration: { type: string; declarations: ReadonlyArray<{ id: { name: string }; init: { value: unknown } }> } };
+      expect(decl.declaration.declarations.length).toBe(2);
+      expect(decl.declaration.declarations[0].id.name).toBe('a');
+      expect(decl.declaration.declarations[0].init.value).toBe(1);
+      expect(decl.declaration.declarations[1].id.name).toBe('b');
+      expect(decl.declaration.declarations[1].init.value).toBe(2);
+    });
+
+    it('should parse export const without initializer', () => {
+      const program = parse('export const x;');
+      const decl = program.body[0] as { type: string; declaration: { declarations: ReadonlyArray<{ id: { name: string }; init: unknown }> } };
+      expect(decl.declaration.declarations[0].id.name).toBe('x');
+      expect(decl.declaration.declarations[0].init).toBeNull();
+    });
+  });
+
+  describe('Class Advanced Features', () => {
+    it('should parse class with computed property key', () => {
+      const program = parse('class Foo { [x]() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; computed: boolean; key: { type: string; name: string } }> } };
+      expect(decl.body.body[0].type).toBe('MethodDefinition');
+      expect(decl.body.body[0].computed).toBe(true);
+      expect(decl.body.body[0].key.type).toBe('Identifier');
+      expect(decl.body.body[0].key.name).toBe('x');
+    });
+
+    it('should parse class with numeric literal key', () => {
+      const program = parse('class Foo { 0() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; key: { type: string; value: unknown } }> } };
+      expect(decl.body.body[0].type).toBe('MethodDefinition');
+      expect(decl.body.body[0].key.type).toBe('Literal');
+      expect(decl.body.body[0].key.value).toBe(0);
+    });
+
+    it('should parse class with string literal key', () => {
+      const program = parse('class Foo { "hello"() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; key: { type: string; value: unknown } }> } };
+      expect(decl.body.body[0].type).toBe('MethodDefinition');
+      expect(decl.body.body[0].key.type).toBe('Literal');
+      expect(decl.body.body[0].key.value).toBe('hello');
+    });
+
+    it('should parse class with static constructor method', () => {
+      const program = parse('class Foo { static constructor() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; kind: string; static: boolean }> } };
+      // Static constructor is a regular static method, not a 'constructor' kind
+      expect(decl.body.body[0].kind).toBe('method');
+      expect(decl.body.body[0].static).toBe(true);
+    });
+
+    it('should parse class with method named "get"', () => {
+      const program = parse('class Foo { get() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; kind: string; key: { name: string } }> } };
+      // 'get' followed by ( means it's a method named 'get'
+      expect(decl.body.body[0].kind).toBe('method');
+      expect(decl.body.body[0].key.name).toBe('get');
+    });
+
+    it('should parse class with method named "set"', () => {
+      const program = parse('class Foo { set() {} }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; kind: string; key: { name: string } }> } };
+      expect(decl.body.body[0].kind).toBe('method');
+      expect(decl.body.body[0].key.name).toBe('set');
+    });
+
+    it('should parse class with computed property field', () => {
+      const program = parse('class Foo { [x] = 1; }');
+      const decl = program.body[0] as { type: string; body: { body: ReadonlyArray<{ type: string; computed: boolean }> } };
+      expect(decl.body.body[0].type).toBe('PropertyDefinition');
+      expect(decl.body.body[0].computed).toBe(true);
+    });
+  });
+
+  describe('Error Cases', () => {
+    it('should throw on missing import source', () => {
+      expect(() => parse('import foo from;')).toThrow(SyntaxError);
+    });
+
+    it('should throw on invalid export syntax', () => {
+      expect(() => parse('export 123;')).toThrow(SyntaxError);
+    });
+
+    it('should throw on missing export source for re-export', () => {
+      expect(() => parse('export * from;')).toThrow(SyntaxError);
+    });
+
+    it('should throw on missing module source in named re-export', () => {
+      expect(() => parse('export { a } from;')).toThrow(SyntaxError);
+    });
+
+    it('should throw for invalid token in class body', () => {
+      expect(() => parse('class Foo { ...invalid }')).toThrow(SyntaxError);
+    });
+
+    it('should throw for export all missing source', () => {
+      expect(() => parse('export * as ns from;')).toThrow(SyntaxError);
+    });
+
+    it('should throw for invalid export specifier alias', () => {
+      expect(() => parse('export { a as 123 };')).toThrow(SyntaxError);
+    });
+
+    it('should throw for invalid import attribute value', () => {
+      expect(() => parse('import x from "y" with { type: 123 };')).toThrow(SyntaxError);
+    });
+
+    it('should throw for invalid import attribute key', () => {
+      expect(() => parse('import x from "y" with { 123: "json" };')).toThrow(SyntaxError);
+    });
+  });
+
+  describe('Multiple Declarations', () => {
+    it('should parse multiple declarations in sequence', () => {
+      const program = parse('import x from "a"; export function foo() {} class Bar {}');
+      expect(program.body.length).toBe(3);
+      expect(program.body[0].type).toBe('ImportDeclaration');
+      expect(program.body[1].type).toBe('ExportNamedDeclaration');
+      expect(program.body[2].type).toBe('ClassDeclaration');
+    });
+
+    it('should parse function followed by class', () => {
+      const program = parse('function foo() {} class Bar {}');
+      expect(program.body.length).toBe(2);
+      expect(program.body[0].type).toBe('FunctionDeclaration');
+      expect(program.body[1].type).toBe('ClassDeclaration');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `src/parser/declarations.ts` with parsing for function declarations (sync/async/generator), class declarations (methods, fields, private members, static blocks, getters/setters), import declarations (default, named, namespace, side-effect, combined, with attributes), and export declarations (named, re-export, all, default, declarations)
- Update `src/parser/parser.ts` to delegate declaration keyword handling (`function`, `async function`, `class`, `import`, `export`) and add `parseBlockStatement`/`parseExpression` helpers
- Add comprehensive test suite with 77 tests covering all declaration forms plus error cases

## Test plan

- [x] All 77 new declaration tests pass
- [x] All 1885 existing tests continue to pass
- [x] Coverage: 99.04% statements, 96.64% branches, 100% functions on declarations.ts

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)