### PR TITLE
feat: implement parser async/await and generators

### DIFF
--- a/src/parser/declarations.ts
+++ b/src/parser/declarations.ts
@@ -91,8 +91,18 @@ export const parseFunctionDeclaration = (
   // Parse parameters
   const params = parseParameters(ctx);
 
+  // Save previous context and set async/generator flags for body parsing
+  const prevAsync = ctx.lexer.inAsync;
+  const prevGenerator = ctx.lexer.inGenerator;
+  ctx.lexer.inAsync = isAsync;
+  ctx.lexer.inGenerator = generator;
+
   // Parse body
   const body = ctx.parseBlockStatement();
+
+  // Restore previous context
+  ctx.lexer.inAsync = prevAsync;
+  ctx.lexer.inGenerator = prevGenerator;
 
   return Object.freeze({
     type: "FunctionDeclaration" as const,

--- a/src/parser/expressions.ts
+++ b/src/parser/expressions.ts
@@ -110,9 +110,101 @@ export const parseExpression = (
 };
 
 /**
+ * Parse a yield expression: yield [expr] or yield* expr.
+ *
+ * Yield has very low precedence (lower than assignment) and is only
+ * valid inside generator function bodies.
+ *
+ * @param lexer - The lexer instance.
+ * @param allowIn - Whether the `in` operator is permitted.
+ * @returns The YieldExpression AST node.
+ */
+const parseYieldExpression = (
+  lexer: Lexer,
+  allowIn: boolean,
+): AST.YieldExpression => {
+  const start = lexer.token.start;
+  lexer.next(); // consume 'yield'
+
+  // Check for delegate: yield*
+  let delegate = false;
+  if (lexer.is(TokenType.Star) && !lexer.hadLineTerminatorBefore) {
+    delegate = true;
+    lexer.next(); // consume '*'
+  }
+
+  // yield without argument (line terminator or restricted token follows)
+  let argument: AST.Expression | null = null;
+  if (
+    !delegate &&
+    (lexer.hadLineTerminatorBefore || isYieldTerminator(lexer))
+  ) {
+    argument = null;
+  } else {
+    argument = parseAssignmentExpression(lexer, allowIn);
+  }
+
+  const end = argument !== null ? argument.end : start + 5;
+
+  return Object.freeze({
+    type: "YieldExpression" as const,
+    start,
+    end,
+    argument,
+    delegate,
+  });
+};
+
+/**
+ * Check if the current token terminates a yield expression without argument.
+ *
+ * @param lexer - The lexer instance.
+ * @returns True if yield should have no argument.
+ */
+const isYieldTerminator = (lexer: Lexer): boolean => {
+  const t = lexer.token.type;
+  return (
+    t === TokenType.Semicolon ||
+    t === TokenType.RightParen ||
+    t === TokenType.RightBracket ||
+    t === TokenType.RightBrace ||
+    t === TokenType.Comma ||
+    t === TokenType.Colon ||
+    t === TokenType.EOF
+  );
+};
+
+/**
+ * Parse an await expression: await expr.
+ *
+ * Await has unary-like precedence (higher than assignment, lower than unary).
+ * Only valid inside async function bodies.
+ *
+ * @param lexer - The lexer instance.
+ * @returns The AwaitExpression AST node.
+ */
+const parseAwaitExpression = (lexer: Lexer): AST.AwaitExpression => {
+  const start = lexer.token.start;
+  lexer.next(); // consume 'await'
+
+  // Parse the argument as a unary expression (await binds tighter than binary)
+  const argument = parseUnaryExpression(lexer, () =>
+    parseLeftHandSideExpression(lexer),
+  );
+
+  return Object.freeze({
+    type: "AwaitExpression" as const,
+    start,
+    end: argument.end,
+    argument,
+  });
+};
+
+/**
  * Parse an assignment expression with full operator support.
  *
- * Pipeline: unary -> binary (Pratt) -> conditional -> assignment check.
+ * Pipeline: yield check -> await check -> unary -> binary (Pratt) ->
+ * conditional -> assignment check.
  * If `allowIn` is false (for-loop init), the `in` operator is excluded
  * from binary precedence.
  *
@@ -124,10 +216,17 @@ export const parseAssignmentExpression = (
   lexer: Lexer,
   allowIn: boolean = true,
 ): AST.Expression => {
+  // Yield has the lowest precedence (lower than assignment)
+  if (lexer.is(TokenType.Yield) && lexer.inGenerator) {
+    return parseYieldExpression(lexer, allowIn);
+  }
+
   // Parse unary (prefix operators + primary with member/call + postfix)
-  const unary = parseUnaryExpression(lexer, () =>
-    parseLeftHandSideExpression(lexer),
-  );
+  // Await is handled at unary level (binds tighter than binary)
+  const unary =
+    lexer.is(TokenType.Await) && lexer.inAsync
+      ? parseAwaitExpression(lexer)
+      : parseUnaryExpression(lexer, () => parseLeftHandSideExpression(lexer));
 
   // Parse binary/logical with Pratt precedence
   const binary = parseBinaryExpression(lexer, unary, 1, allowIn);
@@ -185,6 +284,12 @@ export const parsePrimaryExpression = (lexer: Lexer): AST.Expression => {
 
     case TokenType.Async:
       return parseAsyncExpression(lexer);
+
+    case TokenType.Await:
+      return parseAwaitAsIdentifier(lexer);
+
+    case TokenType.Yield:
+      return parseYieldAsIdentifier(lexer);
 
     case TokenType.This:
       return parseThisExpression(lexer);
@@ -432,6 +537,38 @@ const parseBigIntLiteral = (lexer: Lexer): AST.Literal => {
     value: token.value as bigint,
     raw,
     bigint: bigintStr,
+  });
+};
+
+/**
+ * Parse `await` as an identifier when not inside an async function.
+ *
+ * @param lexer - The lexer instance.
+ * @returns An Identifier AST node.
+ */
+const parseAwaitAsIdentifier = (lexer: Lexer): AST.Identifier => {
+  const consumed = lexer.next();
+  return Object.freeze({
+    type: "Identifier" as const,
+    start: consumed.start,
+    end: consumed.end,
+    name: "await",
+  });
+};
+
+/**
+ * Parse `yield` as an identifier when not inside a generator function.
+ *
+ * @param lexer - The lexer instance.
+ * @returns An Identifier AST node.
+ */
+const parseYieldAsIdentifier = (lexer: Lexer): AST.Identifier => {
+  const consumed = lexer.next();
+  return Object.freeze({
+    type: "Identifier" as const,
+    start: consumed.start,
+    end: consumed.end,
+    name: "yield",
   });
 };
 

--- a/src/parser/function-class-expr.ts
+++ b/src/parser/function-class-expr.ts
@@ -70,8 +70,18 @@ export const parseFunctionExpression = (
   // Parse parameters
   const params = parseParams(ctx);
 
+  // Save previous context and set async/generator flags for body parsing
+  const prevAsync = ctx.lexer.inAsync;
+  const prevGenerator = ctx.lexer.inGenerator;
+  ctx.lexer.inAsync = isAsync;
+  ctx.lexer.inGenerator = generator;
+
   // Parse body
   const body = ctx.parseBlockStatementFromLexer(ctx.lexer);
+
+  // Restore previous context
+  ctx.lexer.inAsync = prevAsync;
+  ctx.lexer.inGenerator = prevGenerator;
 
   return Object.freeze({
     type: "FunctionExpression" as const,
@@ -112,10 +122,21 @@ export const parseArrowFunction = (
   // Consume '=>'
   ctx.lexer.expect(TokenType.Arrow);
 
+  // Save previous context and set async flag for body parsing
+  const prevAsync = ctx.lexer.inAsync;
+  const prevGenerator = ctx.lexer.inGenerator;
+  ctx.lexer.inAsync = isAsync;
+  ctx.lexer.inGenerator = false;
+
   // Determine body type: block or expression
   if (ctx.lexer.is(TokenType.LeftBrace)) {
     // Block body: () => { ... }
     const body = ctx.parseBlockStatementFromLexer(ctx.lexer);
+
+    // Restore previous context
+    ctx.lexer.inAsync = prevAsync;
+    ctx.lexer.inGenerator = prevGenerator;
+
     return Object.freeze({
       type: "ArrowFunctionExpression" as const,
       id: null,
@@ -131,6 +152,11 @@ export const parseArrowFunction = (
 
   // Concise body: () => expr
   const body = ctx.parseAssignmentExpression(ctx.lexer, true);
+
+  // Restore previous context
+  ctx.lexer.inAsync = prevAsync;
+  ctx.lexer.inGenerator = prevGenerator;
+
   return Object.freeze({
     type: "ArrowFunctionExpression" as const,
     id: null,

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -36,6 +36,8 @@ export interface LexerState {
   readonly hadLineTerminatorBefore: boolean;
   readonly previousTokenType: number;
   readonly templateDepth: number;
+  readonly inAsync: boolean;
+  readonly inGenerator: boolean;
 }
 
 /**
@@ -133,6 +135,10 @@ export class Lexer {
   private previousTokenType: number;
   /** Whether the hashbang at source start has been processed. */
   private hashbangProcessed: boolean;
+  /** Whether the current parsing context is inside an async function. */
+  private _inAsync: boolean;
+  /** Whether the current parsing context is inside a generator function. */
+  private _inGenerator: boolean;
 
   /**
    * Create a new Lexer for the given source text.
@@ -149,6 +155,8 @@ export class Lexer {
     this.templateDepth = 0;
     this.previousTokenType = -1;
     this.hashbangProcessed = false;
+    this._inAsync = false;
+    this._inGenerator = false;
 
     // Handle hashbang if allowed and present
     if (allowHashBang) {
@@ -175,6 +183,34 @@ export class Lexer {
    */
   get hadLineTerminatorBefore(): boolean {
     return this.hadLineTerminator;
+  }
+
+  /**
+   * Whether the parser is currently inside an async function body.
+   */
+  get inAsync(): boolean {
+    return this._inAsync;
+  }
+
+  /**
+   * Set whether the parser is inside an async function body.
+   */
+  set inAsync(value: boolean) {
+    this._inAsync = value;
+  }
+
+  /**
+   * Whether the parser is currently inside a generator function body.
+   */
+  get inGenerator(): boolean {
+    return this._inGenerator;
+  }
+
+  /**
+   * Set whether the parser is inside a generator function body.
+   */
+  set inGenerator(value: boolean) {
+    this._inGenerator = value;
   }
 
   /**
@@ -244,6 +280,8 @@ export class Lexer {
       hadLineTerminatorBefore: this.hadLineTerminator,
       previousTokenType: this.previousTokenType,
       templateDepth: this.templateDepth,
+      inAsync: this._inAsync,
+      inGenerator: this._inGenerator,
     });
   }
 
@@ -258,6 +296,8 @@ export class Lexer {
     this.hadLineTerminator = state.hadLineTerminatorBefore;
     this.previousTokenType = state.previousTokenType;
     this.templateDepth = state.templateDepth;
+    this._inAsync = state.inAsync;
+    this._inGenerator = state.inGenerator;
   }
 
   /**

--- a/tests/unit/parser/async-generators.test.ts
+++ b/tests/unit/parser/async-generators.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for async/await and generator (yield) expression parsing.
+ *
+ * Covers AwaitExpression and YieldExpression nodes with context tracking,
+ * precedence behavior, and error cases when used outside valid contexts.
+ *
+ * @module tests/unit/parser/async-generators
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../../src/parser/parser.js";
+import type * as AST from "../../../src/ast/types.js";
+
+/**
+ * Helper to extract the first expression from a parsed program.
+ */
+const parseExpr = (source: string): AST.Expression => {
+  const program = parse(source, { sourceType: "module" });
+  const stmt = program.body[0] as AST.ExpressionStatement;
+  return stmt.expression;
+};
+
+/**
+ * Helper to extract the body statements from a function expression.
+ */
+const parseFnBody = (source: string): ReadonlyArray<AST.Statement> => {
+  const program = parse(source, { sourceType: "module" });
+  const stmt = program.body[0] as AST.ExpressionStatement;
+  const fn = stmt.expression as AST.FunctionExpression;
+  return fn.body.body;
+};
+
+/**
+ * Helper to extract the first expression from inside a function body.
+ */
+const parseFnExpr = (source: string): AST.Expression => {
+  const stmts = parseFnBody(source);
+  const exprStmt = stmts[0] as AST.ExpressionStatement;
+  return exprStmt.expression;
+};
+
+describe("AwaitExpression", () => {
+  it("parses await in async function body", () => {
+    const expr = parseFnExpr("(async function() { await fetch() })");
+    expect(expr.type).toBe("AwaitExpression");
+    const awaitExpr = expr as AST.AwaitExpression;
+    expect(awaitExpr.argument.type).toBe("CallExpression");
+    const call = awaitExpr.argument as AST.CallExpression;
+    expect((call.callee as AST.Identifier).name).toBe("fetch");
+  });
+
+  it("parses await in async arrow function with block body", () => {
+    const program = parse("const f = async () => { await x; }", {
+      sourceType: "module",
+    });
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const arrow = decl.declarations[0].init as AST.ArrowFunctionExpression;
+    const bodyStmt = (arrow.body as AST.BlockStatement)
+      .body[0] as AST.ExpressionStatement;
+    expect(bodyStmt.expression.type).toBe("AwaitExpression");
+  });
+
+  it("parses await in async arrow function with concise body", () => {
+    const program = parse("const f = async () => await x", {
+      sourceType: "module",
+    });
+    const decl = program.body[0] as AST.VariableDeclaration;
+    const arrow = decl.declarations[0].init as AST.ArrowFunctionExpression;
+    expect(arrow.expression).toBe(true);
+    expect((arrow.body as AST.AwaitExpression).type).toBe("AwaitExpression");
+  });
+
+  it("parses await with member expression argument", () => {
+    const expr = parseFnExpr("(async function() { await obj.method() })");
+    expect(expr.type).toBe("AwaitExpression");
+    const awaitExpr = expr as AST.AwaitExpression;
+    expect(awaitExpr.argument.type).toBe("CallExpression");
+  });
+
+  it("parses await with correct precedence (unary level)", () => {
+    // await a + b should parse as (await a) + b since await has unary precedence
+    const stmts = parseFnBody("(async function() { await a + b })");
+    const exprStmt = stmts[0] as AST.ExpressionStatement;
+    // The top-level should be a BinaryExpression with left = AwaitExpression
+    expect(exprStmt.expression.type).toBe("BinaryExpression");
+    const binary = exprStmt.expression as AST.BinaryExpression;
+    expect(binary.operator).toBe("+");
+    expect(binary.left.type).toBe("AwaitExpression");
+    expect(binary.right.type).toBe("Identifier");
+    expect((binary.right as AST.Identifier).name).toBe("b");
+  });
+
+  it("parses nested await expressions", () => {
+    const expr = parseFnExpr("(async function() { await (await inner()) })");
+    expect(expr.type).toBe("AwaitExpression");
+    const outer = expr as AST.AwaitExpression;
+    expect(outer.argument.type).toBe("AwaitExpression");
+    const inner = outer.argument as AST.AwaitExpression;
+    expect(inner.argument.type).toBe("CallExpression");
+  });
+
+  it("parses await as identifier outside async context", () => {
+    const expr = parseExpr("await");
+    expect(expr.type).toBe("Identifier");
+    expect((expr as AST.Identifier).name).toBe("await");
+  });
+
+  it("parses await as identifier in non-async function", () => {
+    const expr = parseFnExpr("(function() { await })");
+    expect(expr.type).toBe("Identifier");
+    expect((expr as AST.Identifier).name).toBe("await");
+  });
+
+  it("preserves correct start and end positions", () => {
+    const expr = parseFnExpr("(async function() { await x })");
+    expect(expr.type).toBe("AwaitExpression");
+    const awaitExpr = expr as AST.AwaitExpression;
+    expect(awaitExpr.start).toBe(20);
+    expect(awaitExpr.end).toBeGreaterThan(awaitExpr.start);
+  });
+
+  it("parses await in async function declaration", () => {
+    const program = parse("async function foo() { await bar(); }", {
+      sourceType: "module",
+    });
+    const fnDecl = program.body[0] as AST.FunctionDeclaration;
+    const exprStmt = fnDecl.body.body[0] as AST.ExpressionStatement;
+    expect(exprStmt.expression.type).toBe("AwaitExpression");
+  });
+});
+
+describe("YieldExpression", () => {
+  it("parses yield with argument in generator", () => {
+    const expr = parseFnExpr("(function*() { yield 1 })");
+    expect(expr.type).toBe("YieldExpression");
+    const yieldExpr = expr as AST.YieldExpression;
+    expect(yieldExpr.delegate).toBe(false);
+    expect(yieldExpr.argument).not.toBeNull();
+    expect(yieldExpr.argument!.type).toBe("Literal");
+    expect((yieldExpr.argument as AST.Literal).value).toBe(1);
+  });
+
+  it("parses yield without argument", () => {
+    const expr = parseFnExpr("(function*() { yield; })");
+    expect(expr.type).toBe("YieldExpression");
+    const yieldExpr = expr as AST.YieldExpression;
+    expect(yieldExpr.delegate).toBe(false);
+    expect(yieldExpr.argument).toBeNull();
+  });
+
+  it("parses yield* delegation", () => {
+    const expr = parseFnExpr("(function*() { yield* iter })");
+    expect(expr.type).toBe("YieldExpression");
+    const yieldExpr = expr as AST.YieldExpression;
+    expect(yieldExpr.delegate).toBe(true);
+    expect(yieldExpr.argument).not.toBeNull();
+    expect(yieldExpr.argument!.type).toBe("Identifier");
+    expect((yieldExpr.argument as AST.Identifier).name).toBe("iter");
+  });
+
+  it("parses yield* with call expression", () => {
+    const expr = parseFnExpr("(function*() { yield* getIter() })");
+    expect(expr.type).toBe("YieldExpression");
+    const yieldExpr = expr as AST.YieldExpression;
+    expect(yieldExpr.delegate).toBe(true);
+    expect(yieldExpr.argument!.type).toBe("CallExpression");
+  });
+
+  it("parses yield in generator function declaration", () => {
+    const program = parse("function* gen() { yield 42; }", {
+      sourceType: "module",
+    });
+    const fnDecl = program.body[0] as AST.FunctionDeclaration;
+    const exprStmt = fnDecl.body.body[0] as AST.ExpressionStatement;
+    expect(exprStmt.expression.type).toBe("YieldExpression");
+    const yieldExpr = exprStmt.expression as AST.YieldExpression;
+    expect((yieldExpr.argument as AST.Literal).value).toBe(42);
+  });
+
+  it("parses yield as identifier outside generator context", () => {
+    const expr = parseExpr("yield");
+    expect(expr.type).toBe("Identifier");
+    expect((expr as AST.Identifier).name).toBe("yield");
+  });
+
+  it("parses yield as identifier in non-generator function", () => {
+    const expr = parseFnExpr("(function() { yield })");
+    expect(expr.type).toBe("Identifier");
+    expect((expr as AST.Identifier).name).toBe("yield");
+  });
+
+  it("parses yield with low precedence (lower than assignment)", () => {
+    // yield a = b should parse as yield (a = b)
+    const expr = parseFnExpr("(function*() { yield a = b })");
+    expect(expr.type).toBe("YieldExpression");
+    const yieldExpr = expr as AST.YieldExpression;
+    expect(yieldExpr.argument!.type).toBe("AssignmentExpression");
+  });
+
+  it("parses yield followed by comma as yield without arg in sequence", () => {
+    // Inside a function: yield, 2 should be (yield), 2 as a sequence
+    const stmts = parseFnBody("(function*() { yield, 2 })");
+    const exprStmt = stmts[0] as AST.ExpressionStatement;
+    // The comma makes it a sequence expression
+    expect(exprStmt.expression.type).toBe("SequenceExpression");
+    const seq = exprStmt.expression as AST.SequenceExpression;
+    expect(seq.expressions[0].type).toBe("YieldExpression");
+    const yieldExpr = seq.expressions[0] as AST.YieldExpression;
+    expect(yieldExpr.argument).toBeNull();
+    expect(seq.expressions[1].type).toBe("Literal");
+  });
+
+  it("preserves correct start and end positions for yield with arg", () => {
+    const expr = parseFnExpr("(function*() { yield 1 })");
+    expect(expr.type).toBe("YieldExpression");
+    const yieldExpr = expr as AST.YieldExpression;
+    expect(yieldExpr.start).toBe(15);
+    expect(yieldExpr.end).toBeGreaterThan(yieldExpr.start);
+  });
+});
+
+describe("Async Generator (combined)", () => {
+  it("parses await inside async generator", () => {
+    const expr = parseFnExpr("(async function*() { await fetch() })");
+    expect(expr.type).toBe("AwaitExpression");
+    const awaitExpr = expr as AST.AwaitExpression;
+    expect(awaitExpr.argument.type).toBe("CallExpression");
+  });
+
+  it("parses yield inside async generator", () => {
+    const stmts = parseFnBody("(async function*() { yield 1 })");
+    const exprStmt = stmts[0] as AST.ExpressionStatement;
+    expect(exprStmt.expression.type).toBe("YieldExpression");
+  });
+
+  it("parses nested await yield in async generator", () => {
+    // await (yield 1) should parse await wrapping a yield
+    const expr = parseFnExpr("(async function*() { await (yield 1) })");
+    expect(expr.type).toBe("AwaitExpression");
+    const awaitExpr = expr as AST.AwaitExpression;
+    expect(awaitExpr.argument.type).toBe("YieldExpression");
+    const yieldExpr = awaitExpr.argument as AST.YieldExpression;
+    expect((yieldExpr.argument as AST.Literal).value).toBe(1);
+  });
+
+  it("parses yield* inside async generator", () => {
+    const expr = parseFnExpr("(async function*() { yield* asyncIter })");
+    expect(expr.type).toBe("YieldExpression");
+    const yieldExpr = expr as AST.YieldExpression;
+    expect(yieldExpr.delegate).toBe(true);
+    expect((yieldExpr.argument as AST.Identifier).name).toBe("asyncIter");
+  });
+
+  it("context resets after exiting function body", () => {
+    // After an async function, await should be an identifier at top level
+    const program = parse("async function f() { await x; } await", {
+      sourceType: "module",
+    });
+    const fnDecl = program.body[0] as AST.FunctionDeclaration;
+    const bodyExpr = (fnDecl.body.body[0] as AST.ExpressionStatement)
+      .expression;
+    expect(bodyExpr.type).toBe("AwaitExpression");
+
+    const topExpr = (program.body[1] as AST.ExpressionStatement).expression;
+    expect(topExpr.type).toBe("Identifier");
+    expect((topExpr as AST.Identifier).name).toBe("await");
+  });
+
+  it("context resets after exiting generator body", () => {
+    // After a generator function, yield should be an identifier at top level
+    const program = parse("function* g() { yield 1; } yield", {
+      sourceType: "module",
+    });
+    const fnDecl = program.body[0] as AST.FunctionDeclaration;
+    const bodyExpr = (fnDecl.body.body[0] as AST.ExpressionStatement)
+      .expression;
+    expect(bodyExpr.type).toBe("YieldExpression");
+
+    const topExpr = (program.body[1] as AST.ExpressionStatement).expression;
+    expect(topExpr.type).toBe("Identifier");
+    expect((topExpr as AST.Identifier).name).toBe("yield");
+  });
+
+  it("nested functions do not inherit async context", () => {
+    const program = parse(
+      "async function outer() { function inner() { await } }",
+      { sourceType: "module" },
+    );
+    const outerFn = program.body[0] as AST.FunctionDeclaration;
+    // inner is a function declaration inside outer
+    const innerFn = outerFn.body.body[0] as AST.FunctionDeclaration;
+    const innerExpr = (innerFn.body.body[0] as AST.ExpressionStatement)
+      .expression;
+    // await inside non-async inner should be identifier
+    expect(innerExpr.type).toBe("Identifier");
+    expect((innerExpr as AST.Identifier).name).toBe("await");
+  });
+
+  it("nested functions do not inherit generator context", () => {
+    const program = parse("function* outer() { function inner() { yield } }", {
+      sourceType: "module",
+    });
+    const outerFn = program.body[0] as AST.FunctionDeclaration;
+    const innerFn = outerFn.body.body[0] as AST.FunctionDeclaration;
+    const innerExpr = (innerFn.body.body[0] as AST.ExpressionStatement)
+      .expression;
+    // yield inside non-generator inner should be identifier
+    expect(innerExpr.type).toBe("Identifier");
+    expect((innerExpr as AST.Identifier).name).toBe("yield");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `AwaitExpression` and `YieldExpression` parsing to the expression parser with correct precedence handling
- Track async/generator context via `inAsync`/`inGenerator` flags on the Lexer, with proper save/restore and context reset across function boundaries
- `await` parses at unary precedence (participates in binary expressions); `yield` parses at assignment precedence (lower than assignment)
- Outside their valid contexts, `await` and `yield` parse as plain identifiers

## Test plan

- [x] `await fetch()` in async function body
- [x] `await a + b` precedence: parses as `(await a) + b`
- [x] `yield 1` in generator
- [x] `yield* iter` delegation
- [x] `yield` without argument
- [x] Nested: `await (yield 1)` in async generator
- [x] `await`/`yield` as identifiers outside async/generator context
- [x] Context resets after exiting function body
- [x] Nested functions do not inherit parent async/generator context
- [x] All 2397 existing tests continue to pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)