### PR TITLE
feat: implement parser function and class expressions

### DIFF
--- a/src/parser/expressions.ts
+++ b/src/parser/expressions.ts
@@ -6,7 +6,7 @@
  * Also provides assignment, sequence, binary, unary, update, and
  * conditional expression parsing via Pratt parsing (issue #29).
  *
- * Function/arrow/class expressions will be implemented by issue #27.
+ * Function/arrow/class expressions are handled by the function-class-expr module.
  * Member/call expressions are handled by the member-call module.
  *
  * @module parser/expressions
@@ -28,6 +28,49 @@ import {
   parseNewExpression,
   parseSuperExpression,
 } from "./member-call.js";
+import {
+  parseFunctionExpression,
+  parseArrowFunction,
+  parseClassExpression,
+  parseParams,
+  isArrowAfterParen,
+  isArrowAfterIdent,
+} from "./function-class-expr.js";
+import type { ExprContext } from "./function-class-expr.js";
+
+/**
+ * Internal reference to the block statement parser.
+ * Set by `setBlockStatementParser` during module initialization from parser.ts.
+ *
+ * This avoids circular imports between expressions.ts and statements.ts.
+ */
+let parseBlockStatementFn: (lexer: Lexer) => AST.BlockStatement;
+
+/**
+ * Register the block statement parser function.
+ * Called by parser.ts during initialization to break the
+ * circular dependency between expressions and statements modules.
+ *
+ * @param fn - The block statement parser function.
+ */
+export const setBlockStatementParser = (
+  fn: (lexer: Lexer) => AST.BlockStatement,
+): void => {
+  parseBlockStatementFn = fn;
+};
+
+/**
+ * Build an ExprContext for the function-class-expr module.
+ *
+ * @param lexer - The lexer instance.
+ * @returns The expression context for function/class expression parsing.
+ */
+const buildExprContext = (lexer: Lexer): ExprContext => ({
+  lexer,
+  parseAssignmentExpression: (lex: Lexer, allowIn: boolean) =>
+    parseAssignmentExpression(lex, allowIn),
+  parseBlockStatementFromLexer: (lex: Lexer) => parseBlockStatementFn(lex),
+});
 
 /**
  * Parse a full expression, handling sequence expressions (comma-separated).
@@ -138,7 +181,10 @@ export const parsePrimaryExpression = (lexer: Lexer): AST.Expression => {
       return parseBigIntLiteral(lexer);
 
     case TokenType.Identifier:
-      return parseIdentifier(lexer);
+      return parseIdentifierOrArrowOrAsync(lexer);
+
+    case TokenType.Async:
+      return parseAsyncExpression(lexer);
 
     case TokenType.This:
       return parseThisExpression(lexer);
@@ -160,10 +206,10 @@ export const parsePrimaryExpression = (lexer: Lexer): AST.Expression => {
       return parseParenthesizedExpression(lexer);
 
     case TokenType.Function:
-      return parseFunctionExpressionStub(lexer);
+      return parseFunctionExpr(lexer, false);
 
     case TokenType.Class:
-      return parseClassExpressionStub(lexer);
+      return parseClassExpr(lexer);
 
     default: {
       const name = tokenTypeName(token.type);
@@ -390,18 +436,107 @@ const parseBigIntLiteral = (lexer: Lexer): AST.Literal => {
 };
 
 /**
- * Parse an identifier reference.
+ * Parse an identifier or arrow function (x => ...).
+ *
+ * Handles:
+ * - Plain identifier reference
+ * - Arrow function with single parameter: x => expr
  *
  * @param lexer - The lexer instance.
- * @returns An Identifier AST node.
+ * @returns An Identifier or ArrowFunctionExpression AST node.
  */
-const parseIdentifier = (lexer: Lexer): AST.Identifier => {
-  const token = lexer.next();
+const parseIdentifierOrArrowOrAsync = (lexer: Lexer): AST.Expression => {
+  const token = lexer.token;
+
+  // Check for arrow function: x => ...
+  if (isArrowAfterIdent(lexer)) {
+    const start = token.start;
+    const paramToken = lexer.next(); // consume identifier
+    const param: AST.Identifier = Object.freeze({
+      type: "Identifier" as const,
+      start: paramToken.start,
+      end: paramToken.end,
+      name: paramToken.value as string,
+    });
+    const ctx = buildExprContext(lexer);
+    return parseArrowFunction(ctx, [param], false, start);
+  }
+
+  // Plain identifier
+  const consumed = lexer.next();
   return Object.freeze({
     type: "Identifier" as const,
-    start: token.start,
-    end: token.end,
-    name: token.value as string,
+    start: consumed.start,
+    end: consumed.end,
+    name: consumed.value as string,
+  });
+};
+
+/**
+ * Parse an async function expression or async arrow function.
+ *
+ * Handles:
+ * - async function [name]() {}
+ * - async () => ...
+ * - async x => ...
+ * - plain identifier 'async' when not followed by function/arrow
+ *
+ * The current token is TokenType.Async.
+ *
+ * @param lexer - The lexer instance.
+ * @returns The parsed expression.
+ */
+const parseAsyncExpression = (lexer: Lexer): AST.Expression => {
+  const start = lexer.token.start;
+  const saved = lexer.saveState();
+
+  // Consume 'async'
+  lexer.next();
+
+  // async function expression
+  if (lexer.is(TokenType.Function)) {
+    return parseFunctionExpr(lexer, true);
+  }
+
+  // async () => ... or async (params) => ...
+  if (lexer.is(TokenType.LeftParen)) {
+    if (isParenArrow(lexer)) {
+      const ctx = buildExprContext(lexer);
+      const params = parseParams(ctx);
+      return parseArrowFunction(ctx, params, true, start);
+    }
+    // Not an arrow - restore and parse 'async' as identifier
+    lexer.restoreState(saved);
+    const consumed = lexer.next();
+    return Object.freeze({
+      type: "Identifier" as const,
+      start: consumed.start,
+      end: consumed.end,
+      name: consumed.value as string,
+    });
+  }
+
+  // async x => ...
+  if (lexer.is(TokenType.Identifier) && isArrowAfterIdent(lexer)) {
+    const paramToken = lexer.next();
+    const param: AST.Identifier = Object.freeze({
+      type: "Identifier" as const,
+      start: paramToken.start,
+      end: paramToken.end,
+      name: paramToken.value as string,
+    });
+    const ctx = buildExprContext(lexer);
+    return parseArrowFunction(ctx, [param], true, start);
+  }
+
+  // Just 'async' as a plain identifier
+  lexer.restoreState(saved);
+  const consumed = lexer.next();
+  return Object.freeze({
+    type: "Identifier" as const,
+    start: consumed.start,
+    end: consumed.end,
+    name: consumed.value as string,
   });
 };
 
@@ -960,19 +1095,44 @@ export const parseTaggedTemplate = (
 };
 
 /**
- * Parse a parenthesized expression: (expr)
- * Returns the inner expression directly (no wrapper node).
+ * Check if the current '(' starts an arrow function parameter list.
+ * Saves state, consumes '(', delegates to isArrowAfterParen, and restores.
+ *
+ * @param lexer - The lexer positioned at '('.
+ * @returns True if this is an arrow function.
+ */
+const isParenArrow = (lexer: Lexer): boolean => {
+  const saved = lexer.saveState();
+  lexer.next(); // consume (
+  const result = isArrowAfterParen(lexer);
+  lexer.restoreState(saved);
+  return result;
+};
+
+/**
+ * Parse a parenthesized expression or arrow function: (expr) or (params) => body
+ * Returns the inner expression directly (no wrapper node) for grouping,
+ * or an ArrowFunctionExpression for arrow functions.
  *
  * @param lexer - The lexer instance.
- * @returns The inner Expression AST node.
+ * @returns The inner Expression AST node or an ArrowFunctionExpression.
  * @throws {SyntaxError} For unterminated parenthesized expressions.
  */
 const parseParenthesizedExpression = (lexer: Lexer): AST.Expression => {
   const start = lexer.token.start;
+
+  // Check if this is an arrow function: (...) =>
+  if (isParenArrow(lexer)) {
+    // Parse as arrow function parameters
+    const ctx = buildExprContext(lexer);
+    const params = parseParams(ctx);
+    return parseArrowFunction(ctx, params, false, start);
+  }
+
   lexer.next(); // consume (
 
   if (lexer.is(TokenType.RightParen)) {
-    // Empty parens - could be arrow function params, error for now
+    // Empty parens not followed by => is an error
     throw new SyntaxError(`Unexpected ')' at position ${lexer.token.start}`);
   }
 
@@ -995,31 +1155,29 @@ const parseParenthesizedExpression = (lexer: Lexer): AST.Expression => {
 };
 
 /**
- * Stub for function expression parsing.
- * Will be implemented by issue #27.
+ * Parse a function expression by delegating to the function-class-expr module.
  *
  * @param lexer - The lexer instance.
- * @returns A FunctionExpression AST node (stub with empty body).
- * @throws {SyntaxError} Always — not yet implemented.
+ * @param isAsync - Whether this is an async function expression.
+ * @returns A FunctionExpression AST node.
  */
-const parseFunctionExpressionStub = (lexer: Lexer): AST.FunctionExpression => {
-  throw new SyntaxError(
-    `Function expressions not yet implemented at position ${lexer.token.start}`,
-  );
+const parseFunctionExpr = (
+  lexer: Lexer,
+  isAsync: boolean,
+): AST.FunctionExpression => {
+  const ctx = buildExprContext(lexer);
+  return parseFunctionExpression(ctx, isAsync);
 };
 
 /**
- * Stub for class expression parsing.
- * Will be implemented by issue #27.
+ * Parse a class expression by delegating to the function-class-expr module.
  *
  * @param lexer - The lexer instance.
- * @returns A ClassExpression AST node (stub).
- * @throws {SyntaxError} Always — not yet implemented.
+ * @returns A ClassExpression AST node.
  */
-const parseClassExpressionStub = (lexer: Lexer): AST.ClassExpression => {
-  throw new SyntaxError(
-    `Class expressions not yet implemented at position ${lexer.token.start}`,
-  );
+const parseClassExpr = (lexer: Lexer): AST.ClassExpression => {
+  const ctx = buildExprContext(lexer);
+  return parseClassExpression(ctx);
 };
 
 // Register left-hand side expression parser with the operators module to

--- a/src/parser/function-class-expr.ts
+++ b/src/parser/function-class-expr.ts
@@ -1,0 +1,525 @@
+/**
+ * Function expression, arrow function, and class expression parsing.
+ *
+ * Handles:
+ * - Function expressions (named/anonymous, async, generator)
+ * - Arrow functions (concise body and block body, async)
+ * - Class expressions (named/anonymous, with extends)
+ * - Parameter list parsing (defaults, rest elements)
+ *
+ * @module parser/function-class-expr
+ */
+
+import type * as AST from "../ast/types.js";
+import type { Lexer } from "./lexer.js";
+import { TokenType } from "./token-types.js";
+
+/**
+ * Context interface required by function/class expression parsers.
+ * Decouples from the full expression parser to avoid circular dependencies.
+ */
+export interface ExprContext {
+  readonly lexer: Lexer;
+  readonly parseAssignmentExpression: (
+    lexer: Lexer,
+    allowIn: boolean,
+  ) => AST.Expression;
+  readonly parseBlockStatementFromLexer: (lexer: Lexer) => AST.BlockStatement;
+}
+
+/**
+ * Parse a function expression.
+ *
+ * Handles: function [name]([params]) { body }
+ *          function* [name]([params]) { body }
+ *
+ * The 'function' keyword should already be the current token.
+ *
+ * @param ctx - The expression context.
+ * @param isAsync - Whether this is an async function expression.
+ * @returns The FunctionExpression AST node.
+ */
+export const parseFunctionExpression = (
+  ctx: ExprContext,
+  isAsync: boolean,
+): AST.FunctionExpression => {
+  const start = isAsync ? ctx.lexer.token.start - 6 : ctx.lexer.token.start;
+
+  // Consume 'function' keyword
+  ctx.lexer.expect(TokenType.Function);
+
+  // Check for generator: function*
+  let generator = false;
+  if (ctx.lexer.is(TokenType.Star)) {
+    generator = true;
+    ctx.lexer.next();
+  }
+
+  // Optional name
+  let id: AST.Identifier | null = null;
+  if (ctx.lexer.is(TokenType.Identifier)) {
+    const nameToken = ctx.lexer.next();
+    id = Object.freeze({
+      type: "Identifier" as const,
+      name: nameToken.value as string,
+      start: nameToken.start,
+      end: nameToken.end,
+    });
+  }
+
+  // Parse parameters
+  const params = parseParams(ctx);
+
+  // Parse body
+  const body = ctx.parseBlockStatementFromLexer(ctx.lexer);
+
+  return Object.freeze({
+    type: "FunctionExpression" as const,
+    id,
+    params: Object.freeze(params),
+    body,
+    generator,
+    async: isAsync,
+    start,
+    end: body.end,
+  });
+};
+
+/**
+ * Parse an arrow function expression.
+ *
+ * Handles: (params) => expr
+ *          (params) => { body }
+ *          param => expr
+ *          param => { body }
+ *          async (params) => expr
+ *          async param => expr
+ *
+ * The params have already been parsed and the `=>` is the current token.
+ *
+ * @param ctx - The expression context.
+ * @param params - The parameter patterns already parsed.
+ * @param isAsync - Whether this is an async arrow function.
+ * @param start - The start position of the arrow function.
+ * @returns The ArrowFunctionExpression AST node.
+ */
+export const parseArrowFunction = (
+  ctx: ExprContext,
+  params: ReadonlyArray<AST.Pattern>,
+  isAsync: boolean,
+  start: number,
+): AST.ArrowFunctionExpression => {
+  // Consume '=>'
+  ctx.lexer.expect(TokenType.Arrow);
+
+  // Determine body type: block or expression
+  if (ctx.lexer.is(TokenType.LeftBrace)) {
+    // Block body: () => { ... }
+    const body = ctx.parseBlockStatementFromLexer(ctx.lexer);
+    return Object.freeze({
+      type: "ArrowFunctionExpression" as const,
+      id: null,
+      params,
+      body,
+      expression: false,
+      generator: false as const,
+      async: isAsync,
+      start,
+      end: body.end,
+    });
+  }
+
+  // Concise body: () => expr
+  const body = ctx.parseAssignmentExpression(ctx.lexer, true);
+  return Object.freeze({
+    type: "ArrowFunctionExpression" as const,
+    id: null,
+    params,
+    body,
+    expression: true,
+    generator: false as const,
+    async: isAsync,
+    start,
+    end: body.end,
+  });
+};
+
+/**
+ * Check whether the current position looks like arrow function parameters
+ * followed by `=>`. Uses lexer save/restore for lookahead.
+ *
+ * Handles two cases:
+ * 1. Single identifier followed by `=>`
+ * 2. `(...)` followed by `=>`
+ *
+ * @param lexer - The lexer instance.
+ * @returns True if this appears to be an arrow function.
+ */
+export const isArrowAfterParen = (lexer: Lexer): boolean => {
+  // We've already consumed '('. We need to find the matching ')' and check for '=>'.
+  const saved = lexer.saveState();
+  let depth = 1;
+
+  while (depth > 0 && !lexer.is(TokenType.EOF)) {
+    if (lexer.is(TokenType.LeftParen)) {
+      depth++;
+    } else if (lexer.is(TokenType.RightParen)) {
+      depth--;
+      if (depth === 0) {
+        break;
+      }
+    }
+    lexer.next();
+  }
+
+  if (lexer.is(TokenType.EOF)) {
+    lexer.restoreState(saved);
+    return false;
+  }
+
+  // Consume the closing ')'
+  lexer.next();
+
+  // Check if next is '=>'
+  const isArrow = lexer.is(TokenType.Arrow);
+  lexer.restoreState(saved);
+  return isArrow;
+};
+
+/**
+ * Check whether a single identifier is followed by `=>`.
+ *
+ * @param lexer - The lexer instance.
+ * @returns True if the current identifier is an arrow param.
+ */
+export const isArrowAfterIdent = (lexer: Lexer): boolean => {
+  const saved = lexer.saveState();
+  lexer.next(); // consume identifier
+  const isArrow = lexer.is(TokenType.Arrow);
+  lexer.restoreState(saved);
+  return isArrow;
+};
+
+/**
+ * Parse a class expression.
+ *
+ * Handles: class [Name] [extends SuperClass] { body }
+ *
+ * The 'class' keyword should be the current token.
+ *
+ * @param ctx - The expression context.
+ * @returns The ClassExpression AST node.
+ */
+export const parseClassExpression = (ctx: ExprContext): AST.ClassExpression => {
+  const start = ctx.lexer.token.start;
+
+  // Consume 'class' keyword
+  ctx.lexer.expect(TokenType.Class);
+
+  // Optional name
+  let id: AST.Identifier | null = null;
+  if (ctx.lexer.is(TokenType.Identifier)) {
+    const nameToken = ctx.lexer.next();
+    id = Object.freeze({
+      type: "Identifier" as const,
+      name: nameToken.value as string,
+      start: nameToken.start,
+      end: nameToken.end,
+    });
+  }
+
+  // Optional extends clause
+  let superClass: AST.Expression | null = null;
+  if (ctx.lexer.is(TokenType.Extends)) {
+    ctx.lexer.next();
+    superClass = ctx.parseAssignmentExpression(ctx.lexer, true);
+  }
+
+  // Parse class body
+  const body = parseClassBody(ctx);
+
+  return Object.freeze({
+    type: "ClassExpression" as const,
+    id,
+    superClass,
+    body,
+    start,
+    end: body.end,
+  });
+};
+
+/**
+ * Parse a class body: { members }
+ *
+ * @param ctx - The expression context.
+ * @returns The ClassBody AST node.
+ */
+const parseClassBody = (ctx: ExprContext): AST.ClassBody => {
+  const start = ctx.lexer.token.start;
+  ctx.lexer.expect(TokenType.LeftBrace);
+
+  const members: Array<
+    AST.MethodDefinition | AST.PropertyDefinition | AST.StaticBlock
+  > = [];
+
+  while (!ctx.lexer.is(TokenType.RightBrace) && !ctx.lexer.is(TokenType.EOF)) {
+    // Skip semicolons
+    if (ctx.lexer.is(TokenType.Semicolon)) {
+      ctx.lexer.next();
+      continue;
+    }
+
+    const member = parseClassMember(ctx);
+    members.push(member);
+  }
+
+  const endToken = ctx.lexer.expect(TokenType.RightBrace);
+
+  return Object.freeze({
+    type: "ClassBody" as const,
+    body: Object.freeze(members),
+    start,
+    end: endToken.end,
+  });
+};
+
+/**
+ * Parse a single class member (method or property).
+ *
+ * @param ctx - The expression context.
+ * @returns A MethodDefinition, PropertyDefinition, or StaticBlock node.
+ */
+const parseClassMember = (
+  ctx: ExprContext,
+): AST.MethodDefinition | AST.PropertyDefinition | AST.StaticBlock => {
+  const memberStart = ctx.lexer.token.start;
+  let isStatic = false;
+  let kind: "constructor" | "method" | "get" | "set" = "method";
+
+  // Check for static keyword
+  if (ctx.lexer.is(TokenType.Static)) {
+    const staticToken = ctx.lexer.next();
+
+    // Static block: static { ... }
+    if (ctx.lexer.is(TokenType.LeftBrace)) {
+      const body = ctx.parseBlockStatementFromLexer(ctx.lexer);
+      return Object.freeze({
+        type: "StaticBlock" as const,
+        body: body.body as unknown as ReadonlyArray<AST.Statement>,
+        start: staticToken.start,
+        end: body.end,
+      });
+    }
+
+    isStatic = true;
+  }
+
+  // Check for get/set
+  if (ctx.lexer.is(TokenType.Get)) {
+    const saved = ctx.lexer.saveState();
+    ctx.lexer.next();
+    if (
+      !ctx.lexer.is(TokenType.LeftParen) &&
+      !ctx.lexer.is(TokenType.Equals) &&
+      !ctx.lexer.is(TokenType.Semicolon)
+    ) {
+      kind = "get";
+    } else {
+      ctx.lexer.restoreState(saved);
+    }
+  } else if (ctx.lexer.is(TokenType.Set)) {
+    const saved = ctx.lexer.saveState();
+    ctx.lexer.next();
+    if (
+      !ctx.lexer.is(TokenType.LeftParen) &&
+      !ctx.lexer.is(TokenType.Equals) &&
+      !ctx.lexer.is(TokenType.Semicolon)
+    ) {
+      kind = "set";
+    } else {
+      ctx.lexer.restoreState(saved);
+    }
+  }
+
+  // Parse the key
+  let key: AST.Expression;
+  let computed = false;
+
+  if (ctx.lexer.is(TokenType.LeftBracket)) {
+    computed = true;
+    ctx.lexer.next();
+    key = ctx.parseAssignmentExpression(ctx.lexer, true);
+    ctx.lexer.expect(TokenType.RightBracket);
+  } else if (
+    ctx.lexer.is(TokenType.Identifier) ||
+    isKeywordToken(ctx.lexer.token.type)
+  ) {
+    const keyToken = ctx.lexer.next();
+    const keyName = keyToken.value as string;
+    if (keyName === "constructor" && !isStatic) {
+      kind = "constructor";
+    }
+    key = Object.freeze({
+      type: "Identifier" as const,
+      name: keyName,
+      start: keyToken.start,
+      end: keyToken.end,
+    });
+  } else if (
+    ctx.lexer.is(TokenType.NumericLiteral) ||
+    ctx.lexer.is(TokenType.StringLiteral)
+  ) {
+    const litToken = ctx.lexer.next();
+    key = Object.freeze({
+      type: "Literal" as const,
+      value: litToken.value as string | number,
+      raw: litToken.raw,
+      start: litToken.start,
+      end: litToken.end,
+    });
+  } else {
+    throw new SyntaxError(
+      `Unexpected token in class member at position ${ctx.lexer.token.start}`,
+    );
+  }
+
+  // Method definition
+  if (ctx.lexer.is(TokenType.LeftParen)) {
+    const params = parseParams(ctx);
+    const body = ctx.parseBlockStatementFromLexer(ctx.lexer);
+
+    const value: AST.FunctionExpression = Object.freeze({
+      type: "FunctionExpression" as const,
+      id: null,
+      params: Object.freeze(params),
+      body,
+      generator: false,
+      async: false,
+      start: params.length > 0 ? (params[0] as AST.BaseNode).start : body.start,
+      end: body.end,
+    });
+
+    return Object.freeze({
+      type: "MethodDefinition" as const,
+      key,
+      value,
+      kind,
+      computed,
+      static: isStatic,
+      start: memberStart,
+      end: body.end,
+    });
+  }
+
+  // Property definition
+  let propValue: AST.Expression | null = null;
+  if (ctx.lexer.is(TokenType.Equals)) {
+    ctx.lexer.next();
+    propValue = ctx.parseAssignmentExpression(ctx.lexer, true);
+  }
+
+  const propEnd = propValue ? propValue.end : key.end;
+
+  // Consume optional semicolon
+  if (ctx.lexer.is(TokenType.Semicolon)) {
+    ctx.lexer.next();
+  }
+
+  return Object.freeze({
+    type: "PropertyDefinition" as const,
+    key,
+    value: propValue,
+    computed,
+    static: isStatic,
+    start: memberStart,
+    end: propEnd,
+  });
+};
+
+/**
+ * Parse a function parameter list: (param1, param2 = default, ...rest)
+ *
+ * Handles simple identifiers, default values (= expr), and rest elements (...x).
+ *
+ * @param ctx - The expression context.
+ * @returns Array of Pattern nodes representing the parameters.
+ */
+export const parseParams = (ctx: ExprContext): Array<AST.Pattern> => {
+  ctx.lexer.expect(TokenType.LeftParen);
+
+  const params: Array<AST.Pattern> = [];
+
+  while (!ctx.lexer.is(TokenType.RightParen) && !ctx.lexer.is(TokenType.EOF)) {
+    if (params.length > 0) {
+      ctx.lexer.expect(TokenType.Comma);
+    }
+
+    // Rest element: ...param
+    if (ctx.lexer.is(TokenType.Ellipsis)) {
+      const restStart = ctx.lexer.token.start;
+      ctx.lexer.next();
+      const argToken = ctx.lexer.expect(TokenType.Identifier);
+      const argument: AST.Identifier = Object.freeze({
+        type: "Identifier" as const,
+        name: argToken.value as string,
+        start: argToken.start,
+        end: argToken.end,
+      });
+      params.push(
+        Object.freeze({
+          type: "RestElement" as const,
+          argument,
+          start: restStart,
+          end: argument.end,
+        }),
+      );
+      // Rest must be last parameter
+      break;
+    }
+
+    // Simple identifier parameter
+    const paramToken = ctx.lexer.expect(TokenType.Identifier);
+    const paramId: AST.Identifier = Object.freeze({
+      type: "Identifier" as const,
+      name: paramToken.value as string,
+      start: paramToken.start,
+      end: paramToken.end,
+    });
+
+    // Check for default value
+    if (ctx.lexer.is(TokenType.Equals)) {
+      const assignStart = paramId.start;
+      ctx.lexer.next();
+      const right = ctx.parseAssignmentExpression(ctx.lexer, true);
+      params.push(
+        Object.freeze({
+          type: "AssignmentPattern" as const,
+          left: paramId,
+          right,
+          start: assignStart,
+          end: right.end,
+        }),
+      );
+    } else {
+      params.push(paramId);
+    }
+  }
+
+  ctx.lexer.expect(TokenType.RightParen);
+  return params;
+};
+
+/**
+ * Check if a token type represents a keyword that can be used as an
+ * identifier in some contexts.
+ *
+ * @param type - The token type to check.
+ * @returns True if the token is a keyword that can serve as identifier.
+ */
+const isKeywordToken = (type: number): boolean => {
+  return (
+    (type >= TokenType.Break && type <= TokenType.With) ||
+    (type >= TokenType.Class && type <= TokenType.Super) ||
+    (type >= TokenType.Async && type <= TokenType.Static)
+  );
+};

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -23,6 +23,7 @@ import type { ParserContext as DeclarationsContext } from "./declarations.js";
 import {
   parseExpression as parseExpressionModule,
   parseAssignmentExpression as parseAssignmentExpressionModule,
+  setBlockStatementParser,
 } from "./expressions.js";
 import {
   parseBlockStatement as parseBlockStmt,
@@ -85,6 +86,10 @@ export class Parser implements DeclarationsContext, StatementsContext {
     this.sourceType = sourceType;
     this.lexer = new Lexer(source, isStrict, allowHashBang);
     this.allowIn = true;
+
+    // Register block statement parser for function/class expression bodies.
+    // The lexer parameter is ignored since this parser instance owns the lexer.
+    setBlockStatementParser((_lex: Lexer) => this.parseBlockStatement());
   }
 
   /**

--- a/tests/unit/parser/function-class-expr.test.ts
+++ b/tests/unit/parser/function-class-expr.test.ts
@@ -1,0 +1,742 @@
+/**
+ * Unit tests for function expression, arrow function, and class expression parsing.
+ *
+ * Covers:
+ * - Function expressions (anonymous, named, generator, async, async generator)
+ * - Arrow functions (concise body, block body, single param, multi param, rest, defaults)
+ * - Async arrow functions
+ * - Class expressions (anonymous, named, extends, methods, fields)
+ * - Error cases and edge cases
+ *
+ * @module tests/unit/parser/function-class-expr
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../../src/parser/parser.js";
+import type * as AST from "../../../src/ast/types.js";
+
+/**
+ * Helper to parse an expression from an expression statement.
+ */
+const parseExpr = (source: string): AST.Expression => {
+  const program = parse(source, { sourceType: "module" });
+  expect(program.body.length).toBeGreaterThan(0);
+  const stmt = program.body[0];
+  expect(stmt.type).toBe("ExpressionStatement");
+  return (stmt as AST.ExpressionStatement).expression;
+};
+
+describe("Function Expression Parsing", () => {
+  describe("Anonymous function expressions", () => {
+    it("should parse anonymous function expression", () => {
+      const expr = parseExpr("(function() {});");
+      expect(expr.type).toBe("FunctionExpression");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id).toBeNull();
+      expect(fn.params).toHaveLength(0);
+      expect(fn.generator).toBe(false);
+      expect(fn.async).toBe(false);
+      expect(fn.body.type).toBe("BlockStatement");
+    });
+
+    it("should parse anonymous function with parameters", () => {
+      const expr = parseExpr("(function(a, b) {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id).toBeNull();
+      expect(fn.params).toHaveLength(2);
+      expect((fn.params[0] as AST.Identifier).name).toBe("a");
+      expect((fn.params[1] as AST.Identifier).name).toBe("b");
+    });
+
+    it("should parse anonymous function with default parameters", () => {
+      const expr = parseExpr("(function(x, y = 1) {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.params).toHaveLength(2);
+      expect((fn.params[0] as AST.Identifier).name).toBe("x");
+      const defParam = fn.params[1] as AST.AssignmentPattern;
+      expect(defParam.type).toBe("AssignmentPattern");
+      expect((defParam.left as AST.Identifier).name).toBe("y");
+      expect((defParam.right as AST.Literal).value).toBe(1);
+    });
+
+    it("should parse anonymous function with rest parameter", () => {
+      const expr = parseExpr("(function(a, ...rest) {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.params).toHaveLength(2);
+      expect((fn.params[0] as AST.Identifier).name).toBe("a");
+      const restParam = fn.params[1] as AST.RestElement;
+      expect(restParam.type).toBe("RestElement");
+      expect((restParam.argument as AST.Identifier).name).toBe("rest");
+    });
+  });
+
+  describe("Named function expressions", () => {
+    it("should parse named function expression", () => {
+      const expr = parseExpr("(function foo() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id).not.toBeNull();
+      expect(fn.id!.name).toBe("foo");
+      expect(fn.params).toHaveLength(0);
+      expect(fn.generator).toBe(false);
+      expect(fn.async).toBe(false);
+    });
+
+    it("should parse named function with parameters", () => {
+      const expr = parseExpr("(function add(a, b) {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id!.name).toBe("add");
+      expect(fn.params).toHaveLength(2);
+    });
+  });
+
+  describe("Generator function expressions", () => {
+    it("should parse anonymous generator function expression", () => {
+      const expr = parseExpr("(function*() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id).toBeNull();
+      expect(fn.generator).toBe(true);
+      expect(fn.async).toBe(false);
+    });
+
+    it("should parse named generator function expression", () => {
+      const expr = parseExpr("(function* gen() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id!.name).toBe("gen");
+      expect(fn.generator).toBe(true);
+    });
+  });
+
+  describe("Async function expressions", () => {
+    it("should parse anonymous async function expression", () => {
+      const expr = parseExpr("(async function() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id).toBeNull();
+      expect(fn.async).toBe(true);
+      expect(fn.generator).toBe(false);
+    });
+
+    it("should parse named async function expression", () => {
+      const expr = parseExpr("(async function fetchData() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id!.name).toBe("fetchData");
+      expect(fn.async).toBe(true);
+    });
+
+    it("should parse async generator function expression", () => {
+      const expr = parseExpr("(async function*() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id).toBeNull();
+      expect(fn.async).toBe(true);
+      expect(fn.generator).toBe(true);
+    });
+
+    it("should parse named async generator function expression", () => {
+      const expr = parseExpr("(async function* gen() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id!.name).toBe("gen");
+      expect(fn.async).toBe(true);
+      expect(fn.generator).toBe(true);
+    });
+  });
+
+  describe("Function expression bodies", () => {
+    it("should parse function with return statement", () => {
+      const expr = parseExpr("(function() { return 42; });");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.body.body).toHaveLength(1);
+      expect(fn.body.body[0].type).toBe("ReturnStatement");
+      const ret = fn.body.body[0] as AST.ReturnStatement;
+      expect(ret.argument).not.toBeNull();
+      expect((ret.argument as AST.Literal).value).toBe(42);
+    });
+
+    it("should parse function with empty return", () => {
+      const expr = parseExpr("(function() { return; });");
+      const fn = expr as AST.FunctionExpression;
+      const ret = fn.body.body[0] as AST.ReturnStatement;
+      expect(ret.argument).toBeNull();
+    });
+
+    it("should parse function with variable declaration", () => {
+      const expr = parseExpr("(function() { const x = 1; });");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.body.body).toHaveLength(1);
+      expect(fn.body.body[0].type).toBe("VariableDeclaration");
+    });
+  });
+
+  describe("Function expression position tracking", () => {
+    it("should have correct start and end positions", () => {
+      const expr = parseExpr("(function foo() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.start).toBeGreaterThanOrEqual(0);
+      expect(fn.end).toBeGreaterThan(fn.start);
+    });
+
+    it("should have correct id positions", () => {
+      const expr = parseExpr("(function bar() {});");
+      const fn = expr as AST.FunctionExpression;
+      expect(fn.id!.start).toBeGreaterThan(0);
+      expect(fn.id!.end).toBeGreaterThan(fn.id!.start);
+    });
+  });
+});
+
+describe("Arrow Function Parsing", () => {
+  describe("Concise body (expression)", () => {
+    it("should parse () => expr", () => {
+      const expr = parseExpr("(() => 42);");
+      expect(expr.type).toBe("ArrowFunctionExpression");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(0);
+      expect(arrow.expression).toBe(true);
+      expect(arrow.async).toBe(false);
+      expect(arrow.generator).toBe(false);
+      expect(arrow.id).toBeNull();
+      expect((arrow.body as AST.Literal).value).toBe(42);
+    });
+
+    it("should parse x => expr", () => {
+      const expr = parseExpr("x => 42;");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(1);
+      expect((arrow.params[0] as AST.Identifier).name).toBe("x");
+      expect(arrow.expression).toBe(true);
+      expect((arrow.body as AST.Literal).value).toBe(42);
+    });
+
+    it("should parse (x) => expr", () => {
+      const expr = parseExpr("((x) => 42);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(1);
+      expect((arrow.params[0] as AST.Identifier).name).toBe("x");
+      expect(arrow.expression).toBe(true);
+    });
+
+    it("should parse (x, y) => expr", () => {
+      const expr = parseExpr("((x, y) => x);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(2);
+      expect((arrow.params[0] as AST.Identifier).name).toBe("x");
+      expect((arrow.params[1] as AST.Identifier).name).toBe("y");
+      expect(arrow.expression).toBe(true);
+    });
+
+    it("should parse (x = 1) => expr", () => {
+      const expr = parseExpr("((x = 1) => x);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(1);
+      const param = arrow.params[0] as AST.AssignmentPattern;
+      expect(param.type).toBe("AssignmentPattern");
+      expect((param.left as AST.Identifier).name).toBe("x");
+      expect((param.right as AST.Literal).value).toBe(1);
+    });
+
+    it("should parse (...args) => expr", () => {
+      const expr = parseExpr("((...args) => args);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(1);
+      const rest = arrow.params[0] as AST.RestElement;
+      expect(rest.type).toBe("RestElement");
+      expect((rest.argument as AST.Identifier).name).toBe("args");
+    });
+
+    it("should parse (a, b, ...rest) => expr", () => {
+      const expr = parseExpr("((a, b, ...rest) => rest);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(3);
+      expect((arrow.params[0] as AST.Identifier).name).toBe("a");
+      expect((arrow.params[1] as AST.Identifier).name).toBe("b");
+      const rest = arrow.params[2] as AST.RestElement;
+      expect(rest.type).toBe("RestElement");
+    });
+  });
+
+  describe("Block body", () => {
+    it("should parse () => { return 1; }", () => {
+      const expr = parseExpr("(() => { return 1; });");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.expression).toBe(false);
+      expect((arrow.body as AST.BlockStatement).type).toBe("BlockStatement");
+      const body = arrow.body as AST.BlockStatement;
+      expect(body.body).toHaveLength(1);
+      expect(body.body[0].type).toBe("ReturnStatement");
+    });
+
+    it("should parse x => { return x; }", () => {
+      const expr = parseExpr("x => { return x; };");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.params).toHaveLength(1);
+      expect(arrow.expression).toBe(false);
+      const body = arrow.body as AST.BlockStatement;
+      expect(body.body).toHaveLength(1);
+    });
+
+    it("should parse arrow with empty block body", () => {
+      const expr = parseExpr("(() => {});");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.expression).toBe(false);
+      const body = arrow.body as AST.BlockStatement;
+      expect(body.body).toHaveLength(0);
+    });
+
+    it("should parse arrow with multiple statements in block", () => {
+      const expr = parseExpr("((x) => { const y = x; return y; });");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.expression).toBe(false);
+      const body = arrow.body as AST.BlockStatement;
+      expect(body.body).toHaveLength(2);
+      expect(body.body[0].type).toBe("VariableDeclaration");
+      expect(body.body[1].type).toBe("ReturnStatement");
+    });
+  });
+
+  describe("Async arrow functions", () => {
+    it("should parse async () => expr", () => {
+      const expr = parseExpr("(async () => 42);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.async).toBe(true);
+      expect(arrow.params).toHaveLength(0);
+      expect(arrow.expression).toBe(true);
+      expect((arrow.body as AST.Literal).value).toBe(42);
+    });
+
+    it("should parse async x => expr", () => {
+      const expr = parseExpr("async x => x;");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.async).toBe(true);
+      expect(arrow.params).toHaveLength(1);
+      expect((arrow.params[0] as AST.Identifier).name).toBe("x");
+    });
+
+    it("should parse async (x, y) => expr", () => {
+      const expr = parseExpr("(async (x, y) => x);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.async).toBe(true);
+      expect(arrow.params).toHaveLength(2);
+    });
+
+    it("should parse async arrow with block body", () => {
+      const expr = parseExpr("(async () => { return 1; });");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.async).toBe(true);
+      expect(arrow.expression).toBe(false);
+      const body = arrow.body as AST.BlockStatement;
+      expect(body.body).toHaveLength(1);
+    });
+
+    it("should parse async arrow with default param", () => {
+      const expr = parseExpr("(async (x = 5) => x);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.async).toBe(true);
+      const param = arrow.params[0] as AST.AssignmentPattern;
+      expect(param.type).toBe("AssignmentPattern");
+      expect((param.right as AST.Literal).value).toBe(5);
+    });
+
+    it("should parse async arrow with rest param", () => {
+      const expr = parseExpr("(async (...args) => args);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.async).toBe(true);
+      const rest = arrow.params[0] as AST.RestElement;
+      expect(rest.type).toBe("RestElement");
+    });
+  });
+
+  describe("Arrow function position tracking", () => {
+    it("should have correct start and end for concise body", () => {
+      const expr = parseExpr("x => 42;");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.start).toBe(0);
+      expect(arrow.end).toBeGreaterThan(arrow.start);
+    });
+
+    it("should have correct start and end for parenthesized params", () => {
+      const expr = parseExpr("((x) => 42);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.start).toBeGreaterThanOrEqual(0);
+      expect(arrow.end).toBeGreaterThan(arrow.start);
+    });
+  });
+
+  describe("Arrow function edge cases", () => {
+    it("should not parse identifier alone as arrow", () => {
+      const expr = parseExpr("x;");
+      expect(expr.type).toBe("Identifier");
+    });
+
+    it("should distinguish parenthesized expr from arrow", () => {
+      const expr = parseExpr("(x + 1);");
+      expect(expr.type).toBe("BinaryExpression");
+    });
+
+    it("should parse arrow returning arrow (nested)", () => {
+      const expr = parseExpr("x => y => x;");
+      const outer = expr as AST.ArrowFunctionExpression;
+      expect(outer.type).toBe("ArrowFunctionExpression");
+      expect(outer.expression).toBe(true);
+      const inner = outer.body as AST.ArrowFunctionExpression;
+      expect(inner.type).toBe("ArrowFunctionExpression");
+      expect((inner.params[0] as AST.Identifier).name).toBe("y");
+    });
+
+    it("should parse arrow as generator is always false", () => {
+      const expr = parseExpr("(() => 1);");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.generator).toBe(false);
+    });
+
+    it("should parse arrow with id always null", () => {
+      const expr = parseExpr("x => x;");
+      const arrow = expr as AST.ArrowFunctionExpression;
+      expect(arrow.id).toBeNull();
+    });
+  });
+});
+
+describe("Class Expression Parsing", () => {
+  describe("Anonymous class expressions", () => {
+    it("should parse empty anonymous class expression", () => {
+      const expr = parseExpr("(class {});");
+      expect(expr.type).toBe("ClassExpression");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.id).toBeNull();
+      expect(cls.superClass).toBeNull();
+      expect(cls.body.type).toBe("ClassBody");
+      expect(cls.body.body).toHaveLength(0);
+    });
+
+    it("should parse anonymous class with method", () => {
+      const expr = parseExpr("(class { foo() {} });");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.id).toBeNull();
+      expect(cls.body.body).toHaveLength(1);
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect(method.type).toBe("MethodDefinition");
+      expect(method.kind).toBe("method");
+      expect((method.key as AST.Identifier).name).toBe("foo");
+    });
+
+    it("should parse anonymous class with constructor", () => {
+      const expr = parseExpr("(class { constructor() {} });");
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect(method.kind).toBe("constructor");
+    });
+
+    it("should parse anonymous class with multiple members", () => {
+      const expr = parseExpr("(class { foo() {} bar() {} });");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.body.body).toHaveLength(2);
+    });
+  });
+
+  describe("Named class expressions", () => {
+    it("should parse named class expression", () => {
+      const expr = parseExpr("(class Foo {});");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.id).not.toBeNull();
+      expect(cls.id!.name).toBe("Foo");
+    });
+
+    it("should parse named class with members", () => {
+      const expr = parseExpr("(class MyClass { method() {} });");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.id!.name).toBe("MyClass");
+      expect(cls.body.body).toHaveLength(1);
+    });
+  });
+
+  describe("Class expressions with extends", () => {
+    it("should parse class extends identifier", () => {
+      const expr = parseExpr("(class extends Base {});");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.id).toBeNull();
+      expect(cls.superClass).not.toBeNull();
+      expect((cls.superClass as AST.Identifier).type).toBe("Identifier");
+      expect((cls.superClass as AST.Identifier).name).toBe("Base");
+    });
+
+    it("should parse named class with extends", () => {
+      const expr = parseExpr("(class Foo extends Bar {});");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.id!.name).toBe("Foo");
+      expect((cls.superClass as AST.Identifier).name).toBe("Bar");
+    });
+
+    it("should parse class extends with members", () => {
+      const expr = parseExpr("(class extends Base { method() {} });");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.superClass).not.toBeNull();
+      expect(cls.body.body).toHaveLength(1);
+    });
+  });
+
+  describe("Class expression members", () => {
+    it("should parse getter method", () => {
+      const expr = parseExpr("(class { get x() {} });");
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect(method.kind).toBe("get");
+      expect((method.key as AST.Identifier).name).toBe("x");
+    });
+
+    it("should parse setter method", () => {
+      const expr = parseExpr("(class { set x(v) {} });");
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect(method.kind).toBe("set");
+      expect((method.key as AST.Identifier).name).toBe("x");
+    });
+
+    it("should parse static method", () => {
+      const expr = parseExpr("(class { static foo() {} });");
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect(method.static).toBe(true);
+      expect((method.key as AST.Identifier).name).toBe("foo");
+    });
+
+    it("should parse property definition with initializer", () => {
+      const expr = parseExpr("(class { x = 42 });");
+      const cls = expr as AST.ClassExpression;
+      const prop = cls.body.body[0] as AST.PropertyDefinition;
+      expect(prop.type).toBe("PropertyDefinition");
+      expect((prop.key as AST.Identifier).name).toBe("x");
+      expect((prop.value as AST.Literal).value).toBe(42);
+    });
+
+    it("should parse property definition without initializer", () => {
+      const expr = parseExpr("(class { x });");
+      const cls = expr as AST.ClassExpression;
+      const prop = cls.body.body[0] as AST.PropertyDefinition;
+      expect(prop.type).toBe("PropertyDefinition");
+      expect(prop.value).toBeNull();
+    });
+
+    it("should parse static property", () => {
+      const expr = parseExpr("(class { static x = 1 });");
+      const cls = expr as AST.ClassExpression;
+      const prop = cls.body.body[0] as AST.PropertyDefinition;
+      expect(prop.static).toBe(true);
+    });
+
+    it("should parse computed method key", () => {
+      const expr = parseExpr('(class { ["foo"]() {} });');
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect(method.computed).toBe(true);
+      expect((method.key as AST.Literal).value).toBe("foo");
+    });
+
+    it("should parse method with parameters", () => {
+      const expr = parseExpr("(class { add(a, b) {} });");
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect(method.value.params).toHaveLength(2);
+    });
+  });
+
+  describe("Class expression position tracking", () => {
+    it("should have correct start and end positions", () => {
+      const expr = parseExpr("(class Foo {});");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.start).toBeGreaterThanOrEqual(0);
+      expect(cls.end).toBeGreaterThan(cls.start);
+      expect(cls.body.start).toBeGreaterThan(0);
+      expect(cls.body.end).toBeGreaterThan(cls.body.start);
+    });
+  });
+
+  describe("Class expression edge cases", () => {
+    it("should parse class with semicolons between members", () => {
+      const expr = parseExpr("(class { ; foo() {} ; bar() {} ; });");
+      const cls = expr as AST.ClassExpression;
+      expect(cls.body.body).toHaveLength(2);
+    });
+
+    it("should parse class with numeric method name", () => {
+      const expr = parseExpr("(class { 0() {} });");
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect((method.key as AST.Literal).value).toBe(0);
+    });
+
+    it("should parse class with string method name", () => {
+      const expr = parseExpr('(class { "hello"() {} });');
+      const cls = expr as AST.ClassExpression;
+      const method = cls.body.body[0] as AST.MethodDefinition;
+      expect((method.key as AST.Literal).value).toBe("hello");
+    });
+  });
+});
+
+describe("Integration: Function/Class expressions in various contexts", () => {
+  it("should parse function expression assigned to variable", () => {
+    const program = parse("const fn = function() {};");
+    expect(program.body).toHaveLength(1);
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const init = (decl.declarations[0] as AST.VariableDeclarator)
+      .init as AST.FunctionExpression;
+    expect(init.type).toBe("FunctionExpression");
+  });
+
+  it("should parse arrow function assigned to variable", () => {
+    const program = parse("const fn = () => 1;");
+    expect(program.body).toHaveLength(1);
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const init = (decl.declarations[0] as AST.VariableDeclarator)
+      .init as AST.ArrowFunctionExpression;
+    expect(init.type).toBe("ArrowFunctionExpression");
+    expect(init.expression).toBe(true);
+  });
+
+  it("should parse class expression assigned to variable", () => {
+    const program = parse("const C = class {};");
+    expect(program.body).toHaveLength(1);
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const init = (decl.declarations[0] as AST.VariableDeclarator)
+      .init as AST.ClassExpression;
+    expect(init.type).toBe("ClassExpression");
+  });
+
+  it("should parse arrow with single param assigned to variable", () => {
+    const program = parse("const double = x => x;");
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const init = (decl.declarations[0] as AST.VariableDeclarator)
+      .init as AST.ArrowFunctionExpression;
+    expect(init.type).toBe("ArrowFunctionExpression");
+    expect(init.params).toHaveLength(1);
+  });
+
+  it("should parse async arrow assigned to variable", () => {
+    const program = parse("const fn = async () => 1;");
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const init = (decl.declarations[0] as AST.VariableDeclarator)
+      .init as AST.ArrowFunctionExpression;
+    expect(init.type).toBe("ArrowFunctionExpression");
+    expect(init.async).toBe(true);
+  });
+
+  it("should parse named function expression assigned to variable", () => {
+    const program = parse("const fn = function named() {};");
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const init = (decl.declarations[0] as AST.VariableDeclarator)
+      .init as AST.FunctionExpression;
+    expect(init.type).toBe("FunctionExpression");
+    expect(init.id!.name).toBe("named");
+  });
+
+  it("should parse async function expression assigned to variable", () => {
+    const program = parse("const fn = async function() {};");
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const init = (decl.declarations[0] as AST.VariableDeclarator)
+      .init as AST.FunctionExpression;
+    expect(init.type).toBe("FunctionExpression");
+    expect(init.async).toBe(true);
+  });
+});
+
+describe("Error handling", () => {
+  it("should throw on unterminated function expression body", () => {
+    expect(() => parseExpr("(function() {")).toThrow(SyntaxError);
+  });
+
+  it("should throw on unterminated class body", () => {
+    expect(() => parseExpr("(class {")).toThrow(SyntaxError);
+  });
+
+  it("should throw on missing arrow after empty parens", () => {
+    expect(() => parseExpr("();")).toThrow(SyntaxError);
+  });
+
+  it("should throw on missing parameter name in function", () => {
+    expect(() => parseExpr("(function(,) {});")).toThrow(SyntaxError);
+  });
+
+  it("should throw on unexpected token in class member", () => {
+    expect(() => parseExpr("(class { + });")).toThrow(SyntaxError);
+  });
+
+  it("should throw on unterminated paren in arrow detection (EOF)", () => {
+    expect(() => parseExpr("((x")).toThrow(SyntaxError);
+  });
+});
+
+describe("Additional edge cases for coverage", () => {
+  it("should parse class with 'set' as regular method name", () => {
+    const expr = parseExpr("(class { set() {} });");
+    const cls = expr as AST.ClassExpression;
+    const method = cls.body.body[0] as AST.MethodDefinition;
+    expect(method.kind).toBe("method");
+    expect((method.key as AST.Identifier).name).toBe("set");
+  });
+
+  it("should parse class with 'get' as regular method name", () => {
+    const expr = parseExpr("(class { get() {} });");
+    const cls = expr as AST.ClassExpression;
+    const method = cls.body.body[0] as AST.MethodDefinition;
+    expect(method.kind).toBe("method");
+    expect((method.key as AST.Identifier).name).toBe("get");
+  });
+
+  it("should parse class property with explicit semicolons", () => {
+    const expr = parseExpr("(class { x = 1; y = 2; });");
+    const cls = expr as AST.ClassExpression;
+    expect(cls.body.body).toHaveLength(2);
+    const prop1 = cls.body.body[0] as AST.PropertyDefinition;
+    expect((prop1.key as AST.Identifier).name).toBe("x");
+    const prop2 = cls.body.body[1] as AST.PropertyDefinition;
+    expect((prop2.key as AST.Identifier).name).toBe("y");
+  });
+
+  it("should parse class with 'set' as property name", () => {
+    const expr = parseExpr("(class { set = 5 });");
+    const cls = expr as AST.ClassExpression;
+    const prop = cls.body.body[0] as AST.PropertyDefinition;
+    expect(prop.type).toBe("PropertyDefinition");
+    expect((prop.key as AST.Identifier).name).toBe("set");
+    expect((prop.value as AST.Literal).value).toBe(5);
+  });
+
+  it("should parse class with 'get' as property name", () => {
+    const expr = parseExpr("(class { get = 5 });");
+    const cls = expr as AST.ClassExpression;
+    const prop = cls.body.body[0] as AST.PropertyDefinition;
+    expect(prop.type).toBe("PropertyDefinition");
+    expect((prop.key as AST.Identifier).name).toBe("get");
+  });
+
+  it("should parse nested parentheses in arrow param detection", () => {
+    const expr = parseExpr("((x) => x);");
+    const arrow = expr as AST.ArrowFunctionExpression;
+    expect(arrow.type).toBe("ArrowFunctionExpression");
+  });
+
+  it("should handle parenthesized expression that is not an arrow", () => {
+    const expr = parseExpr("(1 + 2);");
+    expect(expr.type).toBe("BinaryExpression");
+  });
+
+  it("should parse class with static block", () => {
+    const expr = parseExpr("(class { static { } });");
+    const cls = expr as AST.ClassExpression;
+    expect(cls.body.body).toHaveLength(1);
+    const block = cls.body.body[0] as AST.StaticBlock;
+    expect(block.type).toBe("StaticBlock");
+  });
+
+  it("should parse class with static block containing statements", () => {
+    const expr = parseExpr("(class { static { const x = 1; } });");
+    const cls = expr as AST.ClassExpression;
+    const block = cls.body.body[0] as AST.StaticBlock;
+    expect(block.type).toBe("StaticBlock");
+    expect(block.body).toHaveLength(1);
+  });
+
+  it("should parse 'async' as plain identifier when not followed by function/arrow", () => {
+    const expr = parseExpr("async;");
+    expect(expr.type).toBe("Identifier");
+    expect((expr as AST.Identifier).name).toBe("async");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/parser/function-class-expr.ts` implementing function expressions (named/anonymous, async, generator), arrow functions (concise/block body, async, rest/default params), and class expressions (named/anonymous, extends, methods, properties, static blocks)
- Integrates into `expressions.ts` by replacing stub implementations with real delegation to the new module, including arrow function detection via lexer lookahead
- Registers block statement parser from `parser.ts` to break circular dependency between expressions and statements modules

## Test plan

- [x] 85 new unit tests in `tests/unit/parser/function-class-expr.test.ts` covering all expression types, parameter variations, edge cases, and error handling
- [x] All 1397 existing parser tests continue to pass
- [x] TypeScript strict mode compiles without errors
- [x] Prettier formatting verified

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)