### PR TITLE
feat: implement parser statement types

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -2,16 +2,37 @@
  * Core Parser class for the Steamroller JavaScript parser.
  *
  * Consumes a token stream from the Lexer and produces an ESTree-compatible
- * AST. Currently implements Program node with module/script source type
- * selection. Statement parsing will be expanded by subsequent issues.
+ * AST. Implements full statement parsing with dispatch based on current
+ * token type, and basic expression parsing for statement contexts.
  *
  * @module parser/parser
  */
 
 import type * as AST from '../ast/types.js';
+import type { Token } from './token.js';
 import { Lexer } from './lexer.js';
 import { TokenType } from './token-types.js';
 import { tokenTypeName } from './token-types.js';
+import type { ParserContext } from './statements.js';
+import {
+  parseBlockStatement,
+  parseEmptyStatement,
+  parseDebuggerStatement,
+  parseReturnStatement,
+  parseThrowStatement,
+  parseBreakStatement,
+  parseContinueStatement,
+  parseIfStatement,
+  parseWhileStatement,
+  parseDoWhileStatement,
+  parseForStatement,
+  parseSwitchStatement,
+  parseTryStatement,
+  parseWithStatement,
+  parseLabeledStatement,
+  parseVariableDeclaration,
+  parseExpressionStatement,
+} from './statements.js';
 
 /**
  * Options for the parser.
@@ -31,11 +52,13 @@ export interface ParseOptions {
  * Internal state fields are mutable (documented exception for parser
  * state machine pattern).
  */
