### PR TITLE
feat: implement parser operator expressions with Pratt parsing

### DIFF
--- a/src/parser/expressions.ts
+++ b/src/parser/expressions.ts
@@ -3,9 +3,9 @@
  *
  * Handles primary/literal expressions including identifiers, literals,
  * this, arrays, objects, template literals, and parenthesized expressions.
- * Also provides basic assignment and sequence expression parsing.
+ * Also provides assignment, sequence, binary, unary, update, and
+ * conditional expression parsing via Pratt parsing (issue #29).
  *
- * Operator precedence (Pratt parsing) will be implemented by issue #29.
  * Function/arrow/class expressions will be implemented by issue #27.
  * Member/call expressions will be implemented by issue #31.
  *
@@ -16,15 +16,26 @@ import type * as AST from "../ast/types.js";
 import type { Lexer } from "./lexer.js";
 import { TokenType } from "./token-types.js";
 import { tokenTypeName } from "./token-types.js";
+import {
+  parseBinaryExpression,
+  parseUnaryExpression,
+  parseConditionalExpression,
+  parseAssignment,
+  setPrimaryExpressionParser,
+} from "./operators.js";
 
 /**
  * Parse a full expression, handling sequence expressions (comma-separated).
  *
  * @param lexer - The lexer instance to consume tokens from.
+ * @param allowIn - Whether the `in` operator is permitted. Defaults to true.
  * @returns The parsed Expression AST node.
  */
-export const parseExpression = (lexer: Lexer): AST.Expression => {
-  const expr = parseAssignmentExpression(lexer);
+export const parseExpression = (
+  lexer: Lexer,
+  allowIn: boolean = true,
+): AST.Expression => {
+  const expr = parseAssignmentExpression(lexer, allowIn);
 
   // Check for sequence expression (comma-separated)
   if (!lexer.is(TokenType.Comma)) {
@@ -36,7 +47,7 @@ export const parseExpression = (lexer: Lexer): AST.Expression => {
 
   while (lexer.is(TokenType.Comma)) {
     lexer.next();
-    const next = parseAssignmentExpression(lexer);
+    const next = parseAssignmentExpression(lexer, allowIn);
     expressions.push(next);
   }
 
@@ -51,43 +62,43 @@ export const parseExpression = (lexer: Lexer): AST.Expression => {
 };
 
 /**
- * Parse an assignment expression (simple = form for now).
+ * Parse an assignment expression with full operator support.
  *
- * Full compound assignment operators will be handled when operator
- * parsing is implemented in issue #29.
+ * Pipeline: unary -> binary (Pratt) -> conditional -> assignment check.
+ * If `allowIn` is false (for-loop init), the `in` operator is excluded
+ * from binary precedence.
  *
  * @param lexer - The lexer instance.
+ * @param allowIn - Whether the `in` operator is permitted. Defaults to true.
  * @returns The parsed Expression AST node.
  */
-export const parseAssignmentExpression = (lexer: Lexer): AST.Expression => {
-  const left = parseMaybeUnary(lexer);
+export const parseAssignmentExpression = (
+  lexer: Lexer,
+  allowIn: boolean = true,
+): AST.Expression => {
+  // Parse unary (prefix operators + primary + postfix)
+  const unary = parseUnaryExpression(lexer, () =>
+    parsePrimaryExpression(lexer),
+  );
 
-  if (lexer.is(TokenType.Equals)) {
-    lexer.next();
-    const right = parseAssignmentExpression(lexer);
-    return Object.freeze({
-      type: "AssignmentExpression" as const,
-      start: left.start,
-      end: right.end,
-      operator: "=" as const,
-      left,
-      right,
-    });
+  // Parse binary/logical with Pratt precedence
+  const binary = parseBinaryExpression(lexer, unary, 1, allowIn);
+
+  // Parse conditional (ternary)
+  const conditional = parseConditionalExpression(lexer, binary, () =>
+    parseAssignmentExpression(lexer, allowIn),
+  );
+
+  // Check for assignment
+  const assignment = parseAssignment(lexer, conditional, () =>
+    parseAssignmentExpression(lexer, allowIn),
+  );
+
+  if (assignment !== null) {
+    return assignment;
   }
 
-  return left;
-};
-
-/**
- * Stub for unary/update expression parsing.
- * Will be filled by issue #29 (operator precedence).
- * For now just delegates to primary expressions.
- *
- * @param lexer - The lexer instance.
- * @returns The parsed Expression AST node.
- */
-const parseMaybeUnary = (lexer: Lexer): AST.Expression => {
-  return parsePrimaryExpression(lexer);
+  return conditional;
 };
 
 /**
@@ -905,3 +916,7 @@ const parseClassExpressionStub = (lexer: Lexer): AST.ClassExpression => {
     `Class expressions not yet implemented at position ${lexer.token.start}`,
   );
 };
+
+// Register primary expression parser with the operators module to
+// break the circular dependency.
+setPrimaryExpressionParser(parsePrimaryExpression);

--- a/src/parser/operators.ts
+++ b/src/parser/operators.ts
@@ -1,0 +1,475 @@
+/**
+ * Operator expression parsing using iterative Pratt parsing.
+ *
+ * Implements binary, logical, unary, update, conditional, and assignment
+ * expression parsing with correct operator precedence and associativity.
+ *
+ * Uses iterative approach (while loops) instead of recursive descent
+ * to avoid stack overflow on deeply nested expressions.
+ *
+ * @module parser/operators
+ */
+
+import type * as AST from "../ast/types.js";
+import type { Lexer } from "./lexer.js";
+import { TokenType } from "./token-types.js";
+
+/**
+ * Precedence levels for binary and logical operators.
+ * Higher values indicate tighter binding.
+ */
+const PRECEDENCE: Readonly<Record<number, number>> = Object.freeze({
+  [TokenType.PipePipe]: 1,
+  [TokenType.AmpersandAmpersand]: 2,
+  [TokenType.QuestionQuestion]: 1,
+  [TokenType.Pipe]: 3,
+  [TokenType.Caret]: 4,
+  [TokenType.Ampersand]: 5,
+  [TokenType.EqualsEquals]: 6,
+  [TokenType.ExclamationEquals]: 6,
+  [TokenType.EqualsEqualsEquals]: 6,
+  [TokenType.ExclamationEqualsEquals]: 6,
+  [TokenType.LessThan]: 7,
+  [TokenType.GreaterThan]: 7,
+  [TokenType.LessThanEquals]: 7,
+  [TokenType.GreaterThanEquals]: 7,
+  [TokenType.Instanceof]: 7,
+  [TokenType.In]: 7,
+  [TokenType.LeftShift]: 8,
+  [TokenType.RightShift]: 8,
+  [TokenType.UnsignedRightShift]: 8,
+  [TokenType.Plus]: 9,
+  [TokenType.Minus]: 9,
+  [TokenType.Star]: 10,
+  [TokenType.Slash]: 10,
+  [TokenType.Percent]: 10,
+  [TokenType.StarStar]: 11,
+});
+
+/**
+ * Maps token types to ESTree binary operator strings.
+ */
+const BINARY_OPERATORS: Readonly<Record<number, AST.BinaryOperator>> =
+  Object.freeze({
+    [TokenType.Plus]: "+",
+    [TokenType.Minus]: "-",
+    [TokenType.Star]: "*",
+    [TokenType.Slash]: "/",
+    [TokenType.Percent]: "%",
+    [TokenType.StarStar]: "**",
+    [TokenType.Pipe]: "|",
+    [TokenType.Caret]: "^",
+    [TokenType.Ampersand]: "&",
+    [TokenType.LeftShift]: "<<",
+    [TokenType.RightShift]: ">>",
+    [TokenType.UnsignedRightShift]: ">>>",
+    [TokenType.EqualsEquals]: "==",
+    [TokenType.ExclamationEquals]: "!=",
+    [TokenType.EqualsEqualsEquals]: "===",
+    [TokenType.ExclamationEqualsEquals]: "!==",
+    [TokenType.LessThan]: "<",
+    [TokenType.GreaterThan]: ">",
+    [TokenType.LessThanEquals]: "<=",
+    [TokenType.GreaterThanEquals]: ">=",
+    [TokenType.Instanceof]: "instanceof",
+    [TokenType.In]: "in",
+  });
+
+/**
+ * Maps token types to ESTree logical operator strings.
+ */
+const LOGICAL_OPERATOR_MAP: Readonly<Record<number, AST.LogicalOperator>> =
+  Object.freeze({
+    [TokenType.PipePipe]: "||",
+    [TokenType.AmpersandAmpersand]: "&&",
+    [TokenType.QuestionQuestion]: "??",
+  });
+
+/**
+ * Set of token types that are logical operators.
+ */
+const LOGICAL_OPERATORS: ReadonlySet<number> = new Set([
+  TokenType.PipePipe,
+  TokenType.AmpersandAmpersand,
+  TokenType.QuestionQuestion,
+]);
+
+/**
+ * Maps token types to ESTree assignment operator strings.
+ */
+const ASSIGNMENT_OPERATORS: Readonly<Record<number, AST.AssignmentOperator>> =
+  Object.freeze({
+    [TokenType.Equals]: "=",
+    [TokenType.PlusEquals]: "+=",
+    [TokenType.MinusEquals]: "-=",
+    [TokenType.StarEquals]: "*=",
+    [TokenType.SlashEquals]: "/=",
+    [TokenType.PercentEquals]: "%=",
+    [TokenType.StarStarEquals]: "**=",
+    [TokenType.AmpersandEquals]: "&=",
+    [TokenType.PipeEquals]: "|=",
+    [TokenType.CaretEquals]: "^=",
+    [TokenType.LeftShiftEquals]: "<<=",
+    [TokenType.RightShiftEquals]: ">>=",
+    [TokenType.UnsignedRightShiftEquals]: ">>>=",
+    [TokenType.AmpersandAmpersandEquals]: "&&=",
+    [TokenType.PipePipeEquals]: "||=",
+    [TokenType.QuestionQuestionEquals]: "??=",
+  });
+
+/**
+ * Maps unary prefix operator token types to their string representation.
+ */
+const UNARY_OPERATORS: Readonly<Record<number, AST.UnaryOperator>> =
+  Object.freeze({
+    [TokenType.Exclamation]: "!",
+    [TokenType.Tilde]: "~",
+    [TokenType.Plus]: "+",
+    [TokenType.Minus]: "-",
+    [TokenType.Typeof]: "typeof",
+    [TokenType.Void]: "void",
+    [TokenType.Delete]: "delete",
+  });
+
+/**
+ * Set of token types that can be unary prefix operators.
+ */
+const UNARY_TOKEN_SET: ReadonlySet<number> = new Set([
+  TokenType.Exclamation,
+  TokenType.Tilde,
+  TokenType.Plus,
+  TokenType.Minus,
+  TokenType.Typeof,
+  TokenType.Void,
+  TokenType.Delete,
+]);
+
+/**
+ * Determines if a token type is a binary/logical operator with a
+ * precedence value in the PRECEDENCE table.
+ *
+ * @param tokenType - The token type to check.
+ * @param allowIn - Whether the `in` operator is permitted.
+ * @returns The precedence level, or 0 if not an operator.
+ */
+const getOperatorPrecedence = (tokenType: number, allowIn: boolean): number => {
+  if (tokenType === TokenType.In && !allowIn) {
+    return 0;
+  }
+  return PRECEDENCE[tokenType] ?? 0;
+};
+
+/**
+ * Parse a binary/logical expression using iterative Pratt parsing.
+ *
+ * Builds the expression tree by comparing precedence levels in a while
+ * loop, handling both left-associative and right-associative (** only)
+ * operators.
+ *
+ * @param lexer - The lexer instance to consume tokens from.
+ * @param left - The initial left-hand side expression (typically a unary).
+ * @param minPrecedence - The minimum precedence for operators to consume.
+ * @param allowIn - Whether the `in` operator is allowed.
+ * @returns The combined binary/logical expression.
+ */
+export const parseBinaryExpression = (
+  lexer: Lexer,
+  left: AST.Expression,
+  minPrecedence: number,
+  allowIn: boolean,
+): AST.Expression => {
+  return parseBinaryExpressionInner(lexer, left, minPrecedence, allowIn, 0);
+};
+
+/**
+ * Nullish mixing context flags (bitmask).
+ * 0 = no logical operators seen
+ * 1 = has nullish (??)
+ * 2 = has short-circuit (|| or &&)
+ */
+const NULLISH_FLAG = 1;
+const SHORT_CIRCUIT_FLAG = 2;
+
+/**
+ * Inner Pratt parsing loop with nullish-mixing context tracking.
+ *
+ * The `logicalContext` tracks which kind of logical operators have been
+ * encountered at this parsing level (not including parenthesized sub-exprs).
+ * If both nullish and short-circuit are seen, a SyntaxError is thrown.
+ */
+const parseBinaryExpressionInner = (
+  lexer: Lexer,
+  left: AST.Expression,
+  minPrecedence: number,
+  allowIn: boolean,
+  logicalContext: number,
+): AST.Expression => {
+  let result = left;
+  let ctx = logicalContext;
+
+  while (true) {
+    const tokenType = lexer.token.type;
+    const prec = getOperatorPrecedence(tokenType, allowIn);
+
+    if (prec === 0 || prec < minPrecedence) {
+      break;
+    }
+
+    // Track and validate nullish mixing
+    if (LOGICAL_OPERATORS.has(tokenType)) {
+      const flag =
+        tokenType === TokenType.QuestionQuestion
+          ? NULLISH_FLAG
+          : SHORT_CIRCUIT_FLAG;
+      if ((ctx & ~flag) !== 0) {
+        throw new SyntaxError(
+          `Cannot mix '??' with '||' or '&&' without parentheses at position ${lexer.token.start}`,
+        );
+      }
+      ctx |= flag;
+    }
+
+    const opToken = lexer.next(); // consume operator
+    const opType = opToken.type;
+
+    // For right-associative ** use same precedence; for left-assoc use prec+1
+    const nextMinPrec = opType === TokenType.StarStar ? prec : prec + 1;
+
+    // Parse the right-hand side: unary then binary with higher min precedence
+    // Pass the current logical context so nested operators at higher prec
+    // still participate in mixing checks.
+    const rightUnary = parseUnaryExpression(lexer, () =>
+      parsePrimaryExpressionFn(lexer),
+    );
+    const right = parseBinaryExpressionInner(
+      lexer,
+      rightUnary,
+      nextMinPrec,
+      allowIn,
+      ctx,
+    );
+
+    // Build the node
+    if (LOGICAL_OPERATORS.has(opType)) {
+      const operator = LOGICAL_OPERATOR_MAP[opType];
+      result = Object.freeze({
+        type: "LogicalExpression" as const,
+        start: result.start,
+        end: right.end,
+        operator,
+        left: result,
+        right,
+      });
+    } else {
+      const operator = BINARY_OPERATORS[opType];
+      result = Object.freeze({
+        type: "BinaryExpression" as const,
+        start: result.start,
+        end: right.end,
+        operator,
+        left: result,
+        right,
+      });
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Parse a unary expression (prefix operators).
+ *
+ * Handles: !, ~, +, -, typeof, void, delete, ++, --
+ * Uses an iterative approach with an explicit operator stack.
+ *
+ * @param lexer - The lexer instance.
+ * @param parsePrimary - Function to parse primary expressions.
+ * @returns The parsed unary/update expression, or a primary expression.
+ */
+export const parseUnaryExpression = (
+  lexer: Lexer,
+  parsePrimary: () => AST.Expression,
+): AST.Expression => {
+  // Collect prefix operators onto a stack
+  const prefixStack: Array<{
+    readonly type: "unary" | "update";
+    readonly operator: string;
+    readonly start: number;
+  }> = [];
+
+  while (true) {
+    const tokenType = lexer.token.type;
+
+    // Prefix ++ or --
+    if (
+      tokenType === TokenType.PlusPlus ||
+      tokenType === TokenType.MinusMinus
+    ) {
+      const start = lexer.token.start;
+      const op = tokenType === TokenType.PlusPlus ? "++" : "--";
+      lexer.next();
+      prefixStack.push({ type: "update", operator: op, start });
+      continue;
+    }
+
+    // Unary operators: !, ~, +, -, typeof, void, delete
+    if (UNARY_TOKEN_SET.has(tokenType)) {
+      const start = lexer.token.start;
+      const op = UNARY_OPERATORS[tokenType];
+      lexer.next();
+      prefixStack.push({ type: "unary", operator: op, start });
+      continue;
+    }
+
+    break;
+  }
+
+  // Parse the operand (primary expression)
+  let expr = parsePrimary();
+
+  // Apply postfix ++ / -- (no line terminator between)
+  expr = parsePostfixExpression(lexer, expr);
+
+  // Wrap from innermost to outermost prefix operator
+  for (let i = prefixStack.length - 1; i >= 0; i--) {
+    const prefix = prefixStack[i];
+    if (prefix.type === "update") {
+      expr = Object.freeze({
+        type: "UpdateExpression" as const,
+        start: prefix.start,
+        end: expr.end,
+        operator: prefix.operator as AST.UpdateOperator,
+        argument: expr,
+        prefix: true,
+      });
+    } else {
+      expr = Object.freeze({
+        type: "UnaryExpression" as const,
+        start: prefix.start,
+        end: expr.end,
+        operator: prefix.operator as AST.UnaryOperator,
+        prefix: true,
+        argument: expr,
+      });
+    }
+  }
+
+  return expr;
+};
+
+/**
+ * Parse postfix update expressions (++ and --).
+ *
+ * Only applies if no line terminator precedes the ++ or -- token.
+ *
+ * @param lexer - The lexer instance.
+ * @param expr - The expression to potentially wrap.
+ * @returns The original expression or an UpdateExpression node.
+ */
+export const parsePostfixExpression = (
+  lexer: Lexer,
+  expr: AST.Expression,
+): AST.Expression => {
+  if (
+    (lexer.token.type === TokenType.PlusPlus ||
+      lexer.token.type === TokenType.MinusMinus) &&
+    !lexer.hadLineTerminatorBefore
+  ) {
+    const op = lexer.token.type === TokenType.PlusPlus ? "++" : "--";
+    const endToken = lexer.next();
+    return Object.freeze({
+      type: "UpdateExpression" as const,
+      start: expr.start,
+      end: endToken.end,
+      operator: op as AST.UpdateOperator,
+      argument: expr,
+      prefix: false,
+    });
+  }
+  return expr;
+};
+
+/**
+ * Parse a conditional (ternary) expression: test ? consequent : alternate
+ *
+ * @param lexer - The lexer instance.
+ * @param test - The test expression (already parsed).
+ * @param parseAssign - Function to parse an assignment expression (for branches).
+ * @returns The test expression unchanged, or a ConditionalExpression node.
+ */
+export const parseConditionalExpression = (
+  lexer: Lexer,
+  test: AST.Expression,
+  parseAssign: () => AST.Expression,
+): AST.Expression => {
+  if (!lexer.is(TokenType.QuestionMark)) {
+    return test;
+  }
+
+  lexer.next(); // consume ?
+  const consequent = parseAssign();
+  lexer.expect(TokenType.Colon);
+  const alternate = parseAssign();
+
+  return Object.freeze({
+    type: "ConditionalExpression" as const,
+    start: test.start,
+    end: alternate.end,
+    test,
+    consequent,
+    alternate,
+  });
+};
+
+/**
+ * Parse an assignment expression if the current token is an assignment operator.
+ *
+ * @param lexer - The lexer instance.
+ * @param left - The left-hand side expression.
+ * @param parseRight - Function to parse the right-hand side (assignment expression).
+ * @returns An AssignmentExpression node, or null if not an assignment.
+ */
+export const parseAssignment = (
+  lexer: Lexer,
+  left: AST.Expression,
+  parseRight: () => AST.Expression,
+): AST.Expression | null => {
+  const operator = ASSIGNMENT_OPERATORS[lexer.token.type];
+  if (operator === undefined) {
+    return null;
+  }
+
+  lexer.next(); // consume assignment operator
+  const right = parseRight();
+
+  return Object.freeze({
+    type: "AssignmentExpression" as const,
+    start: left.start,
+    end: right.end,
+    operator,
+    left,
+    right,
+  });
+};
+
+/**
+ * Internal reference to the primary expression parser.
+ * Set by `setPrimaryExpressionParser` during module initialization.
+ *
+ * This avoids circular imports between operators.ts and expressions.ts.
+ */
+let parsePrimaryExpressionFn: (lexer: Lexer) => AST.Expression;
+
+/**
+ * Register the primary expression parser function.
+ *
+ * Called by expressions.ts during initialization to break the
+ * circular dependency between operators and expressions modules.
+ *
+ * @param fn - The primary expression parser function.
+ */
+export const setPrimaryExpressionParser = (
+  fn: (lexer: Lexer) => AST.Expression,
+): void => {
+  parsePrimaryExpressionFn = fn;
+};

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -295,7 +295,7 @@ export class Parser implements DeclarationsContext, StatementsContext {
    * @returns The Expression AST node.
    */
   parseExpression(): AST.Expression {
-    return parseExpressionModule(this.lexer);
+    return parseExpressionModule(this.lexer, this.allowIn);
   }
 
   /**
@@ -304,7 +304,7 @@ export class Parser implements DeclarationsContext, StatementsContext {
    * @returns The Expression AST node.
    */
   parseAssignmentExpression(): AST.Expression {
-    return parseAssignmentExpressionModule(this.lexer);
+    return parseAssignmentExpressionModule(this.lexer, this.allowIn);
   }
 
   /**

--- a/tests/unit/parser/operators.test.ts
+++ b/tests/unit/parser/operators.test.ts
@@ -1,0 +1,683 @@
+/**
+ * Unit tests for operator expression parsing (Pratt parsing).
+ *
+ * Covers binary, logical, unary, update, conditional, and assignment
+ * expressions with correct precedence, associativity, and error handling.
+ *
+ * @module tests/unit/parser/operators
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../../src/parser/parser.js";
+import type * as AST from "../../../src/ast/types.js";
+
+/**
+ * Helper to parse an expression from an expression statement.
+ */
+const parseExpr = (source: string): AST.Expression => {
+  const program = parse(source, { sourceType: "module" });
+  expect(program.body.length).toBeGreaterThan(0);
+  const stmt = program.body[0];
+  expect(stmt.type).toBe("ExpressionStatement");
+  return (stmt as AST.ExpressionStatement).expression;
+};
+
+describe("Operator Parsing (Pratt)", () => {
+  describe("Binary Arithmetic Operators", () => {
+    it("should parse addition", () => {
+      const expr = parseExpr("1 + 2;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("+");
+      expect((expr.left as AST.Literal).value).toBe(1);
+      expect((expr.right as AST.Literal).value).toBe(2);
+    });
+
+    it("should parse subtraction", () => {
+      const expr = parseExpr("5 - 3;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("-");
+      expect((expr.left as AST.Literal).value).toBe(5);
+      expect((expr.right as AST.Literal).value).toBe(3);
+    });
+
+    it("should parse multiplication", () => {
+      const expr = parseExpr("3 * 4;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("*");
+    });
+
+    it("should parse division", () => {
+      const expr = parseExpr("10 / 2;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("/");
+    });
+
+    it("should parse modulo", () => {
+      const expr = parseExpr("7 % 3;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("%");
+    });
+
+    it("should parse exponentiation", () => {
+      const expr = parseExpr("5 ** 2;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("**");
+      expect((expr.left as AST.Literal).value).toBe(5);
+      expect((expr.right as AST.Literal).value).toBe(2);
+    });
+  });
+
+  describe("Precedence", () => {
+    it("should respect multiplication over addition: 1 + 2 * 3", () => {
+      const expr = parseExpr("1 + 2 * 3;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("+");
+      expect((expr.left as AST.Literal).value).toBe(1);
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe("*");
+      expect((right.left as AST.Literal).value).toBe(2);
+      expect((right.right as AST.Literal).value).toBe(3);
+    });
+
+    it("should respect division over subtraction: 6 - 4 / 2", () => {
+      const expr = parseExpr("6 - 4 / 2;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("-");
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe("/");
+    });
+
+    it("should respect exponentiation over multiplication: 2 * 3 ** 2", () => {
+      const expr = parseExpr("2 * 3 ** 2;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("*");
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe("**");
+    });
+
+    it("should respect comparison over logical: a < b && c > d", () => {
+      const expr = parseExpr("a < b && c > d;") as AST.LogicalExpression;
+      expect(expr.operator).toBe("&&");
+      const left = expr.left as AST.BinaryExpression;
+      expect(left.operator).toBe("<");
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe(">");
+    });
+
+    it("should respect && over ||: a || b && c", () => {
+      const expr = parseExpr("a || b && c;") as AST.LogicalExpression;
+      expect(expr.operator).toBe("||");
+      expect((expr.left as AST.Identifier).name).toBe("a");
+      const right = expr.right as AST.LogicalExpression;
+      expect(right.operator).toBe("&&");
+    });
+
+    it("should respect bitwise AND over bitwise OR: a | b & c", () => {
+      const expr = parseExpr("a | b & c;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("|");
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe("&");
+    });
+
+    it("should respect bitwise XOR precedence: a | b ^ c", () => {
+      const expr = parseExpr("a | b ^ c;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("|");
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe("^");
+    });
+
+    it("should respect shift over addition: a + b << c", () => {
+      const expr = parseExpr("a + b << c;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("<<");
+      const left = expr.left as AST.BinaryExpression;
+      expect(left.operator).toBe("+");
+    });
+
+    it("should parse chained additions left-to-right: 1 + 2 + 3", () => {
+      const expr = parseExpr("1 + 2 + 3;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("+");
+      const left = expr.left as AST.BinaryExpression;
+      expect(left.operator).toBe("+");
+      expect((left.left as AST.Literal).value).toBe(1);
+      expect((left.right as AST.Literal).value).toBe(2);
+      expect((expr.right as AST.Literal).value).toBe(3);
+    });
+  });
+
+  describe("Associativity", () => {
+    it("should parse ** as right-associative: 2 ** 3 ** 4", () => {
+      const expr = parseExpr("2 ** 3 ** 4;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("**");
+      expect((expr.left as AST.Literal).value).toBe(2);
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe("**");
+      expect((right.left as AST.Literal).value).toBe(3);
+      expect((right.right as AST.Literal).value).toBe(4);
+    });
+
+    it("should parse subtraction as left-associative: 10 - 3 - 2", () => {
+      const expr = parseExpr("10 - 3 - 2;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("-");
+      const left = expr.left as AST.BinaryExpression;
+      expect(left.operator).toBe("-");
+      expect((left.left as AST.Literal).value).toBe(10);
+      expect((left.right as AST.Literal).value).toBe(3);
+      expect((expr.right as AST.Literal).value).toBe(2);
+    });
+  });
+
+  describe("Comparison Operators", () => {
+    it("should parse less than", () => {
+      const expr = parseExpr("a < b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("<");
+    });
+
+    it("should parse greater than", () => {
+      const expr = parseExpr("a > b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe(">");
+    });
+
+    it("should parse less than or equal", () => {
+      const expr = parseExpr("a <= b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("<=");
+    });
+
+    it("should parse greater than or equal", () => {
+      const expr = parseExpr("a >= b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe(">=");
+    });
+
+    it("should parse strict equality", () => {
+      const expr = parseExpr("a === b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("===");
+    });
+
+    it("should parse strict inequality", () => {
+      const expr = parseExpr("a !== b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("!==");
+    });
+
+    it("should parse loose equality", () => {
+      const expr = parseExpr("a == b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("==");
+    });
+
+    it("should parse loose inequality", () => {
+      const expr = parseExpr("a != b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("!=");
+    });
+  });
+
+  describe("Logical Operators", () => {
+    it("should parse logical OR", () => {
+      const expr = parseExpr("a || b;") as AST.LogicalExpression;
+      expect(expr.type).toBe("LogicalExpression");
+      expect(expr.operator).toBe("||");
+    });
+
+    it("should parse logical AND", () => {
+      const expr = parseExpr("a && b;") as AST.LogicalExpression;
+      expect(expr.type).toBe("LogicalExpression");
+      expect(expr.operator).toBe("&&");
+    });
+
+    it("should parse nullish coalescing", () => {
+      const expr = parseExpr("a ?? b;") as AST.LogicalExpression;
+      expect(expr.type).toBe("LogicalExpression");
+      expect(expr.operator).toBe("??");
+    });
+
+    it("should chain ?? operators", () => {
+      const expr = parseExpr("a ?? b ?? c;") as AST.LogicalExpression;
+      expect(expr.operator).toBe("??");
+      const left = expr.left as AST.LogicalExpression;
+      expect(left.operator).toBe("??");
+    });
+
+    it("should chain || operators", () => {
+      const expr = parseExpr("a || b || c;") as AST.LogicalExpression;
+      expect(expr.operator).toBe("||");
+      const left = expr.left as AST.LogicalExpression;
+      expect(left.operator).toBe("||");
+    });
+  });
+
+  describe("Bitwise Operators", () => {
+    it("should parse bitwise OR", () => {
+      const expr = parseExpr("a | b;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("|");
+    });
+
+    it("should parse bitwise AND", () => {
+      const expr = parseExpr("a & b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("&");
+    });
+
+    it("should parse bitwise XOR", () => {
+      const expr = parseExpr("a ^ b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("^");
+    });
+
+    it("should parse left shift", () => {
+      const expr = parseExpr("a << b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("<<");
+    });
+
+    it("should parse right shift", () => {
+      const expr = parseExpr("a >> b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe(">>");
+    });
+
+    it("should parse unsigned right shift", () => {
+      const expr = parseExpr("a >>> b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe(">>>");
+    });
+  });
+
+  describe("in and instanceof", () => {
+    it("should parse instanceof operator", () => {
+      const expr = parseExpr("a instanceof B;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("instanceof");
+      expect((expr.left as AST.Identifier).name).toBe("a");
+      expect((expr.right as AST.Identifier).name).toBe("B");
+    });
+
+    it("should parse in operator", () => {
+      const expr = parseExpr("a in b;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("in");
+    });
+  });
+
+  describe("Unary Expressions", () => {
+    it("should parse logical NOT", () => {
+      const expr = parseExpr("!x;") as AST.UnaryExpression;
+      expect(expr.type).toBe("UnaryExpression");
+      expect(expr.operator).toBe("!");
+      expect(expr.prefix).toBe(true);
+      expect((expr.argument as AST.Identifier).name).toBe("x");
+    });
+
+    it("should parse bitwise NOT", () => {
+      const expr = parseExpr("~x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("~");
+      expect(expr.prefix).toBe(true);
+    });
+
+    it("should parse unary plus", () => {
+      const expr = parseExpr("+x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("+");
+      expect(expr.prefix).toBe(true);
+    });
+
+    it("should parse unary minus", () => {
+      const expr = parseExpr("-x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("-");
+      expect(expr.prefix).toBe(true);
+    });
+
+    it("should parse typeof", () => {
+      const expr = parseExpr("typeof x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("typeof");
+      expect(expr.prefix).toBe(true);
+    });
+
+    it("should parse void", () => {
+      const expr = parseExpr("void x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("void");
+      expect(expr.prefix).toBe(true);
+    });
+
+    it("should parse delete", () => {
+      const expr = parseExpr("delete x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("delete");
+      expect(expr.prefix).toBe(true);
+    });
+
+    it("should parse double negation", () => {
+      const expr = parseExpr("!!x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("!");
+      const inner = expr.argument as AST.UnaryExpression;
+      expect(inner.operator).toBe("!");
+      expect((inner.argument as AST.Identifier).name).toBe("x");
+    });
+
+    it("should parse chained unary: -+x", () => {
+      const expr = parseExpr("-+x;") as AST.UnaryExpression;
+      expect(expr.operator).toBe("-");
+      const inner = expr.argument as AST.UnaryExpression;
+      expect(inner.operator).toBe("+");
+    });
+  });
+
+  describe("Update Expressions (prefix)", () => {
+    it("should parse prefix increment", () => {
+      const expr = parseExpr("++x;") as AST.UpdateExpression;
+      expect(expr.type).toBe("UpdateExpression");
+      expect(expr.operator).toBe("++");
+      expect(expr.prefix).toBe(true);
+      expect((expr.argument as AST.Identifier).name).toBe("x");
+    });
+
+    it("should parse prefix decrement", () => {
+      const expr = parseExpr("--x;") as AST.UpdateExpression;
+      expect(expr.type).toBe("UpdateExpression");
+      expect(expr.operator).toBe("--");
+      expect(expr.prefix).toBe(true);
+    });
+  });
+
+  describe("Update Expressions (postfix)", () => {
+    it("should parse postfix increment", () => {
+      const expr = parseExpr("x++;") as AST.UpdateExpression;
+      expect(expr.type).toBe("UpdateExpression");
+      expect(expr.operator).toBe("++");
+      expect(expr.prefix).toBe(false);
+      expect((expr.argument as AST.Identifier).name).toBe("x");
+    });
+
+    it("should parse postfix decrement", () => {
+      const expr = parseExpr("x--;") as AST.UpdateExpression;
+      expect(expr.type).toBe("UpdateExpression");
+      expect(expr.operator).toBe("--");
+      expect(expr.prefix).toBe(false);
+    });
+  });
+
+  describe("Conditional (Ternary) Expression", () => {
+    it("should parse simple ternary", () => {
+      const expr = parseExpr("a ? b : c;") as AST.ConditionalExpression;
+      expect(expr.type).toBe("ConditionalExpression");
+      expect((expr.test as AST.Identifier).name).toBe("a");
+      expect((expr.consequent as AST.Identifier).name).toBe("b");
+      expect((expr.alternate as AST.Identifier).name).toBe("c");
+    });
+
+    it("should parse nested ternary in consequent", () => {
+      const expr = parseExpr("a ? b ? c : d : e;") as AST.ConditionalExpression;
+      expect(expr.type).toBe("ConditionalExpression");
+      expect((expr.test as AST.Identifier).name).toBe("a");
+      const inner = expr.consequent as AST.ConditionalExpression;
+      expect(inner.type).toBe("ConditionalExpression");
+      expect((inner.test as AST.Identifier).name).toBe("b");
+      expect((inner.consequent as AST.Identifier).name).toBe("c");
+      expect((inner.alternate as AST.Identifier).name).toBe("d");
+      expect((expr.alternate as AST.Identifier).name).toBe("e");
+    });
+
+    it("should parse nested ternary in alternate", () => {
+      const expr = parseExpr("a ? b : c ? d : e;") as AST.ConditionalExpression;
+      expect(expr.type).toBe("ConditionalExpression");
+      expect((expr.test as AST.Identifier).name).toBe("a");
+      expect((expr.consequent as AST.Identifier).name).toBe("b");
+      const inner = expr.alternate as AST.ConditionalExpression;
+      expect(inner.type).toBe("ConditionalExpression");
+      expect((inner.test as AST.Identifier).name).toBe("c");
+    });
+
+    it("should parse ternary with binary test", () => {
+      const expr = parseExpr("a > b ? c : d;") as AST.ConditionalExpression;
+      expect(expr.type).toBe("ConditionalExpression");
+      const test = expr.test as AST.BinaryExpression;
+      expect(test.operator).toBe(">");
+    });
+  });
+
+  describe("Assignment Expressions", () => {
+    it("should parse simple assignment", () => {
+      const expr = parseExpr("x = 1;") as AST.AssignmentExpression;
+      expect(expr.type).toBe("AssignmentExpression");
+      expect(expr.operator).toBe("=");
+      expect((expr.left as AST.Identifier).name).toBe("x");
+      expect((expr.right as AST.Literal).value).toBe(1);
+    });
+
+    it("should parse += assignment", () => {
+      const expr = parseExpr("x += 1;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("+=");
+    });
+
+    it("should parse -= assignment", () => {
+      const expr = parseExpr("x -= 1;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("-=");
+    });
+
+    it("should parse *= assignment", () => {
+      const expr = parseExpr("x *= 2;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("*=");
+    });
+
+    it("should parse /= assignment", () => {
+      const expr = parseExpr("x /= 2;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("/=");
+    });
+
+    it("should parse %= assignment", () => {
+      const expr = parseExpr("x %= 3;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("%=");
+    });
+
+    it("should parse **= assignment", () => {
+      const expr = parseExpr("x **= 2;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("**=");
+    });
+
+    it("should parse &= assignment", () => {
+      const expr = parseExpr("x &= y;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("&=");
+    });
+
+    it("should parse |= assignment", () => {
+      const expr = parseExpr("x |= y;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("|=");
+    });
+
+    it("should parse ^= assignment", () => {
+      const expr = parseExpr("x ^= y;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("^=");
+    });
+
+    it("should parse <<= assignment", () => {
+      const expr = parseExpr("x <<= 1;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("<<=");
+    });
+
+    it("should parse >>= assignment", () => {
+      const expr = parseExpr("x >>= 1;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe(">>=");
+    });
+
+    it("should parse >>>= assignment", () => {
+      const expr = parseExpr("x >>>= 1;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe(">>>=");
+    });
+
+    it("should parse &&= assignment", () => {
+      const expr = parseExpr("x &&= y;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("&&=");
+    });
+
+    it("should parse ||= assignment", () => {
+      const expr = parseExpr("x ||= y;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("||=");
+    });
+
+    it("should parse ??= assignment", () => {
+      const expr = parseExpr("x ??= y;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("??=");
+    });
+
+    it("should parse chained assignment: a = b = c", () => {
+      const expr = parseExpr("a = b = c;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("=");
+      expect((expr.left as AST.Identifier).name).toBe("a");
+      const right = expr.right as AST.AssignmentExpression;
+      expect(right.operator).toBe("=");
+      expect((right.left as AST.Identifier).name).toBe("b");
+      expect((right.right as AST.Identifier).name).toBe("c");
+    });
+  });
+
+  describe("Sequence Expression", () => {
+    it("should parse comma-separated expressions", () => {
+      const expr = parseExpr("a, b, c;") as AST.SequenceExpression;
+      expect(expr.type).toBe("SequenceExpression");
+      expect(expr.expressions.length).toBe(3);
+      expect((expr.expressions[0] as AST.Identifier).name).toBe("a");
+      expect((expr.expressions[1] as AST.Identifier).name).toBe("b");
+      expect((expr.expressions[2] as AST.Identifier).name).toBe("c");
+    });
+
+    it("should parse two-element sequence", () => {
+      const expr = parseExpr("a, b;") as AST.SequenceExpression;
+      expect(expr.type).toBe("SequenceExpression");
+      expect(expr.expressions.length).toBe(2);
+    });
+  });
+
+  describe("Error Cases", () => {
+    it("should throw when mixing ?? with ||", () => {
+      expect(() => parseExpr("a ?? b || c;")).toThrow(
+        /Cannot mix '\?\?' with '\|\|' or '&&'/,
+      );
+    });
+
+    it("should throw when mixing ?? with &&", () => {
+      expect(() => parseExpr("a ?? b && c;")).toThrow(
+        /Cannot mix '\?\?' with '\|\|' or '&&'/,
+      );
+    });
+
+    it("should throw when mixing || with ??", () => {
+      expect(() => parseExpr("a || b ?? c;")).toThrow(
+        /Cannot mix '\?\?' with '\|\|' or '&&'/,
+      );
+    });
+
+    it("should throw when mixing && with ??", () => {
+      expect(() => parseExpr("a && b ?? c;")).toThrow(
+        /Cannot mix '\?\?' with '\|\|' or '&&'/,
+      );
+    });
+
+    it("should allow ?? with || when parenthesized", () => {
+      // (a ?? b) || c — the ?? is inside parens so no mixing at top level
+      const expr = parseExpr("(a ?? b) || c;") as AST.LogicalExpression;
+      expect(expr.operator).toBe("||");
+      const left = expr.left as AST.LogicalExpression;
+      expect(left.operator).toBe("??");
+    });
+  });
+
+  describe("Complex Expressions", () => {
+    it("should parse unary with binary: -a + b", () => {
+      const expr = parseExpr("-a + b;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("+");
+      const left = expr.left as AST.UnaryExpression;
+      expect(left.operator).toBe("-");
+      expect((left.argument as AST.Identifier).name).toBe("a");
+    });
+
+    it("should parse typeof in comparison: typeof x === 'string'", () => {
+      const expr = parseExpr("typeof x === 'string';") as AST.BinaryExpression;
+      expect(expr.operator).toBe("===");
+      const left = expr.left as AST.UnaryExpression;
+      expect(left.operator).toBe("typeof");
+    });
+
+    it("should parse assignment with binary RHS: x = a + b", () => {
+      const expr = parseExpr("x = a + b;") as AST.AssignmentExpression;
+      expect(expr.operator).toBe("=");
+      const right = expr.right as AST.BinaryExpression;
+      expect(right.operator).toBe("+");
+    });
+
+    it("should parse ternary with assignment: a ? x = 1 : x = 2", () => {
+      const expr = parseExpr("a ? x = 1 : x = 2;") as AST.ConditionalExpression;
+      expect(expr.type).toBe("ConditionalExpression");
+      const consequent = expr.consequent as AST.AssignmentExpression;
+      expect(consequent.operator).toBe("=");
+      const alternate = expr.alternate as AST.AssignmentExpression;
+      expect(alternate.operator).toBe("=");
+    });
+
+    it("should parse postfix with binary: x++ + y", () => {
+      const expr = parseExpr("x++ + y;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("+");
+      const left = expr.left as AST.UpdateExpression;
+      expect(left.operator).toBe("++");
+      expect(left.prefix).toBe(false);
+    });
+
+    it("should parse prefix with binary: ++x * 2", () => {
+      const expr = parseExpr("++x * 2;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("*");
+      const left = expr.left as AST.UpdateExpression;
+      expect(left.operator).toBe("++");
+      expect(left.prefix).toBe(true);
+    });
+
+    it("should parse void with binary: void 0 === undefined", () => {
+      // void binds tighter than ===, so this is (void 0) === undefined
+      // Actually void is a unary prefix so it only takes its immediate operand
+      const expr = parseExpr("void 0 === undefined;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("===");
+      const left = expr.left as AST.UnaryExpression;
+      expect(left.operator).toBe("void");
+    });
+
+    it("should handle parenthesized expressions overriding precedence", () => {
+      const expr = parseExpr("(1 + 2) * 3;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("*");
+      const left = expr.left as AST.BinaryExpression;
+      expect(left.operator).toBe("+");
+    });
+
+    it("should parse equality chain: a === b === c (left-assoc)", () => {
+      const expr = parseExpr("a == b == c;") as AST.BinaryExpression;
+      expect(expr.operator).toBe("==");
+      const left = expr.left as AST.BinaryExpression;
+      expect(left.operator).toBe("==");
+      expect((left.left as AST.Identifier).name).toBe("a");
+      expect((left.right as AST.Identifier).name).toBe("b");
+      expect((expr.right as AST.Identifier).name).toBe("c");
+    });
+  });
+
+  describe("Node Position Tracking", () => {
+    it("should track start/end for binary expression", () => {
+      const expr = parseExpr("a + b;") as AST.BinaryExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(5);
+    });
+
+    it("should track start/end for unary expression", () => {
+      const expr = parseExpr("!x;") as AST.UnaryExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(2);
+    });
+
+    it("should track start/end for update expression (prefix)", () => {
+      const expr = parseExpr("++x;") as AST.UpdateExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(3);
+    });
+
+    it("should track start/end for update expression (postfix)", () => {
+      const expr = parseExpr("x++;") as AST.UpdateExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(3);
+    });
+
+    it("should track start/end for conditional expression", () => {
+      const expr = parseExpr("a ? b : c;") as AST.ConditionalExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(9);
+    });
+
+    it("should track start/end for assignment expression", () => {
+      const expr = parseExpr("x = 1;") as AST.AssignmentExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements iterative Pratt parsing for full operator precedence in `src/parser/operators.ts`
- Supports binary (arithmetic, comparison, bitwise, shift, `in`, `instanceof`), logical (`||`, `&&`, `??`), unary (`!`, `~`, `+`, `-`, `typeof`, `void`, `delete`), update (`++`, `--` prefix/postfix), conditional (ternary), and all assignment operators
- Enforces illegal `??` mixing with `||`/`&&` without parentheses
- Handles right-associativity for `**` and `allowIn` for for-in disambiguation
- 94 new tests with 100% coverage on the operators module

Closes #29

## Test plan

- [x] All 94 operator-specific tests pass
- [x] All 2218 existing tests pass (no regressions)
- [x] TypeScript strict mode typecheck passes
- [x] 100% statement/branch/function/line coverage on `operators.ts`
- [x] Prettier formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)