### PR TITLE
fix: correct invalid GitHub Actions commit SHAs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@48ab28a6b1c830e7e27c0b14aef1f29c3ba5b30a
+        uses: github/codeql-action/init@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@48ab28a6b1c830e7e27c0b14aef1f29c3ba5b30a
+        uses: github/codeql-action/autobuild@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@48ab28a6b1c830e7e27c0b14aef1f29c3ba5b30a
+        uses: github/codeql-action/analyze@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f882d5062a8a97e71
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Summary

- All CI/CD workflows (CI, CodeQL, Benchmarks, Nightly, Publish, Deploy Website) were failing immediately at the "Set up job" phase because two GitHub Actions were pinned to non-existent commit SHAs
- Fixed `actions/setup-node` SHA: the old value (`49933ea...195f882d5062a8a97e71`) does not exist as a commit in the actions/setup-node repo; replaced with the correct SHA for v4.4.0 (`49933ea...d1e84afbd3f7d6820020`)
- Fixed `github/codeql-action` SHA: the old value (`48ab28a6b1c830e7e27c0b14aef1f29c3ba5b30a`) does not exist; replaced with the correct commit SHA for v3.28.0 (`48ab28a6f5dbc2a99bf1e0131198dd8f1df78169`)

## Root Cause

The pinned SHAs appear to have been fabricated (possibly hallucinated during generation). They share common prefixes with real SHAs but have invalid suffixes.

## Test plan

- [ ] Verify CI workflow passes the "Set up job" phase and proceeds to lint/test/build
- [ ] Verify CodeQL workflow completes analysis successfully
- [ ] Verify Benchmarks workflow runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)