-export class Parser {
+export class Parser implements ParserContext {
   /** The lexer producing the token stream. */
   private lexer: Lexer;
   /** Whether parsing as module or script. */
   private sourceType: 'module' | 'script';
+  /** Whether `in` operator is allowed in current expression context. */
+  allowIn: boolean = true;
 
   /**
    * Create a new Parser for the given source text.
@@ -50,6 +73,59 @@ export class Parser {
 
     this.sourceType = sourceType;
     this.lexer = new Lexer(source, isStrict, allowHashBang);
+  }
+
+  /**
+   * Get the current token.
+   */
+  get token(): Token {
+    return this.lexer.token;
+  }
+
+  /**
+   * Whether a line terminator preceded the current token.
+   */
+  get hadLineTerminatorBefore(): boolean {
+    return this.lexer.hadLineTerminatorBefore;
+  }
+
+  /**
+   * Advance to the next token and return the previous one.
+   *
+   * @returns The previous token.
+   */
+  next(): Token {
+    return this.lexer.next();
+  }
+
+  /**
+   * Expect and consume a specific token type.
+   *
+   * @param type - The expected token type.
+   * @returns The consumed token.
+   */
+  expect(type: number): Token {
+    return this.lexer.expect(type);
+  }
+
+  /**
+   * Check if current token is a specific type.
+   *
+   * @param type - The token type to check.
+   * @returns True if current token matches.
+   */
+  is(type: number): boolean {
+    return this.lexer.is(type);
+  }
+
+  /**
+   * Consume a token if it matches the type.
+   *
+   * @param type - The token type to try to consume.
+   * @returns True if consumed.
+   */
+  eat(type: number): boolean {
+    return this.lexer.eat(type);
   }
 
   /**
@@ -82,32 +158,644 @@ export class Parser {
   }
 
   /**
-   * Parse a single statement or module declaration.
+   * Parse a single statement, dispatching based on current token type.
    *
-   * This is a placeholder that handles only semicolons (empty statements)
-   * for now. Full statement parsing will be implemented by issues #19,
-   * #22, and #24.
-   *
-   * @returns The parsed statement or module declaration AST node.
-   * @throws {SyntaxError} For unrecognized tokens (statement parsing not
-   *   yet implemented).
+   * @returns The parsed statement AST node.
    */
-  parseStatement(): AST.Statement | AST.ModuleDeclaration {
-    const token = this.lexer.token;
+  parseStatement(): AST.Statement {
+    const tokenType = this.lexer.token.type;
 
-    // Handle empty statements (bare semicolons)
-    if (token.type === TokenType.Semicolon) {
+    switch (tokenType) {
+      case TokenType.Semicolon:
+        return parseEmptyStatement(this);
+      case TokenType.LeftBrace:
+        return parseBlockStatement(this);
+      case TokenType.If:
+        return parseIfStatement(this);
+      case TokenType.While:
+        return parseWhileStatement(this);
+      case TokenType.Do:
+        return parseDoWhileStatement(this);
+      case TokenType.For:
+        return parseForStatement(this);
+      case TokenType.Break:
+        return parseBreakStatement(this);
+      case TokenType.Continue:
+        return parseContinueStatement(this);
+      case TokenType.Return:
+        return parseReturnStatement(this);
+      case TokenType.Throw:
+        return parseThrowStatement(this);
+      case TokenType.Switch:
+        return parseSwitchStatement(this);
+      case TokenType.Try:
+        return parseTryStatement(this);
+      case TokenType.With:
+        return parseWithStatement(this);
+      case TokenType.Debugger:
+        return parseDebuggerStatement(this);
+      case TokenType.Var:
+      case TokenType.Let:
+      case TokenType.Const:
+        return parseVariableDeclaration(this);
+      case TokenType.Identifier: {
+        // Check for labeled statement: identifier followed by colon
+        const state = this.lexer.saveState();
+        const identToken = this.lexer.token;
+        this.lexer.next();
+        if (this.lexer.is(TokenType.Colon)) {
+          return parseLabeledStatement(this, identToken);
+        }
+        // Not a label, restore and parse as expression statement
+        this.lexer.restoreState(state);
+        return parseExpressionStatement(this);
+      }
+      default:
+        // Expression statement (for identifiers, literals, unary ops, etc.)
+        return parseExpressionStatement(this);
+    }
+  }
+
+  /**
+   * Parse an expression (comma expression allowed).
+   *
+   * Parses assignment expressions separated by commas. If more than one
+   * is found, wraps in a SequenceExpression.
+   *
+   * @returns The parsed expression AST node.
+   */
+  parseExpression(): AST.Expression {
+    const expr = this.parseAssignmentExpression();
+
+    if (!this.lexer.is(TokenType.Comma)) {
+      return expr;
+    }
+
+    const expressions: Array<AST.Expression> = [expr];
+    while (this.lexer.is(TokenType.Comma)) {
       this.lexer.next();
+      expressions.push(this.parseAssignmentExpression());
+    }
+
+    return Object.freeze({
+      type: 'SequenceExpression' as const,
+      start: expressions[0].start,
+      end: expressions[expressions.length - 1].end,
+      expressions: Object.freeze(expressions),
+    });
+  }
+
+  /**
+   * Parse an assignment expression.
+   *
+   * Currently handles primary expressions, unary prefix ops, binary ops
+   * with precedence, member access, call expressions, and assignments.
+   * Full expression parsing will be expanded in subsequent issues.
+   *
+   * @returns The parsed expression AST node.
+   */
+  parseAssignmentExpression(): AST.Expression {
+    const left = this.parseConditionalExpression();
+
+    // Check for assignment operators
+    if (isAssignmentOperator(this.lexer.token.type)) {
+      const opToken = this.lexer.token;
+      const operator = getAssignmentOperator(opToken.type);
+      this.lexer.next();
+      const right = this.parseAssignmentExpression();
       return Object.freeze({
-        type: 'EmptyStatement' as const,
-        start: token.start,
-        end: token.end,
+        type: 'AssignmentExpression' as const,
+        start: left.start,
+        end: right.end,
+        operator,
+        left: left as AST.Pattern | AST.Expression,
+        right,
       });
     }
 
-    const typeName = tokenTypeName(token.type);
+    return left;
+  }
+
+  /**
+   * Parse a conditional (ternary) expression.
+   *
+   * @returns The parsed expression AST node.
+   */
+  private parseConditionalExpression(): AST.Expression {
+    const expr = this.parseBinaryExpression(0);
+
+    if (this.lexer.is(TokenType.QuestionMark)) {
+      this.lexer.next();
+      const consequent = this.parseAssignmentExpression();
+      this.lexer.expect(TokenType.Colon);
+      const alternate = this.parseAssignmentExpression();
+      return Object.freeze({
+        type: 'ConditionalExpression' as const,
+        start: expr.start,
+        end: alternate.end,
+        test: expr,
+        consequent,
+        alternate,
+      });
+    }
+
+    return expr;
+  }
+
+  /**
+   * Parse a binary expression with operator precedence climbing.
+   *
+   * Uses an iterative approach with precedence levels.
+   *
+   * @param minPrecedence - The minimum precedence level to parse.
+   * @returns The parsed expression AST node.
+   */
+  private parseBinaryExpression(minPrecedence: number): AST.Expression {
+    let left = this.parseUnaryExpression();
+
+    // Iterative precedence climbing
+    while (true) {
+      const tokenType = this.lexer.token.type;
+      // Skip `in` operator when not allowed (e.g., in for-loop headers)
+      if (tokenType === TokenType.In && !this.allowIn) {
+        break;
+      }
+      const precedence = getBinaryPrecedence(tokenType);
+      if (precedence <= minPrecedence) {
+        break;
+      }
+
+      const opToken = this.lexer.token;
+      const isLogical = isLogicalOperator(opToken.type);
+      this.lexer.next();
+      const right = this.parseBinaryExpression(precedence);
+
+      if (isLogical) {
+        left = Object.freeze({
+          type: 'LogicalExpression' as const,
+          start: left.start,
+          end: right.end,
+          operator: getLogicalOperator(opToken.type),
+          left,
+          right,
+        });
+      } else {
+        left = Object.freeze({
+          type: 'BinaryExpression' as const,
+          start: left.start,
+          end: right.end,
+          operator: getBinaryOperator(opToken.type),
+          left,
+          right,
+        });
+      }
+    }
+
+    return left;
+  }
+
+  /**
+   * Parse a unary expression (prefix operators).
+   *
+   * @returns The parsed expression AST node.
+   */
+  private parseUnaryExpression(): AST.Expression {
+    const token = this.lexer.token;
+
+    // Prefix unary operators
+    if (isUnaryOperator(token.type)) {
+      const operator = getUnaryOperator(token.type);
+      this.lexer.next();
+      const argument = this.parseUnaryExpression();
+      return Object.freeze({
+        type: 'UnaryExpression' as const,
+        start: token.start,
+        end: argument.end,
+        operator,
+        prefix: true,
+        argument,
+      });
+    }
+
+    // Prefix update operators (++ / --)
+    if (token.type === TokenType.PlusPlus || token.type === TokenType.MinusMinus) {
+      const operator = token.type === TokenType.PlusPlus ? '++' : '--';
+      this.lexer.next();
+      const argument = this.parseUnaryExpression();
+      return Object.freeze({
+        type: 'UpdateExpression' as const,
+        start: token.start,
+        end: argument.end,
+        operator: operator as AST.UpdateOperator,
+        argument,
+        prefix: true,
+      });
+    }
+
+    return this.parsePostfixExpression();
+  }
+
+  /**
+   * Parse postfix expressions (++, --).
+   *
+   * @returns The parsed expression AST node.
+   */
+  private parsePostfixExpression(): AST.Expression {
+    const expr = this.parseCallExpression();
+
+    if (!this.lexer.hadLineTerminatorBefore) {
+      if (this.lexer.is(TokenType.PlusPlus) || this.lexer.is(TokenType.MinusMinus)) {
+        const opToken = this.lexer.token;
+        const operator = opToken.type === TokenType.PlusPlus ? '++' : '--';
+        this.lexer.next();
+        return Object.freeze({
+          type: 'UpdateExpression' as const,
+          start: expr.start,
+          end: opToken.end,
+          operator: operator as AST.UpdateOperator,
+          argument: expr,
+          prefix: false,
+        });
+      }
+    }
+
+    return expr;
+  }
+
+  /**
+   * Parse call and member expressions iteratively.
+   *
+   * @returns The parsed expression AST node.
+   */
+  private parseCallExpression(): AST.Expression {
+    let expr = this.parsePrimaryExpression();
+
+    while (true) {
+      if (this.lexer.is(TokenType.Dot)) {
+        this.lexer.next();
+        const propToken = this.lexer.token;
+        // Allow keywords as property names
+        this.lexer.next();
+        const property: AST.Identifier = Object.freeze({
+          type: 'Identifier' as const,
+          start: propToken.start,
+          end: propToken.end,
+          name: propToken.value as string,
+        });
+        expr = Object.freeze({
+          type: 'MemberExpression' as const,
+          start: expr.start,
+          end: property.end,
+          object: expr,
+          property,
+          computed: false,
+          optional: false,
+        });
+      } else if (this.lexer.is(TokenType.LeftBracket)) {
+        this.lexer.next();
+        const property = this.parseExpression();
+        const endToken = this.lexer.expect(TokenType.RightBracket);
+        expr = Object.freeze({
+          type: 'MemberExpression' as const,
+          start: expr.start,
+          end: endToken.end,
+          object: expr,
+          property,
+          computed: true,
+          optional: false,
+        });
+      } else if (this.lexer.is(TokenType.LeftParen)) {
+        this.lexer.next();
+        const args: Array<AST.Expression | AST.SpreadElement> = [];
+        while (!this.lexer.is(TokenType.RightParen) && !this.lexer.is(TokenType.EOF)) {
+          if (args.length > 0) {
+            this.lexer.expect(TokenType.Comma);
+          }
+          if (this.lexer.is(TokenType.Ellipsis)) {
+            const spreadStart = this.lexer.token.start;
+            this.lexer.next();
+            const argument = this.parseAssignmentExpression();
+            args.push(Object.freeze({
+              type: 'SpreadElement' as const,
+              start: spreadStart,
+              end: argument.end,
+              argument,
+            }));
+          } else {
+            args.push(this.parseAssignmentExpression());
+          }
+        }
+        const endToken = this.lexer.expect(TokenType.RightParen);
+        expr = Object.freeze({
+          type: 'CallExpression' as const,
+          start: expr.start,
+          end: endToken.end,
+          callee: expr,
+          arguments: Object.freeze(args),
+          optional: false,
+        });
+      } else {
+        break;
+      }
+    }
+
+    return expr;
+  }
+
+  /**
+   * Parse a primary expression (literals, identifiers, grouped expressions).
+   *
+   * @returns The parsed expression AST node.
+   */
+  private parsePrimaryExpression(): AST.Expression {
+    const token = this.lexer.token;
+
+    switch (token.type) {
+      case TokenType.Identifier:
+      case TokenType.Let:
+      case TokenType.Of:
+      case TokenType.From:
+      case TokenType.As:
+      case TokenType.Get:
+      case TokenType.Set:
+      case TokenType.Static:
+      case TokenType.Async:
+      case TokenType.Yield:
+      case TokenType.Await: {
+        this.lexer.next();
+        return Object.freeze({
+          type: 'Identifier' as const,
+          start: token.start,
+          end: token.end,
+          name: token.value as string,
+        });
+      }
+
+      case TokenType.NumericLiteral:
+      case TokenType.BigIntLiteral: {
+        this.lexer.next();
+        return Object.freeze({
+          type: 'Literal' as const,
+          start: token.start,
+          end: token.end,
+          value: token.value as number | bigint,
+          raw: token.raw,
+        });
+      }
+
+      case TokenType.StringLiteral: {
+        this.lexer.next();
+        return Object.freeze({
+          type: 'Literal' as const,
+          start: token.start,
+          end: token.end,
+          value: token.value as string,
+          raw: token.raw,
+        });
+      }
+
+      case TokenType.True:
+      case TokenType.False: {
+        this.lexer.next();
+        return Object.freeze({
+          type: 'Literal' as const,
+          start: token.start,
+          end: token.end,
+          value: token.value as boolean,
+          raw: token.raw,
+        });
+      }
+
+      case TokenType.Null: {
+        this.lexer.next();
+        return Object.freeze({
+          type: 'Literal' as const,
+          start: token.start,
+          end: token.end,
+          value: null,
+          raw: token.raw,
+        });
+      }
+
+      case TokenType.This: {
+        this.lexer.next();
+        return Object.freeze({
+          type: 'ThisExpression' as const,
+          start: token.start,
+          end: token.end,
+        });
+      }
+
+      case TokenType.LeftParen: {
+        this.lexer.next();
+        const expr = this.parseExpression();
+        this.lexer.expect(TokenType.RightParen);
+        return expr;
+      }
+
+      case TokenType.LeftBracket: {
+        return this.parseArrayExpression();
+      }
+
+      case TokenType.LeftBrace: {
+        return this.parseObjectExpression();
+      }
+
+      case TokenType.New: {
+        return this.parseNewExpression();
+      }
+
+      default: {
+        const typeName = tokenTypeName(token.type);
+        throw new SyntaxError(
+          `Unexpected token ${typeName} at position ${token.start}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Parse an array expression: [elements]
+   *
+   * @returns The parsed ArrayExpression AST node.
+   */
+  private parseArrayExpression(): AST.ArrayExpression {
+    const start = this.lexer.token.start;
+    this.lexer.next(); // consume '['
+
+    const elements: Array<AST.Expression | AST.SpreadElement | null> = [];
+    while (!this.lexer.is(TokenType.RightBracket) && !this.lexer.is(TokenType.EOF)) {
+      if (this.lexer.is(TokenType.Comma)) {
+        elements.push(null);
+        this.lexer.next();
+        continue;
+      }
+      if (this.lexer.is(TokenType.Ellipsis)) {
+        const spreadStart = this.lexer.token.start;
+        this.lexer.next();
+        const argument = this.parseAssignmentExpression();
+        elements.push(Object.freeze({
+          type: 'SpreadElement' as const,
+          start: spreadStart,
+          end: argument.end,
+          argument,
+        }));
+      } else {
+        elements.push(this.parseAssignmentExpression());
+      }
+      if (!this.lexer.is(TokenType.RightBracket)) {
+        this.lexer.expect(TokenType.Comma);
+      }
+    }
+
+    const endToken = this.lexer.expect(TokenType.RightBracket);
+
+    return Object.freeze({
+      type: 'ArrayExpression' as const,
+      start,
+      end: endToken.end,
+      elements: Object.freeze(elements),
+    });
+  }
+
+  /**
+   * Parse an object expression: { properties }
+   *
+   * @returns The parsed ObjectExpression AST node.
+   */
+  private parseObjectExpression(): AST.ObjectExpression {
+    const start = this.lexer.token.start;
+    this.lexer.next(); // consume '{'
+
+    const properties: Array<AST.Property | AST.SpreadElement> = [];
+    while (!this.lexer.is(TokenType.RightBrace) && !this.lexer.is(TokenType.EOF)) {
+      if (properties.length > 0) {
+        this.lexer.expect(TokenType.Comma);
+        if (this.lexer.is(TokenType.RightBrace)) {
+          break; // trailing comma
+        }
+      }
+
+      if (this.lexer.is(TokenType.Ellipsis)) {
+        const spreadStart = this.lexer.token.start;
+        this.lexer.next();
+        const argument = this.parseAssignmentExpression();
+        properties.push(Object.freeze({
+          type: 'SpreadElement' as const,
+          start: spreadStart,
+          end: argument.end,
+          argument,
+        }));
+        continue;
+      }
+
+      // Parse property key
+      const keyToken = this.lexer.token;
+      const key: AST.Expression = this.parsePrimaryExpression();
+
+      // Shorthand property: { x }
+      if (!this.lexer.is(TokenType.Colon) && key.type === 'Identifier') {
+        properties.push(Object.freeze({
+          type: 'Property' as const,
+          start: key.start,
+          end: key.end,
+          key,
+          value: key,
+          kind: 'init' as const,
+          method: false,
+          shorthand: true,
+          computed: false,
+        }));
+        continue;
+      }
+
+      // Regular property: key: value
+      this.lexer.expect(TokenType.Colon);
+      const value = this.parseAssignmentExpression();
+      properties.push(Object.freeze({
+        type: 'Property' as const,
+        start: keyToken.start,
+        end: value.end,
+        key,
+        value,
+        kind: 'init' as const,
+        method: false,
+        shorthand: false,
+        computed: false,
+      }));
+    }
+
+    const endToken = this.lexer.expect(TokenType.RightBrace);
+
+    return Object.freeze({
+      type: 'ObjectExpression' as const,
+      start,
+      end: endToken.end,
+      properties: Object.freeze(properties),
+    });
+  }
+
+  /**
+   * Parse a new expression: new Callee(args)
+   *
+   * @returns The parsed NewExpression AST node.
+   */
+  private parseNewExpression(): AST.NewExpression {
+    const start = this.lexer.token.start;
+    this.lexer.next(); // consume 'new'
+
+    const callee = this.parsePrimaryExpression();
+    const args: Array<AST.Expression | AST.SpreadElement> = [];
+
+    if (this.lexer.is(TokenType.LeftParen)) {
+      this.lexer.next();
+      while (!this.lexer.is(TokenType.RightParen) && !this.lexer.is(TokenType.EOF)) {
+        if (args.length > 0) {
+          this.lexer.expect(TokenType.Comma);
+        }
+        args.push(this.parseAssignmentExpression());
+      }
+      const endToken = this.lexer.expect(TokenType.RightParen);
+      return Object.freeze({
+        type: 'NewExpression' as const,
+        start,
+        end: endToken.end,
+        callee,
+        arguments: Object.freeze(args),
+      });
+    }
+
+    return Object.freeze({
+      type: 'NewExpression' as const,
+      start,
+      end: callee.end,
+      callee,
+      arguments: Object.freeze(args),
+    });
+  }
+
+  /**
+   * Parse a binding pattern (identifier or destructuring).
+   * Currently supports identifiers only; full destructuring in later issue.
+   *
+   * @returns The parsed Pattern AST node.
+   */
+  parseBindingPattern(): AST.Pattern {
+    const token = this.lexer.token;
+    if (token.type === TokenType.Identifier ||
+        token.type === TokenType.Let ||
+        token.type === TokenType.Yield ||
+        token.type === TokenType.Await) {
+      this.lexer.next();
+      return Object.freeze({
+        type: 'Identifier' as const,
+        start: token.start,
+        end: token.end,
+        name: token.value as string,
+      });
+    }
     throw new SyntaxError(
-      `Statement parsing not yet implemented for ${typeName} at position ${token.start}`,
+      `Expected binding pattern at position ${token.start}`,
     );
   }
 }
@@ -124,4 +812,166 @@ export class Parser {
 export const parse = (source: string, options?: ParseOptions): AST.Program => {
   const parser = new Parser(source, options);
   return parser.parseProgram();
+};
+
+// ============================================================
+// Operator helpers
+// ============================================================
+
+/**
+ * Check if a token type is an assignment operator.
+ *
+ * @param type - The token type to check.
+ * @returns True if the token is an assignment operator.
+ */
+const isAssignmentOperator = (type: number): boolean => {
+  return type >= TokenType.Equals && type <= TokenType.QuestionQuestionEquals;
+};
+
+/**
+ * Get the assignment operator string for a token type.
+ *
+ * @param type - The token type.
+ * @returns The operator string.
+ */
+const getAssignmentOperator = (type: number): AST.AssignmentOperator => {
+  const operators: ReadonlyArray<AST.AssignmentOperator> = [
+    '=', '+=', '-=', '*=', '/=', '%=', '**=',
+    '&=', '|=', '^=', '<<=', '>>=', '>>>=',
+    '&&=', '||=', '??=',
+  ];
+  return operators[type - TokenType.Equals];
+};
+
+/**
+ * Get the precedence level of a binary operator token.
+ *
+ * @param type - The token type.
+ * @returns The precedence level (0 if not a binary operator).
+ */
+const getBinaryPrecedence = (type: number): number => {
+  switch (type) {
+    case TokenType.PipePipe: return 2;
+    case TokenType.AmpersandAmpersand: return 3;
+    case TokenType.QuestionQuestion: return 2;
+    case TokenType.Pipe: return 4;
+    case TokenType.Caret: return 5;
+    case TokenType.Ampersand: return 6;
+    case TokenType.EqualsEquals:
+    case TokenType.ExclamationEquals:
+    case TokenType.EqualsEqualsEquals:
+    case TokenType.ExclamationEqualsEquals: return 7;
+    case TokenType.LessThan:
+    case TokenType.GreaterThan:
+    case TokenType.LessThanEquals:
+    case TokenType.GreaterThanEquals:
+    case TokenType.Instanceof:
+    case TokenType.In: return 8;
+    case TokenType.LeftShift:
+    case TokenType.RightShift:
+    case TokenType.UnsignedRightShift: return 9;
+    case TokenType.Plus:
+    case TokenType.Minus: return 10;
+    case TokenType.Star:
+    case TokenType.Slash:
+    case TokenType.Percent: return 11;
+    case TokenType.StarStar: return 12;
+    default: return 0;
+  }
+};
+
+/**
+ * Check if a token type is a logical operator.
+ *
+ * @param type - The token type.
+ * @returns True if logical operator (||, &&, ??).
+ */
+const isLogicalOperator = (type: number): boolean => {
+  return type === TokenType.PipePipe ||
+         type === TokenType.AmpersandAmpersand ||
+         type === TokenType.QuestionQuestion;
+};
+
+/**
+ * Get the logical operator string for a token type.
+ *
+ * @param type - The token type.
+ * @returns The operator string.
+ */
+const getLogicalOperator = (type: number): AST.LogicalOperator => {
+  switch (type) {
+    case TokenType.PipePipe: return '||';
+    case TokenType.AmpersandAmpersand: return '&&';
+    case TokenType.QuestionQuestion: return '??';
+    default: return '||';
+  }
+};
+
+/**
+ * Get the binary operator string for a token type.
+ *
+ * @param type - The token type.
+ * @returns The operator string.
+ */
+const getBinaryOperator = (type: number): AST.BinaryOperator => {
+  switch (type) {
+    case TokenType.Plus: return '+';
+    case TokenType.Minus: return '-';
+    case TokenType.Star: return '*';
+    case TokenType.Slash: return '/';
+    case TokenType.Percent: return '%';
+    case TokenType.StarStar: return '**';
+    case TokenType.Ampersand: return '&';
+    case TokenType.Pipe: return '|';
+    case TokenType.Caret: return '^';
+    case TokenType.LeftShift: return '<<';
+    case TokenType.RightShift: return '>>';
+    case TokenType.UnsignedRightShift: return '>>>';
+    case TokenType.EqualsEquals: return '==';
+    case TokenType.ExclamationEquals: return '!=';
+    case TokenType.EqualsEqualsEquals: return '===';
+    case TokenType.ExclamationEqualsEquals: return '!==';
+    case TokenType.LessThan: return '<';
+    case TokenType.GreaterThan: return '>';
+    case TokenType.LessThanEquals: return '<=';
+    case TokenType.GreaterThanEquals: return '>=';
+    case TokenType.In: return 'in';
+    case TokenType.Instanceof: return 'instanceof';
+    default: return '+';
+  }
+};
+
+/**
+ * Check if a token type is a unary prefix operator.
+ *
+ * @param type - The token type.
+ * @returns True if it's a unary prefix operator.
+ */
+const isUnaryOperator = (type: number): boolean => {
+  return type === TokenType.Minus ||
+         type === TokenType.Plus ||
+         type === TokenType.Exclamation ||
+         type === TokenType.Tilde ||
+         type === TokenType.Typeof ||
+         type === TokenType.Void ||
+         type === TokenType.Delete;
+};
+
+/**
+ * Get the unary operator string for a token type.
+ *
+ * @param type - The token type.
+ * @returns The operator string.
+ */
+const getUnaryOperator = (type: number): AST.UnaryOperator => {
+  switch (type) {
+    case TokenType.Minus: return '-';
+    case TokenType.Plus: return '+';
+    case TokenType.Exclamation: return '!';
+    case TokenType.Tilde: return '~';
+    case TokenType.Typeof: return 'typeof';
+    case TokenType.Void: return 'void';
+    case TokenType.Delete: return 'delete';
+    default: return '-';
+  }
 };

--- a/src/parser/statements.ts
+++ b/src/parser/statements.ts
@@ -1,0 +1,784 @@
+/**
+ * Statement parsing functions for the Steamroller parser.
+ *
+ * Provides parsing logic for all JavaScript statement types including
+ * control flow, loops, variable declarations, and compound statements.
+ * Works with the Parser class by accepting a ParserContext interface
+ * that abstracts lexer operations and expression parsing.
+ *
+ * @module parser/statements
+ */
+
+import type * as AST from '../ast/types.js';
+import type { Token } from './token.js';
+import { TokenType } from './token-types.js';
+
+/**
+ * Context interface required by statement parsing functions.
+ * Abstracts the parser/lexer operations needed for statement parsing.
+ */
+export interface ParserContext {
+  /** The current token. */
+  readonly token: Token;
+  /** Whether a line terminator preceded the current token. */
+  readonly hadLineTerminatorBefore: boolean;
+  /** Whether `in` operator is allowed in expressions (false in for-loop headers). */
+  allowIn: boolean;
+  /** Advance to the next token and return the previous one. */
+  next(): Token;
+  /** Expect and consume a specific token type. */
+  expect(type: number): Token;
+  /** Check if current token is a specific type. */
+  is(type: number): boolean;
+  /** Consume a token if it matches the type, returns true if consumed. */
+  eat(type: number): boolean;
+  /** Parse an expression (delegated to expression parser). */
+  parseExpression(): AST.Expression;
+  /** Parse an assignment expression (single, no comma). */
+  parseAssignmentExpression(): AST.Expression;
+  /** Parse a statement (recursive via parser). */
+  parseStatement(): AST.Statement;
+  /** Parse a pattern for destructuring. */
+  parseBindingPattern(): AST.Pattern;
+}
+
+/**
+ * Parse a block statement: { stmt* }
+ *
+ * @param ctx - The parser context.
+ * @returns A BlockStatement AST node.
+ */
+export const parseBlockStatement = (ctx: ParserContext): AST.BlockStatement => {
+  const start = ctx.token.start;
+  ctx.expect(TokenType.LeftBrace);
+
+  const body: Array<AST.Statement> = [];
+  while (!ctx.is(TokenType.RightBrace) && !ctx.is(TokenType.EOF)) {
+    body.push(ctx.parseStatement());
+  }
+
+  const end = ctx.token.end;
+  ctx.expect(TokenType.RightBrace);
+
+  return Object.freeze({
+    type: 'BlockStatement' as const,
+    start,
+    end,
+    body: Object.freeze(body),
+  });
+};
+
+/**
+ * Parse an empty statement: ;
+ *
+ * @param ctx - The parser context.
+ * @returns An EmptyStatement AST node.
+ */
+export const parseEmptyStatement = (ctx: ParserContext): AST.EmptyStatement => {
+  const token = ctx.token;
+  ctx.next();
+  return Object.freeze({
+    type: 'EmptyStatement' as const,
+    start: token.start,
+    end: token.end,
+  });
+};
+
+/**
+ * Parse a debugger statement: debugger;
+ *
+ * @param ctx - The parser context.
+ * @returns A DebuggerStatement AST node.
+ */
+export const parseDebuggerStatement = (ctx: ParserContext): AST.DebuggerStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'debugger'
+  const end = ctx.token.end;
+  consumeSemicolon(ctx);
+  return Object.freeze({
+    type: 'DebuggerStatement' as const,
+    start,
+    end: end,
+  });
+};
+
+/**
+ * Parse a return statement: return [expr];
+ *
+ * Handles ASI: if a line terminator follows `return`, the argument is null.
+ *
+ * @param ctx - The parser context.
+ * @returns A ReturnStatement AST node.
+ */
+export const parseReturnStatement = (ctx: ParserContext): AST.ReturnStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'return'
+
+  let argument: AST.Expression | null = null;
+  // ASI: if line terminator before next token, or next is ; or } or EOF
+  if (!ctx.hadLineTerminatorBefore &&
+      !ctx.is(TokenType.Semicolon) &&
+      !ctx.is(TokenType.RightBrace) &&
+      !ctx.is(TokenType.EOF)) {
+    argument = ctx.parseExpression();
+  }
+
+  const end = argument !== null ? argument.end : start + 6; // 'return'.length
+  consumeSemicolon(ctx);
+
+  return Object.freeze({
+    type: 'ReturnStatement' as const,
+    start,
+    end,
+    argument,
+  });
+};
+
+/**
+ * Parse a throw statement: throw expr;
+ *
+ * Throw requires an expression on the same line (no ASI before expression).
+ *
+ * @param ctx - The parser context.
+ * @returns A ThrowStatement AST node.
+ * @throws {SyntaxError} If no expression follows throw on the same line.
+ */
+export const parseThrowStatement = (ctx: ParserContext): AST.ThrowStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'throw'
+
+  if (ctx.hadLineTerminatorBefore) {
+    throw new SyntaxError(
+      `Illegal newline after throw at position ${start}`,
+    );
+  }
+
+  const argument = ctx.parseExpression();
+  const end = argument.end;
+  consumeSemicolon(ctx);
+
+  return Object.freeze({
+    type: 'ThrowStatement' as const,
+    start,
+    end,
+    argument,
+  });
+};
+
+/**
+ * Parse a break statement: break [label];
+ *
+ * Handles ASI: if a line terminator follows `break`, the label is null.
+ *
+ * @param ctx - The parser context.
+ * @returns A BreakStatement AST node.
+ */
+export const parseBreakStatement = (ctx: ParserContext): AST.BreakStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'break'
+
+  let label: AST.Identifier | null = null;
+  if (!ctx.hadLineTerminatorBefore && ctx.is(TokenType.Identifier)) {
+    const labelToken = ctx.token;
+    ctx.next();
+    label = Object.freeze({
+      type: 'Identifier' as const,
+      start: labelToken.start,
+      end: labelToken.end,
+      name: labelToken.value as string,
+    });
+  }
+
+  const end = label !== null ? label.end : start + 5; // 'break'.length
+  consumeSemicolon(ctx);
+
+  return Object.freeze({
+    type: 'BreakStatement' as const,
+    start,
+    end,
+    label,
+  });
+};
+
+/**
+ * Parse a continue statement: continue [label];
+ *
+ * Handles ASI: if a line terminator follows `continue`, the label is null.
+ *
+ * @param ctx - The parser context.
+ * @returns A ContinueStatement AST node.
+ */
+export const parseContinueStatement = (ctx: ParserContext): AST.ContinueStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'continue'
+
+  let label: AST.Identifier | null = null;
+  if (!ctx.hadLineTerminatorBefore && ctx.is(TokenType.Identifier)) {
+    const labelToken = ctx.token;
+    ctx.next();
+    label = Object.freeze({
+      type: 'Identifier' as const,
+      start: labelToken.start,
+      end: labelToken.end,
+      name: labelToken.value as string,
+    });
+  }
+
+  const end = label !== null ? label.end : start + 8; // 'continue'.length
+  consumeSemicolon(ctx);
+
+  return Object.freeze({
+    type: 'ContinueStatement' as const,
+    start,
+    end,
+    label,
+  });
+};
+
+/**
+ * Parse an if statement: if (test) consequent [else alternate]
+ *
+ * @param ctx - The parser context.
+ * @returns An IfStatement AST node.
+ */
+export const parseIfStatement = (ctx: ParserContext): AST.IfStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'if'
+  ctx.expect(TokenType.LeftParen);
+  const test = ctx.parseExpression();
+  ctx.expect(TokenType.RightParen);
+  const consequent = ctx.parseStatement();
+
+  let alternate: AST.Statement | null = null;
+  if (ctx.is(TokenType.Else)) {
+    ctx.next(); // consume 'else'
+    alternate = ctx.parseStatement();
+  }
+
+  const end = alternate !== null ? alternate.end : consequent.end;
+
+  return Object.freeze({
+    type: 'IfStatement' as const,
+    start,
+    end,
+    test,
+    consequent,
+    alternate,
+  });
+};
+
+/**
+ * Parse a while statement: while (test) body
+ *
+ * @param ctx - The parser context.
+ * @returns A WhileStatement AST node.
+ */
+export const parseWhileStatement = (ctx: ParserContext): AST.WhileStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'while'
+  ctx.expect(TokenType.LeftParen);
+  const test = ctx.parseExpression();
+  ctx.expect(TokenType.RightParen);
+  const body = ctx.parseStatement();
+
+  return Object.freeze({
+    type: 'WhileStatement' as const,
+    start,
+    end: body.end,
+    test,
+    body,
+  });
+};
+
+/**
+ * Parse a do-while statement: do body while (test);
+ *
+ * @param ctx - The parser context.
+ * @returns A DoWhileStatement AST node.
+ */
+export const parseDoWhileStatement = (ctx: ParserContext): AST.DoWhileStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'do'
+  const body = ctx.parseStatement();
+  ctx.expect(TokenType.While);
+  ctx.expect(TokenType.LeftParen);
+  const test = ctx.parseExpression();
+  const endToken = ctx.expect(TokenType.RightParen);
+  consumeSemicolon(ctx);
+
+  return Object.freeze({
+    type: 'DoWhileStatement' as const,
+    start,
+    end: endToken.end,
+    body,
+    test,
+  });
+};
+
+/**
+ * Parse a for statement: for (...) body
+ *
+ * Distinguishes between for, for-in, and for-of forms by lookahead.
+ *
+ * @param ctx - The parser context.
+ * @returns A ForStatement, ForInStatement, or ForOfStatement AST node.
+ */
+export const parseForStatement = (
+  ctx: ParserContext,
+): AST.ForStatement | AST.ForInStatement | AST.ForOfStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'for'
+
+  // Check for `for await`
+  const isAwait = ctx.is(TokenType.Await);
+  if (isAwait) {
+    ctx.next(); // consume 'await'
+  }
+
+  ctx.expect(TokenType.LeftParen);
+
+  // Empty init: for (; ...)
+  if (ctx.is(TokenType.Semicolon)) {
+    return parseForRegular(ctx, start, null);
+  }
+
+  // var/let/const declaration as init
+  if (ctx.is(TokenType.Var) || ctx.is(TokenType.Let) || ctx.is(TokenType.Const)) {
+    const decl = parseVariableDeclarationNoSemicolon(ctx);
+
+    if (ctx.is(TokenType.In)) {
+      ctx.next(); // consume 'in'
+      const right = ctx.parseExpression();
+      ctx.expect(TokenType.RightParen);
+      const body = ctx.parseStatement();
+      return Object.freeze({
+        type: 'ForInStatement' as const,
+        start,
+        end: body.end,
+        left: decl,
+        right,
+        body,
+      });
+    }
+
+    if (ctx.is(TokenType.Of)) {
+      ctx.next(); // consume 'of'
+      const right = ctx.parseAssignmentExpression();
+      ctx.expect(TokenType.RightParen);
+      const body = ctx.parseStatement();
+      return Object.freeze({
+        type: 'ForOfStatement' as const,
+        start,
+        end: body.end,
+        left: decl,
+        right,
+        body,
+        await: isAwait,
+      });
+    }
+
+    return parseForRegular(ctx, start, decl);
+  }
+
+  // Expression as init (disallow `in` operator to distinguish for-in)
+  const prevAllowIn = ctx.allowIn;
+  ctx.allowIn = false;
+  const initExpr = ctx.parseExpression();
+  ctx.allowIn = prevAllowIn;
+
+  if (ctx.is(TokenType.In)) {
+    ctx.next(); // consume 'in'
+    const right = ctx.parseExpression();
+    ctx.expect(TokenType.RightParen);
+    const body = ctx.parseStatement();
+    return Object.freeze({
+      type: 'ForInStatement' as const,
+      start,
+      end: body.end,
+      left: initExpr as unknown as AST.Pattern,
+      right,
+      body,
+    });
+  }
+
+  if (ctx.is(TokenType.Of)) {
+    ctx.next(); // consume 'of'
+    const right = ctx.parseAssignmentExpression();
+    ctx.expect(TokenType.RightParen);
+    const body = ctx.parseStatement();
+    return Object.freeze({
+      type: 'ForOfStatement' as const,
+      start,
+      end: body.end,
+      left: initExpr as unknown as AST.Pattern,
+      right,
+      body,
+      await: isAwait,
+    });
+  }
+
+  return parseForRegular(ctx, start, initExpr);
+};
+
+/**
+ * Parse the remainder of a regular for statement (after init is parsed).
+ *
+ * @param ctx - The parser context.
+ * @param start - Start position of the for keyword.
+ * @param init - The already-parsed init expression or declaration (or null).
+ * @returns A ForStatement AST node.
+ */
+const parseForRegular = (
+  ctx: ParserContext,
+  start: number,
+  init: AST.VariableDeclaration | AST.Expression | null,
+): AST.ForStatement => {
+  ctx.expect(TokenType.Semicolon);
+
+  const test: AST.Expression | null = ctx.is(TokenType.Semicolon)
+    ? null
+    : ctx.parseExpression();
+  ctx.expect(TokenType.Semicolon);
+
+  const update: AST.Expression | null = ctx.is(TokenType.RightParen)
+    ? null
+    : ctx.parseExpression();
+  ctx.expect(TokenType.RightParen);
+
+  const body = ctx.parseStatement();
+
+  return Object.freeze({
+    type: 'ForStatement' as const,
+    start,
+    end: body.end,
+    init,
+    test,
+    update,
+    body,
+  });
+};
+
+/**
+ * Parse a switch statement: switch (discriminant) { cases }
+ *
+ * @param ctx - The parser context.
+ * @returns A SwitchStatement AST node.
+ */
+export const parseSwitchStatement = (ctx: ParserContext): AST.SwitchStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'switch'
+  ctx.expect(TokenType.LeftParen);
+  const discriminant = ctx.parseExpression();
+  ctx.expect(TokenType.RightParen);
+  ctx.expect(TokenType.LeftBrace);
+
+  const cases: Array<AST.SwitchCase> = [];
+  while (!ctx.is(TokenType.RightBrace) && !ctx.is(TokenType.EOF)) {
+    cases.push(parseSwitchCase(ctx));
+  }
+
+  const endToken = ctx.expect(TokenType.RightBrace);
+
+  return Object.freeze({
+    type: 'SwitchStatement' as const,
+    start,
+    end: endToken.end,
+    discriminant,
+    cases: Object.freeze(cases),
+  });
+};
+
+/**
+ * Parse a single switch case or default clause.
+ *
+ * @param ctx - The parser context.
+ * @returns A SwitchCase AST node.
+ */
+const parseSwitchCase = (ctx: ParserContext): AST.SwitchCase => {
+  const start = ctx.token.start;
+  let test: AST.Expression | null = null;
+
+  if (ctx.is(TokenType.Case)) {
+    ctx.next(); // consume 'case'
+    test = ctx.parseExpression();
+  } else {
+    ctx.expect(TokenType.Default); // consume 'default'
+  }
+
+  ctx.expect(TokenType.Colon);
+
+  const consequent: Array<AST.Statement> = [];
+  while (!ctx.is(TokenType.Case) &&
+         !ctx.is(TokenType.Default) &&
+         !ctx.is(TokenType.RightBrace) &&
+         !ctx.is(TokenType.EOF)) {
+    consequent.push(ctx.parseStatement());
+  }
+
+  const end = consequent.length > 0
+    ? consequent[consequent.length - 1].end
+    : ctx.token.start;
+
+  return Object.freeze({
+    type: 'SwitchCase' as const,
+    start,
+    end,
+    test,
+    consequent: Object.freeze(consequent),
+  });
+};
+
+/**
+ * Parse a try statement: try { } [catch (param) { }] [finally { }]
+ *
+ * Supports optional catch binding (catch without parameter).
+ *
+ * @param ctx - The parser context.
+ * @returns A TryStatement AST node.
+ * @throws {SyntaxError} If neither catch nor finally is present.
+ */
+export const parseTryStatement = (ctx: ParserContext): AST.TryStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'try'
+
+  const block = parseBlockStatement(ctx);
+
+  let handler: AST.CatchClause | null = null;
+  if (ctx.is(TokenType.Catch)) {
+    handler = parseCatchClause(ctx);
+  }
+
+  let finalizer: AST.BlockStatement | null = null;
+  if (ctx.is(TokenType.Finally)) {
+    ctx.next(); // consume 'finally'
+    finalizer = parseBlockStatement(ctx);
+  }
+
+  if (handler === null && finalizer === null) {
+    throw new SyntaxError(
+      `Missing catch or finally after try at position ${start}`,
+    );
+  }
+
+  const end = finalizer !== null ? finalizer.end : (handler !== null ? handler.end : block.end);
+
+  return Object.freeze({
+    type: 'TryStatement' as const,
+    start,
+    end,
+    block,
+    handler,
+    finalizer,
+  });
+};
+
+/**
+ * Parse a catch clause: catch [(param)] { body }
+ *
+ * @param ctx - The parser context.
+ * @returns A CatchClause AST node.
+ */
+const parseCatchClause = (ctx: ParserContext): AST.CatchClause => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'catch'
+
+  let param: AST.Pattern | null = null;
+  if (ctx.is(TokenType.LeftParen)) {
+    ctx.next(); // consume '('
+    param = ctx.parseBindingPattern();
+    ctx.expect(TokenType.RightParen);
+  }
+
+  const body = parseBlockStatement(ctx);
+
+  return Object.freeze({
+    type: 'CatchClause' as const,
+    start,
+    end: body.end,
+    param,
+    body,
+  });
+};
+
+/**
+ * Parse a with statement: with (object) body
+ *
+ * @param ctx - The parser context.
+ * @returns A WithStatement AST node.
+ */
+export const parseWithStatement = (ctx: ParserContext): AST.WithStatement => {
+  const start = ctx.token.start;
+  ctx.next(); // consume 'with'
+  ctx.expect(TokenType.LeftParen);
+  const object = ctx.parseExpression();
+  ctx.expect(TokenType.RightParen);
+  const body = ctx.parseStatement();
+
+  return Object.freeze({
+    type: 'WithStatement' as const,
+    start,
+    end: body.end,
+    object,
+    body,
+  });
+};
+
+/**
+ * Parse a labeled statement: label: stmt
+ *
+ * Called when an identifier followed by colon is detected.
+ *
+ * @param ctx - The parser context.
+ * @param labelToken - The identifier token representing the label.
+ * @returns A LabeledStatement AST node.
+ */
+export const parseLabeledStatement = (
+  ctx: ParserContext,
+  labelToken: Token,
+): AST.LabeledStatement => {
+  const start = labelToken.start;
+  const label: AST.Identifier = Object.freeze({
+    type: 'Identifier' as const,
+    start: labelToken.start,
+    end: labelToken.end,
+    name: labelToken.value as string,
+  });
+
+  ctx.next(); // consume ':'
+  const body = ctx.parseStatement();
+
+  return Object.freeze({
+    type: 'LabeledStatement' as const,
+    start,
+    end: body.end,
+    label,
+    body,
+  });
+};
+
+/**
+ * Parse a variable declaration: var/let/const declarators;
+ *
+ * @param ctx - The parser context.
+ * @returns A VariableDeclaration AST node.
+ */
+export const parseVariableDeclaration = (ctx: ParserContext): AST.VariableDeclaration => {
+  const decl = parseVariableDeclarationNoSemicolon(ctx);
+  consumeSemicolon(ctx);
+  return decl;
+};
+
+/**
+ * Parse a variable declaration without consuming the trailing semicolon.
+ * Used internally for for-loop headers.
+ *
+ * @param ctx - The parser context.
+ * @returns A VariableDeclaration AST node.
+ */
+const parseVariableDeclarationNoSemicolon = (ctx: ParserContext): AST.VariableDeclaration => {
+  const start = ctx.token.start;
+  const kindToken = ctx.token;
+  const kind = kindToken.value as 'var' | 'let' | 'const';
+  ctx.next(); // consume var/let/const
+
+  const declarations: Array<AST.VariableDeclarator> = [];
+  declarations.push(parseVariableDeclarator(ctx));
+
+  while (ctx.is(TokenType.Comma)) {
+    ctx.next(); // consume ','
+    declarations.push(parseVariableDeclarator(ctx));
+  }
+
+  const end = declarations[declarations.length - 1].end;
+
+  return Object.freeze({
+    type: 'VariableDeclaration' as const,
+    start,
+    end,
+    declarations: Object.freeze(declarations),
+    kind,
+  });
+};
+
+/**
+ * Parse a single variable declarator: pattern [= initializer]
+ *
+ * @param ctx - The parser context.
+ * @returns A VariableDeclarator AST node.
+ */
+const parseVariableDeclarator = (ctx: ParserContext): AST.VariableDeclarator => {
+  const id = ctx.parseBindingPattern();
+  let init: AST.Expression | null = null;
+
+  if (ctx.is(TokenType.Equals)) {
+    ctx.next(); // consume '='
+    init = ctx.parseAssignmentExpression();
+  }
+
+  const end = init !== null ? init.end : id.end;
+
+  return Object.freeze({
+    type: 'VariableDeclarator' as const,
+    start: id.start,
+    end,
+    id,
+    init,
+  });
+};
+
+/**
+ * Parse an expression statement: expr;
+ *
+ * Handles ASI and directives (string literal expression statements).
+ *
+ * @param ctx - The parser context.
+ * @returns An ExpressionStatement AST node.
+ */
+export const parseExpressionStatement = (ctx: ParserContext): AST.ExpressionStatement => {
+  const start = ctx.token.start;
+  const expression = ctx.parseExpression();
+  const end = expression.end;
+  consumeSemicolon(ctx);
+
+  // Check for directive (string literal expression statement)
+  const directive = expression.type === 'Literal' && typeof expression.value === 'string'
+    ? expression.value
+    : undefined;
+
+  const node: AST.ExpressionStatement = {
+    type: 'ExpressionStatement' as const,
+    start,
+    end,
+    expression,
+    ...(directive !== undefined ? { directive } : {}),
+  };
+
+  return Object.freeze(node);
+};
+
+/**
+ * Consume a semicolon, applying Automatic Semicolon Insertion rules.
+ *
+ * A semicolon is consumed if present. Otherwise ASI applies when:
+ * - A line terminator preceded the current token
+ * - The current token is }
+ * - The current token is EOF
+ *
+ * @param ctx - The parser context.
+ * @throws {SyntaxError} If no semicolon and ASI does not apply.
+ */
+const consumeSemicolon = (ctx: ParserContext): void => {
+  if (ctx.is(TokenType.Semicolon)) {
+    ctx.next();
+    return;
+  }
+  // ASI: line terminator before current token, or at } or EOF
+  if (ctx.hadLineTerminatorBefore ||
+      ctx.is(TokenType.RightBrace) ||
+      ctx.is(TokenType.EOF)) {
+    return;
+  }
+  throw new SyntaxError(
+    `Expected semicolon at position ${ctx.token.start}`,
+  );
+};

--- a/tests/unit/parser/parser.test.ts
+++ b/tests/unit/parser/parser.test.ts
@@ -123,19 +123,22 @@ describe('Parser', () => {
       expect(program.body[0].type).toBe('EmptyStatement');
     });
 
-    it('should throw for unimplemented statement types', () => {
+    it('should parse identifiers as expression statements', () => {
       const parser = new Parser('foo');
-      expect(() => parser.parseProgram()).toThrow(SyntaxError);
+      const program = parser.parseProgram();
+      expect(program.body.length).toBe(1);
+      expect(program.body[0].type).toBe('ExpressionStatement');
     });
 
-    it('should include token type name in error for unimplemented statements', () => {
-      const parser = new Parser('foo');
-      expect(() => parser.parseProgram()).toThrow(/Identifier/);
-    });
-
-    it('should include position in error for unimplemented statements', () => {
+    it('should parse expression statement with correct position', () => {
       const parser = new Parser('  foo');
-      expect(() => parser.parseProgram()).toThrow(/position 2/);
+      const program = parser.parseProgram();
+      expect(program.body[0].start).toBe(2);
+    });
+
+    it('should throw on truly unexpected tokens', () => {
+      const parser = new Parser(')');
+      expect(() => parser.parseProgram()).toThrow(SyntaxError);
     });
   });
 });
@@ -164,8 +167,9 @@ describe('parse() function', () => {
     expect(program.body[0].type).toBe('EmptyStatement');
   });
 
-  it('should throw on unimplemented statements', () => {
-    expect(() => parse('x')).toThrow(SyntaxError);
+  it('should parse identifiers as expression statements', () => {
+    const program = parse('x');
+    expect(program.body[0].type).toBe('ExpressionStatement');
   });
 
   it('should accept allowHashBang option', () => {

--- a/tests/unit/parser/statements.test.ts
+++ b/tests/unit/parser/statements.test.ts
@@ -1,0 +1,1531 @@
+/**
+ * Tests for statement parsing in the Steamroller parser.
+ *
+ * Covers all statement types: block, empty, debugger, return, throw,
+ * break, continue, if, while, do-while, for, for-in, for-of, switch,
+ * try/catch/finally, with, labeled, variable declarations, and
+ * expression statements.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '../../../src/parser/parser.js';
+
+describe('Statement Parsing', () => {
+  describe('EmptyStatement', () => {
+    it('should parse a single semicolon', () => {
+      const program = parse(';');
+      expect(program.body.length).toBe(1);
+      expect(program.body[0].type).toBe('EmptyStatement');
+    });
+
+    it('should parse multiple semicolons', () => {
+      const program = parse(';;;');
+      expect(program.body.length).toBe(3);
+    });
+
+    it('should set correct positions', () => {
+      const program = parse(';');
+      const stmt = program.body[0];
+      expect(stmt.start).toBe(0);
+      expect(stmt.end).toBe(1);
+    });
+  });
+
+  describe('BlockStatement', () => {
+    it('should parse an empty block', () => {
+      const program = parse('{}');
+      expect(program.body.length).toBe(1);
+      expect(program.body[0].type).toBe('BlockStatement');
+      const block = program.body[0] as { type: string; body: unknown[] };
+      expect(block.body.length).toBe(0);
+    });
+
+    it('should parse a block with statements', () => {
+      const program = parse('{ ; ; }');
+      const block = program.body[0] as { type: string; body: unknown[] };
+      expect(block.body.length).toBe(2);
+    });
+
+    it('should parse nested blocks', () => {
+      const program = parse('{ { } }');
+      const outer = program.body[0] as { type: string; body: Array<{ type: string }> };
+      expect(outer.body[0].type).toBe('BlockStatement');
+    });
+
+    it('should set correct positions for block', () => {
+      const program = parse('{}');
+      const block = program.body[0];
+      expect(block.start).toBe(0);
+      expect(block.end).toBe(2);
+    });
+  });
+
+  describe('DebuggerStatement', () => {
+    it('should parse debugger;', () => {
+      const program = parse('debugger;');
+      expect(program.body[0].type).toBe('DebuggerStatement');
+    });
+
+    it('should parse debugger with ASI', () => {
+      const program = parse('debugger\n;');
+      expect(program.body[0].type).toBe('DebuggerStatement');
+    });
+
+    it('should set correct start position', () => {
+      const program = parse('debugger;');
+      expect(program.body[0].start).toBe(0);
+    });
+  });
+
+  describe('ReturnStatement', () => {
+    it('should parse return with no argument', () => {
+      const program = parse('return;', { sourceType: 'script' });
+      const stmt = program.body[0] as { type: string; argument: unknown };
+      expect(stmt.type).toBe('ReturnStatement');
+      expect(stmt.argument).toBeNull();
+    });
+
+    it('should parse return with expression', () => {
+      const program = parse('return 42;', { sourceType: 'script' });
+      const stmt = program.body[0] as { type: string; argument: { type: string; value: number } };
+      expect(stmt.type).toBe('ReturnStatement');
+      expect(stmt.argument.type).toBe('Literal');
+      expect(stmt.argument.value).toBe(42);
+    });
+
+    it('should handle ASI after return with newline', () => {
+      const program = parse('return\n42;', { sourceType: 'script' });
+      const stmt = program.body[0] as { type: string; argument: unknown };
+      expect(stmt.type).toBe('ReturnStatement');
+      expect(stmt.argument).toBeNull();
+    });
+
+    it('should parse return with identifier', () => {
+      const program = parse('return x;', { sourceType: 'script' });
+      const stmt = program.body[0] as { type: string; argument: { type: string; name: string } };
+      expect(stmt.argument.type).toBe('Identifier');
+      expect(stmt.argument.name).toBe('x');
+    });
+  });
+
+  describe('ThrowStatement', () => {
+    it('should parse throw with expression', () => {
+      const program = parse('throw x;');
+      const stmt = program.body[0] as { type: string; argument: { type: string; name: string } };
+      expect(stmt.type).toBe('ThrowStatement');
+      expect(stmt.argument.type).toBe('Identifier');
+      expect(stmt.argument.name).toBe('x');
+    });
+
+    it('should parse throw with new expression', () => {
+      const program = parse('throw new Error();');
+      const stmt = program.body[0] as { type: string; argument: { type: string } };
+      expect(stmt.type).toBe('ThrowStatement');
+      expect(stmt.argument.type).toBe('NewExpression');
+    });
+
+    it('should throw error on newline after throw', () => {
+      expect(() => parse('throw\nx;')).toThrow(/newline after throw/);
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('throw x;');
+      const stmt = program.body[0] as { type: string; argument: { end: number }; start: number };
+      expect(stmt.start).toBe(0);
+      expect(stmt.argument.end).toBe(7);
+    });
+  });
+
+  describe('BreakStatement', () => {
+    it('should parse break without label', () => {
+      const program = parse('break;');
+      const stmt = program.body[0] as { type: string; label: unknown };
+      expect(stmt.type).toBe('BreakStatement');
+      expect(stmt.label).toBeNull();
+    });
+
+    it('should parse break with label', () => {
+      const program = parse('break foo;');
+      const stmt = program.body[0] as { type: string; label: { type: string; name: string } };
+      expect(stmt.type).toBe('BreakStatement');
+      expect(stmt.label.type).toBe('Identifier');
+      expect(stmt.label.name).toBe('foo');
+    });
+
+    it('should handle ASI: break with newline before label', () => {
+      const program = parse('break\nfoo;');
+      const stmt = program.body[0] as { type: string; label: unknown };
+      expect(stmt.type).toBe('BreakStatement');
+      expect(stmt.label).toBeNull();
+    });
+  });
+
+  describe('ContinueStatement', () => {
+    it('should parse continue without label', () => {
+      const program = parse('continue;');
+      const stmt = program.body[0] as { type: string; label: unknown };
+      expect(stmt.type).toBe('ContinueStatement');
+      expect(stmt.label).toBeNull();
+    });
+
+    it('should parse continue with label', () => {
+      const program = parse('continue foo;');
+      const stmt = program.body[0] as { type: string; label: { type: string; name: string } };
+      expect(stmt.type).toBe('ContinueStatement');
+      expect(stmt.label.type).toBe('Identifier');
+      expect(stmt.label.name).toBe('foo');
+    });
+
+    it('should handle ASI: continue with newline before label', () => {
+      const program = parse('continue\nfoo;');
+      const stmt = program.body[0] as { type: string; label: unknown };
+      expect(stmt.type).toBe('ContinueStatement');
+      expect(stmt.label).toBeNull();
+    });
+  });
+
+  describe('IfStatement', () => {
+    it('should parse if without else', () => {
+      const program = parse('if (x) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        test: { type: string; name: string };
+        consequent: { type: string };
+        alternate: unknown;
+      };
+      expect(stmt.type).toBe('IfStatement');
+      expect(stmt.test.name).toBe('x');
+      expect(stmt.consequent.type).toBe('EmptyStatement');
+      expect(stmt.alternate).toBeNull();
+    });
+
+    it('should parse if with else', () => {
+      const program = parse('if (x) ; else ;');
+      const stmt = program.body[0] as {
+        type: string;
+        alternate: { type: string };
+      };
+      expect(stmt.type).toBe('IfStatement');
+      expect(stmt.alternate).not.toBeNull();
+      expect(stmt.alternate.type).toBe('EmptyStatement');
+    });
+
+    it('should parse if with block body', () => {
+      const program = parse('if (x) {}');
+      const stmt = program.body[0] as {
+        type: string;
+        consequent: { type: string };
+      };
+      expect(stmt.consequent.type).toBe('BlockStatement');
+    });
+
+    it('should parse nested if-else (dangling else)', () => {
+      const program = parse('if (x) if (y) ; else ;');
+      const stmt = program.body[0] as {
+        type: string;
+        consequent: { type: string; alternate: unknown };
+        alternate: unknown;
+      };
+      expect(stmt.type).toBe('IfStatement');
+      // Else associates with innermost if
+      expect(stmt.alternate).toBeNull();
+      expect(stmt.consequent.type).toBe('IfStatement');
+      expect(stmt.consequent.alternate).not.toBeNull();
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('if (x) ;');
+      const stmt = program.body[0];
+      expect(stmt.start).toBe(0);
+    });
+  });
+
+  describe('WhileStatement', () => {
+    it('should parse while loop', () => {
+      const program = parse('while (x) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        test: { name: string };
+        body: { type: string };
+      };
+      expect(stmt.type).toBe('WhileStatement');
+      expect(stmt.test.name).toBe('x');
+      expect(stmt.body.type).toBe('EmptyStatement');
+    });
+
+    it('should parse while with block body', () => {
+      const program = parse('while (x) {}');
+      const stmt = program.body[0] as {
+        type: string;
+        body: { type: string };
+      };
+      expect(stmt.body.type).toBe('BlockStatement');
+    });
+
+    it('should parse while with expression test', () => {
+      const program = parse('while (true) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        test: { value: boolean };
+      };
+      expect(stmt.test.value).toBe(true);
+    });
+  });
+
+  describe('DoWhileStatement', () => {
+    it('should parse do-while loop', () => {
+      const program = parse('do ; while (x);');
+      const stmt = program.body[0] as {
+        type: string;
+        body: { type: string };
+        test: { name: string };
+      };
+      expect(stmt.type).toBe('DoWhileStatement');
+      expect(stmt.body.type).toBe('EmptyStatement');
+      expect(stmt.test.name).toBe('x');
+    });
+
+    it('should parse do-while with block body', () => {
+      const program = parse('do {} while (x);');
+      const stmt = program.body[0] as {
+        type: string;
+        body: { type: string };
+      };
+      expect(stmt.body.type).toBe('BlockStatement');
+    });
+
+    it('should parse do-while without trailing semicolon (ASI)', () => {
+      const program = parse('do ; while (x)\n;');
+      expect(program.body[0].type).toBe('DoWhileStatement');
+    });
+  });
+
+  describe('ForStatement', () => {
+    it('should parse for with all parts', () => {
+      const program = parse('for (x; y; z) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        init: { name: string };
+        test: { name: string };
+        update: { name: string };
+        body: { type: string };
+      };
+      expect(stmt.type).toBe('ForStatement');
+      expect(stmt.init.name).toBe('x');
+      expect(stmt.test.name).toBe('y');
+      expect(stmt.update.name).toBe('z');
+      expect(stmt.body.type).toBe('EmptyStatement');
+    });
+
+    it('should parse for with empty init', () => {
+      const program = parse('for (; y; z) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        init: unknown;
+      };
+      expect(stmt.type).toBe('ForStatement');
+      expect(stmt.init).toBeNull();
+    });
+
+    it('should parse for with empty test', () => {
+      const program = parse('for (x; ; z) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        test: unknown;
+      };
+      expect(stmt.type).toBe('ForStatement');
+      expect(stmt.test).toBeNull();
+    });
+
+    it('should parse for with empty update', () => {
+      const program = parse('for (x; y;) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        update: unknown;
+      };
+      expect(stmt.type).toBe('ForStatement');
+      expect(stmt.update).toBeNull();
+    });
+
+    it('should parse for with all parts empty', () => {
+      const program = parse('for (;;) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        init: unknown;
+        test: unknown;
+        update: unknown;
+      };
+      expect(stmt.type).toBe('ForStatement');
+      expect(stmt.init).toBeNull();
+      expect(stmt.test).toBeNull();
+      expect(stmt.update).toBeNull();
+    });
+
+    it('should parse for with var declaration', () => {
+      const program = parse('for (var i = 0; i; i) ;', { sourceType: 'script' });
+      const stmt = program.body[0] as {
+        type: string;
+        init: { type: string; kind: string };
+      };
+      expect(stmt.type).toBe('ForStatement');
+      expect(stmt.init.type).toBe('VariableDeclaration');
+      expect(stmt.init.kind).toBe('var');
+    });
+  });
+
+  describe('ForInStatement', () => {
+    it('should parse for-in with var', () => {
+      const program = parse('for (var x in obj) ;', { sourceType: 'script' });
+      const stmt = program.body[0] as {
+        type: string;
+        left: { type: string; kind: string };
+        right: { name: string };
+      };
+      expect(stmt.type).toBe('ForInStatement');
+      expect(stmt.left.type).toBe('VariableDeclaration');
+      expect(stmt.right.name).toBe('obj');
+    });
+
+    it('should parse for-in with expression', () => {
+      const program = parse('for (x in obj) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        left: { type: string; name: string };
+        right: { name: string };
+      };
+      expect(stmt.type).toBe('ForInStatement');
+      expect(stmt.left.name).toBe('x');
+      expect(stmt.right.name).toBe('obj');
+    });
+
+    it('should parse for-in with block body', () => {
+      const program = parse('for (x in obj) {}');
+      const stmt = program.body[0] as {
+        type: string;
+        body: { type: string };
+      };
+      expect(stmt.body.type).toBe('BlockStatement');
+    });
+  });
+
+  describe('ForOfStatement', () => {
+    it('should parse for-of with const', () => {
+      const program = parse('for (const x of arr) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        left: { type: string; kind: string };
+        right: { name: string };
+        await: boolean;
+      };
+      expect(stmt.type).toBe('ForOfStatement');
+      expect(stmt.left.type).toBe('VariableDeclaration');
+      expect(stmt.left.kind).toBe('const');
+      expect(stmt.right.name).toBe('arr');
+      expect(stmt.await).toBe(false);
+    });
+
+    it('should parse for-of with expression', () => {
+      const program = parse('for (x of arr) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        left: { name: string };
+      };
+      expect(stmt.type).toBe('ForOfStatement');
+      expect(stmt.left.name).toBe('x');
+    });
+
+    it('should parse for-of with let', () => {
+      const program = parse('for (let x of arr) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        left: { kind: string };
+      };
+      expect(stmt.type).toBe('ForOfStatement');
+      expect(stmt.left.kind).toBe('let');
+    });
+  });
+
+  describe('SwitchStatement', () => {
+    it('should parse switch with single case', () => {
+      const program = parse('switch (x) { case 1: ; }');
+      const stmt = program.body[0] as {
+        type: string;
+        discriminant: { name: string };
+        cases: Array<{ type: string; test: { value: number }; consequent: unknown[] }>;
+      };
+      expect(stmt.type).toBe('SwitchStatement');
+      expect(stmt.discriminant.name).toBe('x');
+      expect(stmt.cases.length).toBe(1);
+      expect(stmt.cases[0].test.value).toBe(1);
+      expect(stmt.cases[0].consequent.length).toBe(1);
+    });
+
+    it('should parse switch with default', () => {
+      const program = parse('switch (x) { default: ; }');
+      const stmt = program.body[0] as {
+        type: string;
+        cases: Array<{ test: unknown }>;
+      };
+      expect(stmt.cases[0].test).toBeNull();
+    });
+
+    it('should parse switch with multiple cases and default', () => {
+      const program = parse('switch (x) { case 1: ; case 2: ; default: ; }');
+      const stmt = program.body[0] as {
+        type: string;
+        cases: unknown[];
+      };
+      expect(stmt.cases.length).toBe(3);
+    });
+
+    it('should parse switch with fallthrough (no consequent)', () => {
+      const program = parse('switch (x) { case 1: case 2: ; }');
+      const stmt = program.body[0] as {
+        type: string;
+        cases: Array<{ consequent: unknown[] }>;
+      };
+      expect(stmt.cases[0].consequent.length).toBe(0);
+      expect(stmt.cases[1].consequent.length).toBe(1);
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('switch (x) {}');
+      const stmt = program.body[0];
+      expect(stmt.start).toBe(0);
+    });
+  });
+
+  describe('TryStatement', () => {
+    it('should parse try-catch', () => {
+      const program = parse('try {} catch (e) {}');
+      const stmt = program.body[0] as {
+        type: string;
+        block: { type: string };
+        handler: { type: string; param: { name: string } };
+        finalizer: unknown;
+      };
+      expect(stmt.type).toBe('TryStatement');
+      expect(stmt.block.type).toBe('BlockStatement');
+      expect(stmt.handler.type).toBe('CatchClause');
+      expect(stmt.handler.param.name).toBe('e');
+      expect(stmt.finalizer).toBeNull();
+    });
+
+    it('should parse try-finally', () => {
+      const program = parse('try {} finally {}');
+      const stmt = program.body[0] as {
+        type: string;
+        handler: unknown;
+        finalizer: { type: string };
+      };
+      expect(stmt.handler).toBeNull();
+      expect(stmt.finalizer).not.toBeNull();
+      expect(stmt.finalizer.type).toBe('BlockStatement');
+    });
+
+    it('should parse try-catch-finally', () => {
+      const program = parse('try {} catch (e) {} finally {}');
+      const stmt = program.body[0] as {
+        type: string;
+        handler: { type: string };
+        finalizer: { type: string };
+      };
+      expect(stmt.handler).not.toBeNull();
+      expect(stmt.finalizer).not.toBeNull();
+    });
+
+    it('should parse optional catch binding', () => {
+      const program = parse('try {} catch {}');
+      const stmt = program.body[0] as {
+        type: string;
+        handler: { param: unknown };
+      };
+      expect(stmt.handler.param).toBeNull();
+    });
+
+    it('should throw if neither catch nor finally present', () => {
+      expect(() => parse('try {}')).toThrow(/Missing catch or finally/);
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('try {} catch (e) {}');
+      const stmt = program.body[0];
+      expect(stmt.start).toBe(0);
+    });
+  });
+
+  describe('WithStatement', () => {
+    it('should parse with statement', () => {
+      const program = parse('with (obj) ;', { sourceType: 'script' });
+      const stmt = program.body[0] as {
+        type: string;
+        object: { name: string };
+        body: { type: string };
+      };
+      expect(stmt.type).toBe('WithStatement');
+      expect(stmt.object.name).toBe('obj');
+      expect(stmt.body.type).toBe('EmptyStatement');
+    });
+
+    it('should parse with with block body', () => {
+      const program = parse('with (obj) {}', { sourceType: 'script' });
+      const stmt = program.body[0] as {
+        type: string;
+        body: { type: string };
+      };
+      expect(stmt.body.type).toBe('BlockStatement');
+    });
+  });
+
+  describe('LabeledStatement', () => {
+    it('should parse labeled statement', () => {
+      const program = parse('foo: ;');
+      const stmt = program.body[0] as {
+        type: string;
+        label: { type: string; name: string };
+        body: { type: string };
+      };
+      expect(stmt.type).toBe('LabeledStatement');
+      expect(stmt.label.name).toBe('foo');
+      expect(stmt.body.type).toBe('EmptyStatement');
+    });
+
+    it('should parse labeled block', () => {
+      const program = parse('foo: {}');
+      const stmt = program.body[0] as {
+        type: string;
+        body: { type: string };
+      };
+      expect(stmt.type).toBe('LabeledStatement');
+      expect(stmt.body.type).toBe('BlockStatement');
+    });
+
+    it('should parse labeled loop', () => {
+      const program = parse('outer: while (true) ;');
+      const stmt = program.body[0] as {
+        type: string;
+        label: { name: string };
+        body: { type: string };
+      };
+      expect(stmt.type).toBe('LabeledStatement');
+      expect(stmt.label.name).toBe('outer');
+      expect(stmt.body.type).toBe('WhileStatement');
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('foo: ;');
+      const stmt = program.body[0];
+      expect(stmt.start).toBe(0);
+    });
+  });
+
+  describe('VariableDeclaration', () => {
+    it('should parse var declaration', () => {
+      const program = parse('var x = 1;', { sourceType: 'script' });
+      const stmt = program.body[0] as {
+        type: string;
+        kind: string;
+        declarations: Array<{
+          type: string;
+          id: { name: string };
+          init: { value: number };
+        }>;
+      };
+      expect(stmt.type).toBe('VariableDeclaration');
+      expect(stmt.kind).toBe('var');
+      expect(stmt.declarations.length).toBe(1);
+      expect(stmt.declarations[0].id.name).toBe('x');
+      expect(stmt.declarations[0].init.value).toBe(1);
+    });
+
+    it('should parse let declaration', () => {
+      const program = parse('let x = 1;');
+      const stmt = program.body[0] as {
+        type: string;
+        kind: string;
+      };
+      expect(stmt.type).toBe('VariableDeclaration');
+      expect(stmt.kind).toBe('let');
+    });
+
+    it('should parse const declaration', () => {
+      const program = parse('const x = 1;');
+      const stmt = program.body[0] as {
+        type: string;
+        kind: string;
+      };
+      expect(stmt.type).toBe('VariableDeclaration');
+      expect(stmt.kind).toBe('const');
+    });
+
+    it('should parse multiple declarators', () => {
+      const program = parse('var x = 1, y = 2;', { sourceType: 'script' });
+      const stmt = program.body[0] as {
+        type: string;
+        declarations: Array<{ id: { name: string }; init: { value: number } }>;
+      };
+      expect(stmt.declarations.length).toBe(2);
+      expect(stmt.declarations[0].id.name).toBe('x');
+      expect(stmt.declarations[1].id.name).toBe('y');
+    });
+
+    it('should parse declaration without initializer', () => {
+      const program = parse('var x;', { sourceType: 'script' });
+      const stmt = program.body[0] as {
+        type: string;
+        declarations: Array<{ init: unknown }>;
+      };
+      expect(stmt.declarations[0].init).toBeNull();
+    });
+
+    it('should set correct positions', () => {
+      const program = parse('const x = 1;');
+      const stmt = program.body[0];
+      expect(stmt.start).toBe(0);
+    });
+  });
+
+  describe('ExpressionStatement', () => {
+    it('should parse identifier expression', () => {
+      const program = parse('x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; name: string };
+      };
+      expect(stmt.type).toBe('ExpressionStatement');
+      expect(stmt.expression.type).toBe('Identifier');
+      expect(stmt.expression.name).toBe('x');
+    });
+
+    it('should parse numeric literal expression', () => {
+      const program = parse('42;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; value: number };
+      };
+      expect(stmt.type).toBe('ExpressionStatement');
+      expect(stmt.expression.value).toBe(42);
+    });
+
+    it('should parse string literal expression (directive)', () => {
+      const program = parse('"use strict";');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { value: string };
+        directive?: string;
+      };
+      expect(stmt.type).toBe('ExpressionStatement');
+      expect(stmt.directive).toBe('use strict');
+    });
+
+    it('should parse assignment expression', () => {
+      const program = parse('x = 1;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: {
+          type: string;
+          operator: string;
+          left: { name: string };
+          right: { value: number };
+        };
+      };
+      expect(stmt.expression.type).toBe('AssignmentExpression');
+      expect(stmt.expression.operator).toBe('=');
+      expect(stmt.expression.left.name).toBe('x');
+      expect(stmt.expression.right.value).toBe(1);
+    });
+
+    it('should parse call expression', () => {
+      const program = parse('foo();');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; callee: { name: string }; arguments: unknown[] };
+      };
+      expect(stmt.expression.type).toBe('CallExpression');
+      expect(stmt.expression.callee.name).toBe('foo');
+      expect(stmt.expression.arguments.length).toBe(0);
+    });
+
+    it('should parse call expression with arguments', () => {
+      const program = parse('foo(1, 2);');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { arguments: unknown[] };
+      };
+      expect(stmt.expression.arguments.length).toBe(2);
+    });
+
+    it('should parse member expression', () => {
+      const program = parse('a.b;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: {
+          type: string;
+          object: { name: string };
+          property: { name: string };
+          computed: boolean;
+        };
+      };
+      expect(stmt.expression.type).toBe('MemberExpression');
+      expect(stmt.expression.object.name).toBe('a');
+      expect(stmt.expression.property.name).toBe('b');
+      expect(stmt.expression.computed).toBe(false);
+    });
+
+    it('should parse computed member expression', () => {
+      const program = parse('a[0];');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; computed: boolean };
+      };
+      expect(stmt.expression.type).toBe('MemberExpression');
+      expect(stmt.expression.computed).toBe(true);
+    });
+
+    it('should handle ASI', () => {
+      const program = parse('x\ny');
+      expect(program.body.length).toBe(2);
+      expect(program.body[0].type).toBe('ExpressionStatement');
+      expect(program.body[1].type).toBe('ExpressionStatement');
+    });
+
+    it('should parse binary expression', () => {
+      const program = parse('x + y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: {
+          type: string;
+          operator: string;
+          left: { name: string };
+          right: { name: string };
+        };
+      };
+      expect(stmt.expression.type).toBe('BinaryExpression');
+      expect(stmt.expression.operator).toBe('+');
+    });
+
+    it('should parse unary expression', () => {
+      const program = parse('!x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: {
+          type: string;
+          operator: string;
+          prefix: boolean;
+        };
+      };
+      expect(stmt.expression.type).toBe('UnaryExpression');
+      expect(stmt.expression.operator).toBe('!');
+      expect(stmt.expression.prefix).toBe(true);
+    });
+
+    it('should parse this expression', () => {
+      const program = parse('this;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string };
+      };
+      expect(stmt.expression.type).toBe('ThisExpression');
+    });
+
+    it('should parse null literal', () => {
+      const program = parse('null;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; value: unknown };
+      };
+      expect(stmt.expression.type).toBe('Literal');
+      expect(stmt.expression.value).toBeNull();
+    });
+
+    it('should parse boolean literals', () => {
+      const program = parse('true;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { value: boolean };
+      };
+      expect(stmt.expression.value).toBe(true);
+    });
+
+    it('should parse sequence expression', () => {
+      const program = parse('x, y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; expressions: Array<{ name: string }> };
+      };
+      expect(stmt.expression.type).toBe('SequenceExpression');
+      expect(stmt.expression.expressions.length).toBe(2);
+    });
+
+    it('should parse new expression', () => {
+      const program = parse('new Foo();');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; callee: { name: string } };
+      };
+      expect(stmt.expression.type).toBe('NewExpression');
+      expect(stmt.expression.callee.name).toBe('Foo');
+    });
+  });
+
+  describe('Nested statements', () => {
+    it('should parse if inside while', () => {
+      const program = parse('while (x) if (y) ;');
+      const whileStmt = program.body[0] as {
+        type: string;
+        body: { type: string };
+      };
+      expect(whileStmt.type).toBe('WhileStatement');
+      expect(whileStmt.body.type).toBe('IfStatement');
+    });
+
+    it('should parse while inside if', () => {
+      const program = parse('if (x) while (y) ;');
+      const ifStmt = program.body[0] as {
+        type: string;
+        consequent: { type: string };
+      };
+      expect(ifStmt.type).toBe('IfStatement');
+      expect(ifStmt.consequent.type).toBe('WhileStatement');
+    });
+
+    it('should parse block with multiple statement types', () => {
+      const program = parse('{ ; debugger; break; }');
+      const block = program.body[0] as {
+        type: string;
+        body: Array<{ type: string }>;
+      };
+      expect(block.body.length).toBe(3);
+      expect(block.body[0].type).toBe('EmptyStatement');
+      expect(block.body[1].type).toBe('DebuggerStatement');
+      expect(block.body[2].type).toBe('BreakStatement');
+    });
+
+    it('should parse for inside switch case', () => {
+      const program = parse('switch (x) { case 1: for (;;) ; }');
+      const switchStmt = program.body[0] as {
+        type: string;
+        cases: Array<{ consequent: Array<{ type: string }> }>;
+      };
+      expect(switchStmt.cases[0].consequent[0].type).toBe('ForStatement');
+    });
+
+    it('should parse try with if in catch', () => {
+      const program = parse('try {} catch (e) { if (e) ; }');
+      const tryStmt = program.body[0] as {
+        type: string;
+        handler: { body: { body: Array<{ type: string }> } };
+      };
+      expect(tryStmt.handler.body.body[0].type).toBe('IfStatement');
+    });
+  });
+
+  describe('Error cases', () => {
+    it('should throw on missing closing brace for block', () => {
+      expect(() => parse('{')).toThrow();
+    });
+
+    it('should throw on missing paren in if condition', () => {
+      expect(() => parse('if x ;')).toThrow();
+    });
+
+    it('should throw on missing paren in while condition', () => {
+      expect(() => parse('while x ;')).toThrow();
+    });
+
+    it('should throw on missing while in do-while', () => {
+      expect(() => parse('do ; }')).toThrow();
+    });
+
+    it('should throw on missing paren in for', () => {
+      expect(() => parse('for x ;')).toThrow();
+    });
+
+    it('should throw on missing paren in switch', () => {
+      expect(() => parse('switch x {}')).toThrow();
+    });
+
+    it('should throw on try without catch or finally', () => {
+      expect(() => parse('try {}')).toThrow(/Missing catch or finally/);
+    });
+
+    it('should throw on throw with newline', () => {
+      expect(() => parse('throw\nx;')).toThrow(/newline after throw/);
+    });
+
+    it('should throw on unexpected token in expression', () => {
+      expect(() => parse('if () ;')).toThrow();
+    });
+
+    it('should throw on missing semicolon when ASI does not apply', () => {
+      expect(() => parse('x y')).toThrow();
+    });
+  });
+
+  describe('ASI (Automatic Semicolon Insertion)', () => {
+    it('should insert semicolon before }', () => {
+      const program = parse('{ x }');
+      const block = program.body[0] as { body: Array<{ type: string }> };
+      expect(block.body[0].type).toBe('ExpressionStatement');
+    });
+
+    it('should insert semicolon at EOF', () => {
+      const program = parse('x');
+      expect(program.body[0].type).toBe('ExpressionStatement');
+    });
+
+    it('should insert semicolon after line terminator', () => {
+      const program = parse('x\ny');
+      expect(program.body.length).toBe(2);
+    });
+
+    it('should not insert semicolon when no line terminator', () => {
+      expect(() => parse('x y')).toThrow();
+    });
+  });
+
+  describe('Compound assignment operators', () => {
+    it('should parse +=', () => {
+      const program = parse('x += 1;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('+=');
+    });
+
+    it('should parse -=', () => {
+      const program = parse('x -= 1;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('-=');
+    });
+
+    it('should parse *=', () => {
+      const program = parse('x *= 1;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('*=');
+    });
+  });
+
+  describe('Update expressions', () => {
+    it('should parse prefix ++', () => {
+      const program = parse('++x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string; prefix: boolean };
+      };
+      expect(stmt.expression.type).toBe('UpdateExpression');
+      expect(stmt.expression.operator).toBe('++');
+      expect(stmt.expression.prefix).toBe(true);
+    });
+
+    it('should parse postfix ++', () => {
+      const program = parse('x++;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string; prefix: boolean };
+      };
+      expect(stmt.expression.type).toBe('UpdateExpression');
+      expect(stmt.expression.operator).toBe('++');
+      expect(stmt.expression.prefix).toBe(false);
+    });
+
+    it('should parse prefix --', () => {
+      const program = parse('--x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string; prefix: boolean };
+      };
+      expect(stmt.expression.type).toBe('UpdateExpression');
+      expect(stmt.expression.operator).toBe('--');
+      expect(stmt.expression.prefix).toBe(true);
+    });
+
+    it('should parse postfix --', () => {
+      const program = parse('x--;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string; prefix: boolean };
+      };
+      expect(stmt.expression.type).toBe('UpdateExpression');
+      expect(stmt.expression.operator).toBe('--');
+      expect(stmt.expression.prefix).toBe(false);
+    });
+  });
+
+  describe('Conditional expression', () => {
+    it('should parse ternary', () => {
+      const program = parse('x ? y : z;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: {
+          type: string;
+          test: { name: string };
+          consequent: { name: string };
+          alternate: { name: string };
+        };
+      };
+      expect(stmt.expression.type).toBe('ConditionalExpression');
+      expect(stmt.expression.test.name).toBe('x');
+      expect(stmt.expression.consequent.name).toBe('y');
+      expect(stmt.expression.alternate.name).toBe('z');
+    });
+  });
+
+  describe('Logical expressions', () => {
+    it('should parse ||', () => {
+      const program = parse('x || y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string };
+      };
+      expect(stmt.expression.type).toBe('LogicalExpression');
+      expect(stmt.expression.operator).toBe('||');
+    });
+
+    it('should parse &&', () => {
+      const program = parse('x && y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string };
+      };
+      expect(stmt.expression.type).toBe('LogicalExpression');
+      expect(stmt.expression.operator).toBe('&&');
+    });
+
+    it('should parse ??', () => {
+      const program = parse('x ?? y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string };
+      };
+      expect(stmt.expression.type).toBe('LogicalExpression');
+      expect(stmt.expression.operator).toBe('??');
+    });
+  });
+
+  describe('Array and object expressions', () => {
+    it('should parse empty array', () => {
+      const program = parse('[];');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; elements: unknown[] };
+      };
+      expect(stmt.expression.type).toBe('ArrayExpression');
+      expect(stmt.expression.elements.length).toBe(0);
+    });
+
+    it('should parse array with elements', () => {
+      const program = parse('[1, 2, 3];');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { elements: unknown[] };
+      };
+      expect(stmt.expression.elements.length).toBe(3);
+    });
+
+    it('should parse array with holes', () => {
+      const program = parse('[,1,,2,];');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { elements: Array<unknown | null> };
+      };
+      expect(stmt.expression.elements[0]).toBeNull();
+      expect(stmt.expression.elements[2]).toBeNull();
+    });
+
+    it('should parse array with spread', () => {
+      const program = parse('[...x];');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { elements: Array<{ type: string }> };
+      };
+      expect(stmt.expression.elements[0].type).toBe('SpreadElement');
+    });
+
+    it('should parse empty object', () => {
+      const program = parse('({});');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; properties: unknown[] };
+      };
+      expect(stmt.expression.type).toBe('ObjectExpression');
+      expect(stmt.expression.properties.length).toBe(0);
+    });
+
+    it('should parse object with properties', () => {
+      const program = parse('({a: 1, b: 2});');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { properties: Array<{ type: string; key: { name: string } }> };
+      };
+      expect(stmt.expression.properties.length).toBe(2);
+    });
+
+    it('should parse object with shorthand', () => {
+      const program = parse('({x});');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { properties: Array<{ shorthand: boolean }> };
+      };
+      expect(stmt.expression.properties[0].shorthand).toBe(true);
+    });
+
+    it('should parse object with spread', () => {
+      const program = parse('({...x});');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { properties: Array<{ type: string }> };
+      };
+      expect(stmt.expression.properties[0].type).toBe('SpreadElement');
+    });
+
+    it('should parse object with trailing comma', () => {
+      const program = parse('({a: 1,});');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { properties: unknown[] };
+      };
+      expect(stmt.expression.properties.length).toBe(1);
+    });
+  });
+
+  describe('Binding pattern errors', () => {
+    it('should throw on invalid binding in variable declaration', () => {
+      expect(() => parse('const 123 = 1;')).toThrow(/binding pattern/);
+    });
+  });
+
+  describe('New expression', () => {
+    it('should parse new without arguments', () => {
+      const program = parse('new Foo;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; arguments: unknown[] };
+      };
+      expect(stmt.expression.type).toBe('NewExpression');
+      expect(stmt.expression.arguments.length).toBe(0);
+    });
+
+    it('should parse new with arguments', () => {
+      const program = parse('new Foo(1, 2);');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; arguments: unknown[] };
+      };
+      expect(stmt.expression.type).toBe('NewExpression');
+      expect(stmt.expression.arguments.length).toBe(2);
+    });
+  });
+
+  describe('Call expression with spread', () => {
+    it('should parse spread in function call', () => {
+      const program = parse('foo(...x);');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { arguments: Array<{ type: string }> };
+      };
+      expect(stmt.expression.arguments[0].type).toBe('SpreadElement');
+    });
+  });
+
+  describe('typeof and void and delete', () => {
+    it('should parse typeof', () => {
+      const program = parse('typeof x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string };
+      };
+      expect(stmt.expression.type).toBe('UnaryExpression');
+      expect(stmt.expression.operator).toBe('typeof');
+    });
+
+    it('should parse void', () => {
+      const program = parse('void 0;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string };
+      };
+      expect(stmt.expression.operator).toBe('void');
+    });
+
+    it('should parse delete', () => {
+      const program = parse('delete x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; operator: string };
+      };
+      expect(stmt.expression.operator).toBe('delete');
+    });
+
+    it('should parse ~ (bitwise not)', () => {
+      const program = parse('~x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('~');
+    });
+
+    it('should parse unary +', () => {
+      const program = parse('+x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('+');
+    });
+
+    it('should parse unary -', () => {
+      const program = parse('-x;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('-');
+    });
+  });
+
+  describe('Binary operators', () => {
+    it('should parse -', () => {
+      const program = parse('x - y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('-');
+    });
+
+    it('should parse *', () => {
+      const program = parse('x * y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('*');
+    });
+
+    it('should parse /', () => {
+      const program = parse('x / y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('/');
+    });
+
+    it('should parse %', () => {
+      const program = parse('x % y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('%');
+    });
+
+    it('should parse **', () => {
+      const program = parse('x ** y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('**');
+    });
+
+    it('should parse &', () => {
+      const program = parse('x & y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('&');
+    });
+
+    it('should parse |', () => {
+      const program = parse('x | y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('|');
+    });
+
+    it('should parse ^', () => {
+      const program = parse('x ^ y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('^');
+    });
+
+    it('should parse <<', () => {
+      const program = parse('x << y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('<<');
+    });
+
+    it('should parse >>', () => {
+      const program = parse('x >> y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('>>');
+    });
+
+    it('should parse >>>', () => {
+      const program = parse('x >>> y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('>>>');
+    });
+
+    it('should parse ==', () => {
+      const program = parse('x == y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('==');
+    });
+
+    it('should parse !=', () => {
+      const program = parse('x != y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('!=');
+    });
+
+    it('should parse ===', () => {
+      const program = parse('x === y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('===');
+    });
+
+    it('should parse !==', () => {
+      const program = parse('x !== y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('!==');
+    });
+
+    it('should parse <', () => {
+      const program = parse('x < y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('<');
+    });
+
+    it('should parse >', () => {
+      const program = parse('x > y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('>');
+    });
+
+    it('should parse <=', () => {
+      const program = parse('x <= y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('<=');
+    });
+
+    it('should parse >=', () => {
+      const program = parse('x >= y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('>=');
+    });
+
+    it('should parse instanceof', () => {
+      const program = parse('x instanceof y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('instanceof');
+    });
+
+    it('should parse in', () => {
+      const program = parse('x in y;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { operator: string };
+      };
+      expect(stmt.expression.operator).toBe('in');
+    });
+
+    it('should respect operator precedence (* before +)', () => {
+      const program = parse('a + b * c;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: {
+          type: string;
+          operator: string;
+          left: { name: string };
+          right: { operator: string };
+        };
+      };
+      // a + (b * c)
+      expect(stmt.expression.operator).toBe('+');
+      expect(stmt.expression.right.operator).toBe('*');
+    });
+  });
+
+  describe('Contextual keywords as identifiers', () => {
+    it('should parse let as variable declaration keyword', () => {
+      const program = parse('let x = 1;');
+      const stmt = program.body[0] as {
+        type: string;
+        kind: string;
+      };
+      expect(stmt.type).toBe('VariableDeclaration');
+      expect(stmt.kind).toBe('let');
+    });
+
+    it('should parse of as identifier', () => {
+      const program = parse('of;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { type: string; name: string };
+      };
+      expect(stmt.expression.name).toBe('of');
+    });
+
+    it('should parse async as identifier', () => {
+      const program = parse('async;');
+      const stmt = program.body[0] as {
+        type: string;
+        expression: { name: string };
+      };
+      expect(stmt.expression.name).toBe('async');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements parsing for all JavaScript statement types: block, empty, debugger, return, throw, break, continue, if, while, do-while, for, for-in, for-of, switch, try/catch/finally, with, labeled, and variable declarations
- Creates `src/parser/statements.ts` module with composable statement parsing functions using a `ParserContext` interface
- Extends the `Parser` class with basic expression parsing (primary, binary, unary, assignment, call, member, new) to support statement test/body contexts
- Handles Automatic Semicolon Insertion (ASI) for return, break, continue, throw
- Distinguishes for/for-in/for-of via `allowIn` flag on expression parsing
- Supports optional catch binding (`catch {}` without parameter)

## Test plan

- [x] 160 unit tests covering all statement types with valid input
- [x] Nested statements (if inside while, for inside switch, etc.)
- [x] For-in, for-of, and regular for loop variants
- [x] Switch with multiple cases, default, and fallthrough
- [x] Try/catch/finally combinations including optional catch binding
- [x] ASI cases (return/break/continue with newline, EOF, before `}`)
- [x] Error cases (throw without expression, missing parens, etc.)
- [x] All existing 1968 tests pass
- [x] Coverage: statements.ts 99.58% lines, parser.ts 99.69% lines

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)