### PR TITLE
feat: implement parser member access, calls, and optional chaining

### DIFF
--- a/src/parser/expressions.ts
+++ b/src/parser/expressions.ts
@@ -7,7 +7,7 @@
  * conditional expression parsing via Pratt parsing (issue #29).
  *
  * Function/arrow/class expressions will be implemented by issue #27.
- * Member/call expressions will be implemented by issue #31.
+ * Member/call expressions are handled by the member-call module.
  *
  * @module parser/expressions
  */
@@ -23,6 +23,11 @@ import {
   parseAssignment,
   setPrimaryExpressionParser,
 } from "./operators.js";
+import {
+  parseMemberCallExpression,
+  parseNewExpression,
+  parseSuperExpression,
+} from "./member-call.js";
 
 /**
  * Parse a full expression, handling sequence expressions (comma-separated).
@@ -76,9 +81,9 @@ export const parseAssignmentExpression = (
   lexer: Lexer,
   allowIn: boolean = true,
 ): AST.Expression => {
-  // Parse unary (prefix operators + primary + postfix)
+  // Parse unary (prefix operators + primary with member/call + postfix)
   const unary = parseUnaryExpression(lexer, () =>
-    parsePrimaryExpression(lexer),
+    parseLeftHandSideExpression(lexer),
   );
 
   // Parse binary/logical with Pratt precedence
@@ -167,6 +172,106 @@ export const parsePrimaryExpression = (lexer: Lexer): AST.Expression => {
       );
     }
   }
+};
+
+/**
+ * Parse a left-hand side expression.
+ *
+ * Handles new expressions, super, and extends primary expressions
+ * with member access, call expressions, and optional chaining.
+ *
+ * @param lexer - The lexer instance.
+ * @returns The parsed Expression AST node.
+ */
+const parseLeftHandSideExpression = (lexer: Lexer): AST.Expression => {
+  // Handle 'new' expression
+  if (lexer.is(TokenType.New)) {
+    const newExpr = parseNewExpression(
+      lexer,
+      () => parsePrimaryExpression(lexer),
+      () => parseAssignmentExpression(lexer),
+    );
+    // After new, continue with member/call chain
+    return parseMemberCallExpression(lexer, newExpr, () =>
+      parseAssignmentExpression(lexer),
+    );
+  }
+
+  // Handle 'super' expression
+  if (lexer.is(TokenType.Super)) {
+    const superExpr = parseSuperExpression(lexer, () =>
+      parseAssignmentExpression(lexer),
+    );
+    // After super.prop or super(), continue with member/call chain
+    return parseMemberCallExpression(lexer, superExpr, () =>
+      parseAssignmentExpression(lexer),
+    );
+  }
+
+  // Handle 'import' for import() and import.meta
+  if (lexer.is(TokenType.Import)) {
+    const saved = lexer.saveState();
+    const importStart = lexer.token.start;
+    lexer.next();
+
+    // import.meta
+    if (lexer.is(TokenType.Dot)) {
+      lexer.next();
+      if (
+        lexer.is(TokenType.Identifier) &&
+        (lexer.token.value as string) === "meta"
+      ) {
+        const metaToken = lexer.next();
+        const metaProp: AST.MetaProperty = Object.freeze({
+          type: "MetaProperty" as const,
+          start: importStart,
+          end: metaToken.end,
+          meta: Object.freeze({
+            type: "Identifier" as const,
+            start: importStart,
+            end: importStart + 6,
+            name: "import",
+          }),
+          property: Object.freeze({
+            type: "Identifier" as const,
+            start: metaToken.start,
+            end: metaToken.end,
+            name: "meta",
+          }),
+        });
+        return parseMemberCallExpression(lexer, metaProp, () =>
+          parseAssignmentExpression(lexer),
+        );
+      }
+      // Not import.meta, restore
+      lexer.restoreState(saved);
+    }
+
+    // import() dynamic import
+    if (lexer.is(TokenType.LeftParen)) {
+      lexer.next();
+      const source = parseAssignmentExpression(lexer);
+      const closeParen = lexer.expect(TokenType.RightParen);
+      const importExpr: AST.ImportExpression = Object.freeze({
+        type: "ImportExpression" as const,
+        start: importStart,
+        end: closeParen.end,
+        source,
+      });
+      return parseMemberCallExpression(lexer, importExpr, () =>
+        parseAssignmentExpression(lexer),
+      );
+    }
+
+    // Not import() or import.meta, restore for statement-level import
+    lexer.restoreState(saved);
+  }
+
+  // Parse primary expression and extend with member/call
+  const primary = parsePrimaryExpression(lexer);
+  return parseMemberCallExpression(lexer, primary, () =>
+    parseAssignmentExpression(lexer),
+  );
 };
 
 /**
@@ -917,6 +1022,6 @@ const parseClassExpressionStub = (lexer: Lexer): AST.ClassExpression => {
   );
 };
 
-// Register primary expression parser with the operators module to
-// break the circular dependency.
-setPrimaryExpressionParser(parsePrimaryExpression);
+// Register left-hand side expression parser with the operators module to
+// break the circular dependency. This includes member/call/new parsing.
+setPrimaryExpressionParser(parseLeftHandSideExpression);

--- a/src/parser/member-call.ts
+++ b/src/parser/member-call.ts
@@ -1,0 +1,511 @@
+/**
+ * Member access, call expression, and optional chaining parser.
+ *
+ * Implements iterative left-to-right parsing of:
+ * - Member access: obj.prop, obj[expr]
+ * - Call expressions: fn(args), fn(...args)
+ * - Optional chaining: obj?.prop, obj?.[expr], fn?.()
+ * - New expressions: new Foo(), new Foo, new Foo(a, b)
+ * - Tagged templates: tag`template`
+ *
+ * Uses iterative while loops (no recursion) per coding standards.
+ *
+ * @module parser/member-call
+ */
+
+import type * as AST from "../ast/types.js";
+import type { Lexer } from "./lexer.js";
+import { TokenType } from "./token-types.js";
+import { tokenTypeName } from "./token-types.js";
+import { parseTaggedTemplate } from "./expressions.js";
+
+/**
+ * Result of parsing call arguments: the argument list and end position.
+ */
+interface ParsedArguments {
+  readonly args: ReadonlyArray<AST.Expression | AST.SpreadElement>;
+  readonly end: number;
+}
+
+/**
+ * Parse call arguments: (expr, expr, ...expr)
+ *
+ * Consumes the opening and closing parentheses and parses
+ * comma-separated expressions with spread support.
+ *
+ * @param lexer - The lexer instance.
+ * @param parseExpr - Function to parse an assignment expression.
+ * @returns The parsed arguments and the end position after closing paren.
+ */
+export const parseArguments = (
+  lexer: Lexer,
+  parseExpr: () => AST.Expression,
+): ParsedArguments => {
+  lexer.expect(TokenType.LeftParen);
+  const args: Array<AST.Expression | AST.SpreadElement> = [];
+
+  while (!lexer.is(TokenType.RightParen)) {
+    if (lexer.is(TokenType.EOF)) {
+      throw new SyntaxError(
+        `Unterminated argument list at position ${lexer.token.start}`,
+      );
+    }
+
+    // Spread argument
+    if (lexer.is(TokenType.Ellipsis)) {
+      const spreadStart = lexer.token.start;
+      lexer.next();
+      const argument = parseExpr();
+      args.push(
+        Object.freeze({
+          type: "SpreadElement" as const,
+          start: spreadStart,
+          end: argument.end,
+          argument,
+        }),
+      );
+    } else {
+      const arg = parseExpr();
+      args.push(arg);
+    }
+
+    // Consume trailing comma or expect closing paren
+    if (!lexer.is(TokenType.RightParen)) {
+      if (lexer.is(TokenType.Comma)) {
+        lexer.next();
+      } else {
+        const name = tokenTypeName(lexer.token.type);
+        throw new SyntaxError(
+          `Expected ',' or ')' in argument list but found ${name} at position ${lexer.token.start}`,
+        );
+      }
+    }
+  }
+
+  const closeParen = lexer.expect(TokenType.RightParen);
+  return { args: Object.freeze(args), end: closeParen.end };
+};
+
+/**
+ * Parse an identifier for member access (property name).
+ *
+ * Accepts identifiers and contextual keywords that are valid as
+ * property names (e.g., get, set, async, etc.).
+ *
+ * @param lexer - The lexer instance.
+ * @returns An Identifier AST node.
+ * @throws {SyntaxError} If the current token is not a valid property name.
+ */
+const parsePropertyIdentifier = (lexer: Lexer): AST.Identifier => {
+  const token = lexer.token;
+
+  // Accept identifiers and contextual/reserved keywords as property names
+  if (
+    token.type === TokenType.Identifier ||
+    token.type === TokenType.Get ||
+    token.type === TokenType.Set ||
+    token.type === TokenType.Async ||
+    token.type === TokenType.From ||
+    token.type === TokenType.Of ||
+    token.type === TokenType.As ||
+    token.type === TokenType.Let ||
+    token.type === TokenType.Static ||
+    token.type === TokenType.Yield ||
+    token.type === TokenType.Await ||
+    // Reserved keywords allowed as property names
+    token.type === TokenType.Break ||
+    token.type === TokenType.Case ||
+    token.type === TokenType.Catch ||
+    token.type === TokenType.Continue ||
+    token.type === TokenType.Debugger ||
+    token.type === TokenType.Default ||
+    token.type === TokenType.Delete ||
+    token.type === TokenType.Do ||
+    token.type === TokenType.Else ||
+    token.type === TokenType.Finally ||
+    token.type === TokenType.For ||
+    token.type === TokenType.Function ||
+    token.type === TokenType.If ||
+    token.type === TokenType.In ||
+    token.type === TokenType.Instanceof ||
+    token.type === TokenType.New ||
+    token.type === TokenType.Return ||
+    token.type === TokenType.Switch ||
+    token.type === TokenType.This ||
+    token.type === TokenType.Throw ||
+    token.type === TokenType.Try ||
+    token.type === TokenType.Typeof ||
+    token.type === TokenType.Var ||
+    token.type === TokenType.Void ||
+    token.type === TokenType.While ||
+    token.type === TokenType.With ||
+    token.type === TokenType.Class ||
+    token.type === TokenType.Const ||
+    token.type === TokenType.Export ||
+    token.type === TokenType.Extends ||
+    token.type === TokenType.Import ||
+    token.type === TokenType.Super ||
+    token.type === TokenType.True ||
+    token.type === TokenType.False ||
+    token.type === TokenType.Null
+  ) {
+    const consumed = lexer.next();
+    // For literal keywords (true/false/null), use raw since value is the actual value
+    const name =
+      consumed.type === TokenType.True ||
+      consumed.type === TokenType.False ||
+      consumed.type === TokenType.Null
+        ? consumed.raw
+        : (consumed.value as string);
+    return Object.freeze({
+      type: "Identifier" as const,
+      start: consumed.start,
+      end: consumed.end,
+      name,
+    });
+  }
+
+  const name = tokenTypeName(token.type);
+  throw new SyntaxError(
+    `Expected property name but found ${name} at position ${token.start}`,
+  );
+};
+
+/**
+ * Parse member/call/optional chain expression iteratively.
+ *
+ * Takes a parsed primary expression and extends it with
+ * .prop, [expr], (args), ?.prop, ?.[expr], ?.(), and tagged templates.
+ *
+ * If optional chaining is used, the result is wrapped in a ChainExpression.
+ *
+ * @param lexer - The lexer instance.
+ * @param object - The initial (primary) expression.
+ * @param parseExpr - Function to parse an assignment expression.
+ * @returns The extended expression (possibly wrapped in ChainExpression).
+ */
+export const parseMemberCallExpression = (
+  lexer: Lexer,
+  object: AST.Expression,
+  parseExpr: () => AST.Expression,
+): AST.Expression => {
+  let result = object;
+  let inOptionalChain = false;
+
+  // Iterative loop: keep consuming . [] () ?. or tagged templates
+  while (true) {
+    if (lexer.is(TokenType.Dot)) {
+      // MemberExpression: obj.prop
+      lexer.next();
+      const property = parsePropertyIdentifier(lexer);
+      result = Object.freeze({
+        type: "MemberExpression" as const,
+        start: result.start,
+        end: property.end,
+        object: result,
+        property,
+        computed: false,
+        optional: false,
+      });
+    } else if (lexer.is(TokenType.LeftBracket)) {
+      // MemberExpression (computed): obj[expr]
+      lexer.next();
+      const property = parseExpr();
+      const closeBracket = lexer.expect(TokenType.RightBracket);
+      result = Object.freeze({
+        type: "MemberExpression" as const,
+        start: result.start,
+        end: closeBracket.end,
+        object: result,
+        property,
+        computed: true,
+        optional: false,
+      });
+    } else if (lexer.is(TokenType.LeftParen)) {
+      // CallExpression: fn(args)
+      const parsed = parseArguments(lexer, parseExpr);
+      result = Object.freeze({
+        type: "CallExpression" as const,
+        start: result.start,
+        end: parsed.end,
+        callee: result,
+        arguments: parsed.args,
+        optional: false,
+      });
+    } else if (lexer.is(TokenType.QuestionDot)) {
+      // Optional chaining: ?.prop, ?.[expr], ?.()
+      inOptionalChain = true;
+      lexer.next();
+
+      if (lexer.is(TokenType.LeftParen)) {
+        // Optional call: obj?.()
+        const parsed = parseArguments(lexer, parseExpr);
+        result = Object.freeze({
+          type: "CallExpression" as const,
+          start: result.start,
+          end: parsed.end,
+          callee: result,
+          arguments: parsed.args,
+          optional: true,
+        });
+      } else if (lexer.is(TokenType.LeftBracket)) {
+        // Optional computed member: obj?.[expr]
+        lexer.next();
+        const property = parseExpr();
+        const closeBracket = lexer.expect(TokenType.RightBracket);
+        result = Object.freeze({
+          type: "MemberExpression" as const,
+          start: result.start,
+          end: closeBracket.end,
+          object: result,
+          property,
+          computed: true,
+          optional: true,
+        });
+      } else {
+        // Optional member: obj?.prop
+        const property = parsePropertyIdentifier(lexer);
+        result = Object.freeze({
+          type: "MemberExpression" as const,
+          start: result.start,
+          end: property.end,
+          object: result,
+          property,
+          computed: false,
+          optional: true,
+        });
+      }
+    } else if (
+      lexer.is(TokenType.TemplateHead) ||
+      lexer.is(TokenType.TemplateNoSub) ||
+      lexer.is(TokenType.TemplateLiteral)
+    ) {
+      // Tagged template: tag`...`
+      result = parseTaggedTemplate(lexer, result);
+    } else {
+      break;
+    }
+  }
+
+  // Wrap in ChainExpression if optional chaining was used
+  if (inOptionalChain) {
+    result = Object.freeze({
+      type: "ChainExpression" as const,
+      start: result.start,
+      end: result.end,
+      expression: result as AST.CallExpression | AST.MemberExpression,
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Parse a new expression: new Foo(args) or new Foo
+ *
+ * Handles nested new expressions (new new Foo()) iteratively using
+ * an explicit stack of 'new' start positions.
+ *
+ * @param lexer - The lexer instance.
+ * @param parsePrimary - Function to parse primary expressions.
+ * @param parseExpr - Function to parse assignment expressions.
+ * @returns A NewExpression AST node.
+ */
+export const parseNewExpression = (
+  lexer: Lexer,
+  parsePrimary: () => AST.Expression,
+  parseExpr: () => AST.Expression,
+): AST.Expression => {
+  // Collect nested 'new' keywords
+  const newStarts: Array<number> = [];
+
+  while (lexer.is(TokenType.New)) {
+    const start = lexer.token.start;
+    lexer.next();
+
+    // Check for new.target meta property
+    if (lexer.is(TokenType.Dot)) {
+      const saved = lexer.saveState();
+      lexer.next();
+      if (
+        lexer.is(TokenType.Identifier) &&
+        (lexer.token.value as string) === "target"
+      ) {
+        const targetToken = lexer.next();
+        const metaResult: AST.MetaProperty = Object.freeze({
+          type: "MetaProperty" as const,
+          start,
+          end: targetToken.end,
+          meta: Object.freeze({
+            type: "Identifier" as const,
+            start,
+            end: start + 3,
+            name: "new",
+          }),
+          property: Object.freeze({
+            type: "Identifier" as const,
+            start: targetToken.start,
+            end: targetToken.end,
+            name: "target",
+          }),
+        });
+
+        // Wrap any pending new starts around the result
+        let wrapped: AST.Expression = metaResult;
+        for (let i = newStarts.length - 1; i >= 0; i--) {
+          wrapped = Object.freeze({
+            type: "NewExpression" as const,
+            start: newStarts[i],
+            end: wrapped.end,
+            callee: wrapped,
+            arguments: Object.freeze([]) as ReadonlyArray<
+              AST.Expression | AST.SpreadElement
+            >,
+          });
+        }
+        return wrapped;
+      }
+      lexer.restoreState(saved);
+    }
+
+    newStarts.push(start);
+  }
+
+  // Parse the callee (primary expression)
+  let callee = parsePrimary();
+
+  // Parse member accesses on the callee (but not calls - those are for the outermost new)
+  // new foo.bar() should be new (foo.bar)()
+  while (lexer.is(TokenType.Dot) || lexer.is(TokenType.LeftBracket)) {
+    if (lexer.is(TokenType.Dot)) {
+      lexer.next();
+      const property = parsePropertyIdentifier(lexer);
+      callee = Object.freeze({
+        type: "MemberExpression" as const,
+        start: callee.start,
+        end: property.end,
+        object: callee,
+        property,
+        computed: false,
+        optional: false,
+      });
+    } else {
+      lexer.next();
+      const property = parseExpr();
+      const closeBracket = lexer.expect(TokenType.RightBracket);
+      callee = Object.freeze({
+        type: "MemberExpression" as const,
+        start: callee.start,
+        end: closeBracket.end,
+        object: callee,
+        property,
+        computed: true,
+        optional: false,
+      });
+    }
+  }
+
+  // Build NewExpression nodes from inside out
+  // The innermost 'new' gets the arguments (if any)
+  let result: AST.Expression = callee;
+
+  for (let i = newStarts.length - 1; i >= 0; i--) {
+    // Only the outermost (first) new gets arguments if there's a paren
+    // Actually, the innermost new gets the args: new new Foo(a) => new (new Foo(a))
+    // Let's handle it: only the innermost gets args if () follows immediately
+    if (i === newStarts.length - 1 && lexer.is(TokenType.LeftParen)) {
+      const parsed = parseArguments(lexer, parseExpr);
+      result = Object.freeze({
+        type: "NewExpression" as const,
+        start: newStarts[i],
+        end: parsed.end,
+        callee: result,
+        arguments: parsed.args,
+      });
+    } else {
+      result = Object.freeze({
+        type: "NewExpression" as const,
+        start: newStarts[i],
+        end: result.end,
+        callee: result,
+        arguments: Object.freeze([]) as ReadonlyArray<
+          AST.Expression | AST.SpreadElement
+        >,
+      });
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Parse a super keyword expression for member access and calls.
+ *
+ * Handles: super.prop, super[expr], super(args)
+ *
+ * @param lexer - The lexer instance.
+ * @param parseExpr - Function to parse assignment expressions.
+ * @returns A Super-based expression (MemberExpression or CallExpression).
+ * @throws {SyntaxError} If super is not followed by . [ or (.
+ */
+export const parseSuperExpression = (
+  lexer: Lexer,
+  parseExpr: () => AST.Expression,
+): AST.Expression => {
+  const start = lexer.token.start;
+  const superToken = lexer.next(); // consume 'super'
+
+  const superNode: AST.Super = Object.freeze({
+    type: "Super" as const,
+    start,
+    end: superToken.end,
+  });
+
+  if (lexer.is(TokenType.Dot)) {
+    // super.prop
+    lexer.next();
+    const property = parsePropertyIdentifier(lexer);
+    return Object.freeze({
+      type: "MemberExpression" as const,
+      start,
+      end: property.end,
+      object: superNode,
+      property,
+      computed: false,
+      optional: false,
+    });
+  }
+
+  if (lexer.is(TokenType.LeftBracket)) {
+    // super[expr]
+    lexer.next();
+    const property = parseExpr();
+    const closeBracket = lexer.expect(TokenType.RightBracket);
+    return Object.freeze({
+      type: "MemberExpression" as const,
+      start,
+      end: closeBracket.end,
+      object: superNode,
+      property,
+      computed: true,
+      optional: false,
+    });
+  }
+
+  if (lexer.is(TokenType.LeftParen)) {
+    // super(args)
+    const parsed = parseArguments(lexer, parseExpr);
+    return Object.freeze({
+      type: "CallExpression" as const,
+      start,
+      end: parsed.end,
+      callee: superNode,
+      arguments: parsed.args,
+      optional: false,
+    });
+  }
+
+  throw new SyntaxError(
+    `'super' keyword must be followed by '.', '[', or '(' at position ${lexer.token.start}`,
+  );
+};

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -208,9 +208,21 @@ export class Parser implements DeclarationsContext, StatementsContext {
       case TokenType.Class:
         return parseClassDeclaration(this);
 
-      // Import declaration (module only)
-      case TokenType.Import:
+      // Import declaration (module only) or import() / import.meta expression
+      case TokenType.Import: {
+        const savedImport = this.lexer.saveState();
+        this.lexer.next();
+        if (
+          this.lexer.is(TokenType.LeftParen) ||
+          this.lexer.is(TokenType.Dot)
+        ) {
+          // import() or import.meta - treat as expression statement
+          this.lexer.restoreState(savedImport);
+          return parseExpressionStatement(this);
+        }
+        this.lexer.restoreState(savedImport);
         return parseImportDeclaration(this);
+      }
 
       // Export declaration (module only)
       case TokenType.Export:

--- a/tests/unit/parser/member-call.test.ts
+++ b/tests/unit/parser/member-call.test.ts
@@ -1,0 +1,576 @@
+/**
+ * Unit tests for member access, call expression, and optional chaining parsing.
+ *
+ * Covers dot access, computed access, function calls, spread in arguments,
+ * chained expressions, optional chaining, new expressions, super expressions,
+ * tagged templates, and error cases.
+ *
+ * @module tests/unit/parser/member-call
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../../src/parser/parser.js";
+import type * as AST from "../../../src/ast/types.js";
+
+/**
+ * Helper to parse an expression from an expression statement.
+ */
+const parseExpr = (source: string): AST.Expression => {
+  const program = parse(source, { sourceType: "module" });
+  expect(program.body.length).toBeGreaterThan(0);
+  const stmt = program.body[0];
+  expect(stmt.type).toBe("ExpressionStatement");
+  return (stmt as AST.ExpressionStatement).expression;
+};
+
+describe("Member Access, Calls, and Optional Chaining", () => {
+  describe("Dot Member Access", () => {
+    it("should parse simple dot access: obj.prop", () => {
+      const expr = parseExpr("obj.prop;") as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect(expr.computed).toBe(false);
+      expect(expr.optional).toBe(false);
+      expect((expr.object as AST.Identifier).name).toBe("obj");
+      expect((expr.property as AST.Identifier).name).toBe("prop");
+    });
+
+    it("should parse chained dot access: obj.a.b.c", () => {
+      const expr = parseExpr("obj.a.b.c;") as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect((expr.property as AST.Identifier).name).toBe("c");
+
+      const mid = expr.object as AST.MemberExpression;
+      expect(mid.type).toBe("MemberExpression");
+      expect((mid.property as AST.Identifier).name).toBe("b");
+
+      const inner = mid.object as AST.MemberExpression;
+      expect(inner.type).toBe("MemberExpression");
+      expect((inner.property as AST.Identifier).name).toBe("a");
+      expect((inner.object as AST.Identifier).name).toBe("obj");
+    });
+
+    it("should allow keywords as property names: obj.class", () => {
+      const expr = parseExpr("obj.class;") as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect((expr.property as AST.Identifier).name).toBe("class");
+    });
+
+    it("should allow contextual keywords as property names: obj.get", () => {
+      const expr = parseExpr("obj.get;") as AST.MemberExpression;
+      expect((expr.property as AST.Identifier).name).toBe("get");
+    });
+
+    it("should allow 'true' as property name: obj.true", () => {
+      const expr = parseExpr("obj.true;") as AST.MemberExpression;
+      expect((expr.property as AST.Identifier).name).toBe("true");
+    });
+
+    it("should allow 'null' as property name: obj.null", () => {
+      const expr = parseExpr("obj.null;") as AST.MemberExpression;
+      expect((expr.property as AST.Identifier).name).toBe("null");
+    });
+
+    it("should have correct start/end positions", () => {
+      const expr = parseExpr("obj.prop;") as AST.MemberExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(8);
+    });
+  });
+
+  describe("Computed Member Access", () => {
+    it("should parse computed access: obj[expr]", () => {
+      const expr = parseExpr("obj[0];") as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect(expr.computed).toBe(true);
+      expect(expr.optional).toBe(false);
+      expect((expr.object as AST.Identifier).name).toBe("obj");
+      expect((expr.property as AST.Literal).value).toBe(0);
+    });
+
+    it("should parse string key: obj['key']", () => {
+      const expr = parseExpr("obj['key'];") as AST.MemberExpression;
+      expect(expr.computed).toBe(true);
+      expect((expr.property as AST.Literal).value).toBe("key");
+    });
+
+    it("should parse expression key: obj[a + b]", () => {
+      const expr = parseExpr("obj[a + b];") as AST.MemberExpression;
+      expect(expr.computed).toBe(true);
+      expect((expr.property as AST.BinaryExpression).operator).toBe("+");
+    });
+
+    it("should parse nested computed: obj[a][b]", () => {
+      const expr = parseExpr("obj[a][b];") as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect((expr.property as AST.Identifier).name).toBe("b");
+      const inner = expr.object as AST.MemberExpression;
+      expect((inner.property as AST.Identifier).name).toBe("a");
+    });
+
+    it("should have correct end position after bracket", () => {
+      const expr = parseExpr("obj[0];") as AST.MemberExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(6);
+    });
+  });
+
+  describe("Call Expressions", () => {
+    it("should parse no-argument call: fn()", () => {
+      const expr = parseExpr("fn();") as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      expect(expr.optional).toBe(false);
+      expect((expr.callee as AST.Identifier).name).toBe("fn");
+      expect(expr.arguments.length).toBe(0);
+    });
+
+    it("should parse single argument: fn(a)", () => {
+      const expr = parseExpr("fn(a);") as AST.CallExpression;
+      expect(expr.arguments.length).toBe(1);
+      expect((expr.arguments[0] as AST.Identifier).name).toBe("a");
+    });
+
+    it("should parse multiple arguments: fn(a, b, c)", () => {
+      const expr = parseExpr("fn(a, b, c);") as AST.CallExpression;
+      expect(expr.arguments.length).toBe(3);
+      expect((expr.arguments[0] as AST.Identifier).name).toBe("a");
+      expect((expr.arguments[1] as AST.Identifier).name).toBe("b");
+      expect((expr.arguments[2] as AST.Identifier).name).toBe("c");
+    });
+
+    it("should parse spread in call: fn(...args)", () => {
+      const expr = parseExpr("fn(...args);") as AST.CallExpression;
+      expect(expr.arguments.length).toBe(1);
+      const spread = expr.arguments[0] as AST.SpreadElement;
+      expect(spread.type).toBe("SpreadElement");
+      expect((spread.argument as AST.Identifier).name).toBe("args");
+    });
+
+    it("should parse mixed args with spread: fn(a, ...rest)", () => {
+      const expr = parseExpr("fn(a, ...rest);") as AST.CallExpression;
+      expect(expr.arguments.length).toBe(2);
+      expect((expr.arguments[0] as AST.Identifier).name).toBe("a");
+      expect((expr.arguments[1] as AST.SpreadElement).type).toBe(
+        "SpreadElement",
+      );
+    });
+
+    it("should parse trailing comma in args: fn(a, b,)", () => {
+      const expr = parseExpr("fn(a, b,);") as AST.CallExpression;
+      expect(expr.arguments.length).toBe(2);
+    });
+
+    it("should parse chained calls: fn()()", () => {
+      const expr = parseExpr("fn()();") as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      const inner = expr.callee as AST.CallExpression;
+      expect(inner.type).toBe("CallExpression");
+      expect((inner.callee as AST.Identifier).name).toBe("fn");
+    });
+
+    it("should have correct end position", () => {
+      const expr = parseExpr("fn();") as AST.CallExpression;
+      expect(expr.start).toBe(0);
+      expect(expr.end).toBe(4);
+    });
+  });
+
+  describe("Method Calls", () => {
+    it("should parse method call: obj.method()", () => {
+      const expr = parseExpr("obj.method();") as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect(callee.type).toBe("MemberExpression");
+      expect((callee.object as AST.Identifier).name).toBe("obj");
+      expect((callee.property as AST.Identifier).name).toBe("method");
+    });
+
+    it("should parse chained method calls: a.b().c()", () => {
+      const expr = parseExpr("a.b().c();") as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect(callee.type).toBe("MemberExpression");
+      expect((callee.property as AST.Identifier).name).toBe("c");
+      const inner = callee.object as AST.CallExpression;
+      expect(inner.type).toBe("CallExpression");
+    });
+
+    it("should parse computed method call: obj['method']()", () => {
+      const expr = parseExpr("obj['method']();") as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect(callee.computed).toBe(true);
+    });
+  });
+
+  describe("Optional Chaining", () => {
+    it("should parse optional dot access: obj?.prop", () => {
+      const expr = parseExpr("obj?.prop;") as AST.ChainExpression;
+      expect(expr.type).toBe("ChainExpression");
+      const member = expr.expression as AST.MemberExpression;
+      expect(member.type).toBe("MemberExpression");
+      expect(member.optional).toBe(true);
+      expect(member.computed).toBe(false);
+      expect((member.object as AST.Identifier).name).toBe("obj");
+      expect((member.property as AST.Identifier).name).toBe("prop");
+    });
+
+    it("should parse optional computed access: obj?.[expr]", () => {
+      const expr = parseExpr("obj?.[0];") as AST.ChainExpression;
+      expect(expr.type).toBe("ChainExpression");
+      const member = expr.expression as AST.MemberExpression;
+      expect(member.optional).toBe(true);
+      expect(member.computed).toBe(true);
+      expect((member.property as AST.Literal).value).toBe(0);
+    });
+
+    it("should parse optional call: fn?.()", () => {
+      const expr = parseExpr("fn?.();") as AST.ChainExpression;
+      expect(expr.type).toBe("ChainExpression");
+      const call = expr.expression as AST.CallExpression;
+      expect(call.type).toBe("CallExpression");
+      expect(call.optional).toBe(true);
+      expect((call.callee as AST.Identifier).name).toBe("fn");
+    });
+
+    it("should parse optional call with args: fn?.(a, b)", () => {
+      const expr = parseExpr("fn?.(a, b);") as AST.ChainExpression;
+      const call = expr.expression as AST.CallExpression;
+      expect(call.optional).toBe(true);
+      expect(call.arguments.length).toBe(2);
+    });
+
+    it("should parse deep optional chain: a?.b?.c", () => {
+      const expr = parseExpr("a?.b?.c;") as AST.ChainExpression;
+      expect(expr.type).toBe("ChainExpression");
+      const outer = expr.expression as AST.MemberExpression;
+      expect(outer.optional).toBe(true);
+      expect((outer.property as AST.Identifier).name).toBe("c");
+      const inner = outer.object as AST.MemberExpression;
+      expect(inner.optional).toBe(true);
+      expect((inner.property as AST.Identifier).name).toBe("b");
+    });
+
+    it("should wrap mixed chain in ChainExpression: a?.b.c", () => {
+      const expr = parseExpr("a?.b.c;") as AST.ChainExpression;
+      expect(expr.type).toBe("ChainExpression");
+      const outer = expr.expression as AST.MemberExpression;
+      expect(outer.optional).toBe(false);
+      expect((outer.property as AST.Identifier).name).toBe("c");
+      const inner = outer.object as AST.MemberExpression;
+      expect(inner.optional).toBe(true);
+    });
+
+    it("should wrap optional call chain: obj?.method()", () => {
+      const expr = parseExpr("obj?.method();") as AST.ChainExpression;
+      expect(expr.type).toBe("ChainExpression");
+      const call = expr.expression as AST.CallExpression;
+      expect(call.type).toBe("CallExpression");
+      expect(call.optional).toBe(false);
+      const callee = call.callee as AST.MemberExpression;
+      expect(callee.optional).toBe(true);
+    });
+
+    it("should not wrap non-optional chains in ChainExpression", () => {
+      const expr = parseExpr("a.b.c;");
+      expect(expr.type).toBe("MemberExpression");
+    });
+  });
+
+  describe("New Expressions", () => {
+    it("should parse new with no args: new Foo", () => {
+      const expr = parseExpr("new Foo;") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      expect((expr.callee as AST.Identifier).name).toBe("Foo");
+      expect(expr.arguments.length).toBe(0);
+    });
+
+    it("should parse new with empty parens: new Foo()", () => {
+      const expr = parseExpr("new Foo();") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      expect((expr.callee as AST.Identifier).name).toBe("Foo");
+      expect(expr.arguments.length).toBe(0);
+    });
+
+    it("should parse new with args: new Foo(a, b)", () => {
+      const expr = parseExpr("new Foo(a, b);") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      expect(expr.arguments.length).toBe(2);
+      expect((expr.arguments[0] as AST.Identifier).name).toBe("a");
+      expect((expr.arguments[1] as AST.Identifier).name).toBe("b");
+    });
+
+    it("should parse new with member callee: new foo.Bar()", () => {
+      const expr = parseExpr("new foo.Bar();") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect(callee.type).toBe("MemberExpression");
+      expect((callee.object as AST.Identifier).name).toBe("foo");
+      expect((callee.property as AST.Identifier).name).toBe("Bar");
+    });
+
+    it("should parse new with computed callee: new obj['Foo']()", () => {
+      const expr = parseExpr("new obj['Foo']();") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect(callee.computed).toBe(true);
+    });
+
+    it("should allow method calls after new: new Foo().bar()", () => {
+      const expr = parseExpr("new Foo().bar();") as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect(callee.type).toBe("MemberExpression");
+      expect((callee.property as AST.Identifier).name).toBe("bar");
+      const newExpr = callee.object as AST.NewExpression;
+      expect(newExpr.type).toBe("NewExpression");
+    });
+
+    it("should parse new.target", () => {
+      const expr = parseExpr("new.target;") as AST.MetaProperty;
+      expect(expr.type).toBe("MetaProperty");
+      expect(expr.meta.name).toBe("new");
+      expect(expr.property.name).toBe("target");
+    });
+
+    it("should parse new with spread: new Foo(...args)", () => {
+      const expr = parseExpr("new Foo(...args);") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      expect(expr.arguments.length).toBe(1);
+      expect((expr.arguments[0] as AST.SpreadElement).type).toBe(
+        "SpreadElement",
+      );
+    });
+
+    it("should parse new with dot property that is not target: new Foo.bar", () => {
+      // new Foo.bar - the dot is member access on the callee
+      const expr = parseExpr("new Foo.bar;") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect(callee.type).toBe("MemberExpression");
+      expect((callee.object as AST.Identifier).name).toBe("Foo");
+      expect((callee.property as AST.Identifier).name).toBe("bar");
+    });
+
+    it("should parse nested new new Foo()", () => {
+      const expr = parseExpr("new new Foo();") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      expect(expr.arguments.length).toBe(0);
+      const inner = expr.callee as AST.NewExpression;
+      expect(inner.type).toBe("NewExpression");
+      expect((inner.callee as AST.Identifier).name).toBe("Foo");
+    });
+
+    it("should handle new followed by dot that is not target (new Foo.bar)", () => {
+      // Exercises the restoreState branch when new.X where X !== target
+      // In this case `new` is followed by identifier `Foo` then `.bar`
+      const expr = parseExpr("new a.b();") as AST.NewExpression;
+      expect(expr.type).toBe("NewExpression");
+      const callee = expr.callee as AST.MemberExpression;
+      expect((callee.object as AST.Identifier).name).toBe("a");
+      expect((callee.property as AST.Identifier).name).toBe("b");
+    });
+  });
+
+  describe("Super Expressions", () => {
+    it("should parse super.prop", () => {
+      // Parse in script mode to avoid strict-mode issues with super outside class
+      const program = parse("super.prop;", { sourceType: "script" });
+      const stmt = program.body[0] as AST.ExpressionStatement;
+      const expr = stmt.expression as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect((expr.object as AST.Super).type).toBe("Super");
+      expect((expr.property as AST.Identifier).name).toBe("prop");
+      expect(expr.computed).toBe(false);
+    });
+
+    it("should parse super[expr]", () => {
+      const program = parse("super[0];", { sourceType: "script" });
+      const stmt = program.body[0] as AST.ExpressionStatement;
+      const expr = stmt.expression as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect((expr.object as AST.Super).type).toBe("Super");
+      expect(expr.computed).toBe(true);
+    });
+
+    it("should parse super()", () => {
+      const program = parse("super();", { sourceType: "script" });
+      const stmt = program.body[0] as AST.ExpressionStatement;
+      const expr = stmt.expression as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      expect((expr.callee as AST.Super).type).toBe("Super");
+      expect(expr.arguments.length).toBe(0);
+    });
+
+    it("should parse super(a, b)", () => {
+      const program = parse("super(a, b);", { sourceType: "script" });
+      const stmt = program.body[0] as AST.ExpressionStatement;
+      const expr = stmt.expression as AST.CallExpression;
+      expect(expr.arguments.length).toBe(2);
+    });
+
+    it("should throw for bare super", () => {
+      expect(() => parse("super;", { sourceType: "script" })).toThrow(
+        SyntaxError,
+      );
+    });
+  });
+
+  describe("Tagged Templates", () => {
+    it("should parse tagged no-sub template: tag`text`", () => {
+      const expr = parseExpr("tag`text`;") as AST.TaggedTemplateExpression;
+      expect(expr.type).toBe("TaggedTemplateExpression");
+      expect((expr.tag as AST.Identifier).name).toBe("tag");
+      expect(expr.quasi.type).toBe("TemplateLiteral");
+    });
+
+    it("should parse tagged template after member: obj.tag`text`", () => {
+      const expr = parseExpr("obj.tag`text`;") as AST.TaggedTemplateExpression;
+      expect(expr.type).toBe("TaggedTemplateExpression");
+      const tag = expr.tag as AST.MemberExpression;
+      expect(tag.type).toBe("MemberExpression");
+      expect((tag.property as AST.Identifier).name).toBe("tag");
+    });
+  });
+
+  describe("Complex Chained Expressions", () => {
+    it("should parse obj.a[0].b(c).d", () => {
+      const expr = parseExpr("obj.a[0].b(c).d;") as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect((expr.property as AST.Identifier).name).toBe("d");
+      const call = expr.object as AST.CallExpression;
+      expect(call.type).toBe("CallExpression");
+      const callee = call.callee as AST.MemberExpression;
+      expect((callee.property as AST.Identifier).name).toBe("b");
+    });
+
+    it("should parse fn()(a)()", () => {
+      const expr = parseExpr("fn()(a)();") as AST.CallExpression;
+      expect(expr.type).toBe("CallExpression");
+      expect(expr.arguments.length).toBe(0);
+      const mid = expr.callee as AST.CallExpression;
+      expect(mid.arguments.length).toBe(1);
+      const inner = mid.callee as AST.CallExpression;
+      expect((inner.callee as AST.Identifier).name).toBe("fn");
+    });
+
+    it("should parse a[0][1][2]", () => {
+      const expr = parseExpr("a[0][1][2];") as AST.MemberExpression;
+      expect((expr.property as AST.Literal).value).toBe(2);
+      const mid = expr.object as AST.MemberExpression;
+      expect((mid.property as AST.Literal).value).toBe(1);
+      const inner = mid.object as AST.MemberExpression;
+      expect((inner.property as AST.Literal).value).toBe(0);
+    });
+  });
+
+  describe("Error Cases", () => {
+    it("should throw on unterminated argument list", () => {
+      expect(() => parse("fn(a, b", { sourceType: "module" })).toThrow(
+        SyntaxError,
+      );
+    });
+
+    it("should throw on invalid argument separator", () => {
+      expect(() => parse("fn(a b);", { sourceType: "module" })).toThrow(
+        SyntaxError,
+      );
+    });
+
+    it("should throw on invalid property after dot", () => {
+      expect(() => parse("obj.123;", { sourceType: "module" })).toThrow(
+        SyntaxError,
+      );
+    });
+
+    it("should throw on invalid property after ?.", () => {
+      expect(() => parse("obj?.123;", { sourceType: "module" })).toThrow(
+        SyntaxError,
+      );
+    });
+
+    it("should throw on super without member/call", () => {
+      expect(() => parse("super;", { sourceType: "script" })).toThrow(
+        SyntaxError,
+      );
+    });
+
+    it("should throw on unterminated computed access", () => {
+      expect(() => parse("obj[0", { sourceType: "module" })).toThrow(
+        SyntaxError,
+      );
+    });
+  });
+
+  describe("Import Expressions", () => {
+    it("should parse import.meta", () => {
+      const expr = parseExpr("import.meta;") as AST.MetaProperty;
+      expect(expr.type).toBe("MetaProperty");
+      expect(expr.meta.name).toBe("import");
+      expect(expr.property.name).toBe("meta");
+    });
+
+    it("should parse import.meta.url", () => {
+      const expr = parseExpr("import.meta.url;") as AST.MemberExpression;
+      expect(expr.type).toBe("MemberExpression");
+      expect((expr.property as AST.Identifier).name).toBe("url");
+      const inner = expr.object as AST.MetaProperty;
+      expect(inner.type).toBe("MetaProperty");
+    });
+
+    it("should parse dynamic import: import(source)", () => {
+      const expr = parseExpr("import('./mod.js');") as AST.ImportExpression;
+      expect(expr.type).toBe("ImportExpression");
+      expect((expr.source as AST.Literal).value).toBe("./mod.js");
+    });
+  });
+
+  describe("Interaction with Operators", () => {
+    it("should parse member access in binary: a.b + c.d", () => {
+      const expr = parseExpr("a.b + c.d;") as AST.BinaryExpression;
+      expect(expr.type).toBe("BinaryExpression");
+      expect(expr.operator).toBe("+");
+      expect((expr.left as AST.MemberExpression).type).toBe("MemberExpression");
+      expect((expr.right as AST.MemberExpression).type).toBe(
+        "MemberExpression",
+      );
+    });
+
+    it("should parse call in assignment: obj.prop = fn()", () => {
+      const expr = parseExpr("obj.prop = fn();") as AST.AssignmentExpression;
+      expect(expr.type).toBe("AssignmentExpression");
+      expect((expr.left as AST.MemberExpression).type).toBe("MemberExpression");
+      expect((expr.right as AST.CallExpression).type).toBe("CallExpression");
+    });
+
+    it("should parse typeof obj.prop", () => {
+      const expr = parseExpr("typeof obj.prop;") as AST.UnaryExpression;
+      expect(expr.type).toBe("UnaryExpression");
+      expect(expr.operator).toBe("typeof");
+      expect((expr.argument as AST.MemberExpression).type).toBe(
+        "MemberExpression",
+      );
+    });
+
+    it("should parse obj.prop++", () => {
+      const expr = parseExpr("obj.prop++;") as AST.UpdateExpression;
+      expect(expr.type).toBe("UpdateExpression");
+      expect(expr.operator).toBe("++");
+      expect(expr.prefix).toBe(false);
+      expect((expr.argument as AST.MemberExpression).type).toBe(
+        "MemberExpression",
+      );
+    });
+
+    it("should parse conditional with calls: a() ? b() : c()", () => {
+      const expr = parseExpr("a() ? b() : c();") as AST.ConditionalExpression;
+      expect(expr.type).toBe("ConditionalExpression");
+      expect((expr.test as AST.CallExpression).type).toBe("CallExpression");
+      expect((expr.consequent as AST.CallExpression).type).toBe(
+        "CallExpression",
+      );
+      expect((expr.alternate as AST.CallExpression).type).toBe(
+        "CallExpression",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds iterative member/call/optional chain parsing in `src/parser/member-call.ts`
- Integrates into expression parsing via `parseLeftHandSideExpression` wrapper
- Supports dot access, computed access, call expressions, optional chaining (`?.`), `new` expressions, `super`, tagged templates, `import.meta`, and `import()`
- Wraps optional chains in `ChainExpression` per ESTree spec

## Details

All parsing uses iterative while loops (no recursion). The new module handles:
- `obj.prop`, `obj[expr]` (member access)
- `fn(a, b, ...rest)` (calls with spread)
- `obj?.prop`, `obj?.[expr]`, `fn?.()` (optional chaining)
- `new Foo(args)`, `new Foo`, `new.target` (new expressions)
- `super.prop`, `super[expr]`, `super()` (super keyword)
- `tag\`template\`` (tagged templates)
- `import.meta`, `import()` (import expressions)

## Test plan

- [x] 66 unit tests covering happy and sad paths
- [x] All 2284 existing + new tests pass
- [x] TypeScript strict mode compiles without errors
- [x] Prettier formatting passes
- [x] ~95% code coverage on new module

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)