### PR TITLE
feat: JSX parsing and error recovery diagnostics

### DIFF
--- a/src/parser/diagnostics.ts
+++ b/src/parser/diagnostics.ts
@@ -1,0 +1,194 @@
+/**
+ * Enhanced error handling and diagnostics for the Steamroller parser.
+ *
+ * Provides structured parse errors with source locations, code frames,
+ * and a recoverable parsing mode that collects multiple errors while
+ * producing a partial AST.
+ *
+ * @module parser/diagnostics
+ */
+
+import { generateCodeFrame } from "../utils/errors.js";
+import { TokenType } from "./token-types.js";
+import type { Lexer } from "./lexer.js";
+
+/**
+ * Source location with line and column information.
+ */
+export interface SourceLoc {
+  readonly line: number;
+  readonly column: number;
+}
+
+/**
+ * A structured parse error with position, location, and code frame.
+ */
+export interface ParseError {
+  readonly message: string;
+  readonly pos: number;
+  readonly loc: SourceLoc;
+  readonly frame: string;
+}
+
+/**
+ * Compute line and column from a byte offset in a source string.
+ *
+ * Uses an iterative scan of newline characters.
+ *
+ * @param source - The full source text.
+ * @param pos - The byte offset (0-based).
+ * @returns A SourceLoc with 1-based line and 0-based column.
+ */
+export const positionToLineColumn = (
+  source: string,
+  pos: number,
+): SourceLoc => {
+  let line = 1;
+  let lastNewline = -1;
+  for (let i = 0; i < pos && i < source.length; i++) {
+    if (source.charCodeAt(i) === 0x0a) {
+      line++;
+      lastNewline = i;
+    }
+  }
+  const column = pos - lastNewline - 1;
+  return { line, column };
+};
+
+/**
+ * Create a structured SyntaxError with enhanced diagnostics.
+ *
+ * The returned error includes:
+ * - A message with line:column info appended.
+ * - A `pos` property with the byte offset.
+ * - A `loc` property with line/column.
+ * - A `frame` property with a code frame.
+ *
+ * @param message - The base error message.
+ * @param pos - The byte offset in the source where the error occurred.
+ * @param source - The full source text for generating a code frame.
+ * @returns A SyntaxError augmented with diagnostic metadata.
+ */
+export const createParseError = (
+  message: string,
+  pos: number,
+  source: string,
+): SyntaxError & ParseError => {
+  const loc = positionToLineColumn(source, pos);
+  const frame = generateCodeFrame(source, loc.line, loc.column);
+  const fullMessage = `${message} (${loc.line}:${loc.column})`;
+
+  const error = new SyntaxError(fullMessage) as SyntaxError & ParseError;
+  Object.defineProperty(error, "pos", {
+    value: pos,
+    enumerable: true,
+    writable: false,
+    configurable: true,
+  });
+  Object.defineProperty(error, "loc", {
+    value: loc,
+    enumerable: true,
+    writable: false,
+    configurable: true,
+  });
+  Object.defineProperty(error, "frame", {
+    value: frame,
+    enumerable: true,
+    writable: false,
+    configurable: true,
+  });
+
+  return error;
+};
+
+/** Token types that represent statement boundaries for error recovery. */
+const STATEMENT_BOUNDARY_TYPES: ReadonlyArray<number> = Object.freeze([
+  TokenType.Semicolon,
+  TokenType.RightBrace,
+  TokenType.Function,
+  TokenType.Class,
+  TokenType.Const,
+  TokenType.Let,
+  TokenType.Var,
+  TokenType.If,
+  TokenType.For,
+  TokenType.While,
+  TokenType.Do,
+  TokenType.Return,
+  TokenType.Throw,
+  TokenType.Try,
+  TokenType.Switch,
+  TokenType.Import,
+  TokenType.Export,
+]);
+
+/**
+ * Skip tokens in the lexer until a statement boundary is found.
+ *
+ * Used for error recovery: after encountering a parse error, the parser
+ * skips tokens until it finds a likely statement start or delimiter,
+ * then continues parsing from there.
+ *
+ * @param lexer - The lexer instance to advance.
+ */
+export const skipToStatementBoundary = (lexer: Lexer): void => {
+  while (!lexer.is(TokenType.EOF)) {
+    const tokenType = lexer.token.type;
+
+    // If we find a semicolon, consume it and stop
+    if (tokenType === TokenType.Semicolon) {
+      lexer.next();
+      return;
+    }
+
+    // If we find a right brace, stop without consuming (may be block end)
+    if (tokenType === TokenType.RightBrace) {
+      return;
+    }
+
+    // If we hit a keyword that starts a statement, stop without consuming
+    for (let i = 2; i < STATEMENT_BOUNDARY_TYPES.length; i++) {
+      if (tokenType === STATEMENT_BOUNDARY_TYPES[i]) {
+        return;
+      }
+    }
+
+    lexer.next();
+  }
+};
+
+/**
+ * Collector for recoverable parse errors.
+ *
+ * Accumulates errors without throwing, allowing the parser to continue
+ * and report multiple issues from a single parse pass.
+ */
+export class ErrorCollector {
+  /** The list of collected errors. */
+  readonly errors: Array<ParseError> = [];
+
+  /**
+   * Record an error without throwing.
+   *
+   * @param message - The error message.
+   * @param pos - The byte offset.
+   * @param source - The full source text.
+   */
+  addError(message: string, pos: number, source: string): void {
+    const loc = positionToLineColumn(source, pos);
+    const frame = generateCodeFrame(source, loc.line, loc.column);
+    this.errors.push({
+      message: `${message} (${loc.line}:${loc.column})`,
+      pos,
+      loc,
+      frame,
+    });
+  }
+
+  /**
+   * Whether any errors have been collected.
+   */
+  get hasErrors(): boolean {
+    return this.errors.length > 0;
+  }
+}

--- a/src/parser/expressions.ts
+++ b/src/parser/expressions.ts
@@ -47,6 +47,13 @@ import type { ExprContext } from "./function-class-expr.js";
 let parseBlockStatementFn: (lexer: Lexer) => AST.BlockStatement;
 
 /**
+ * Internal reference to the JSX parser function.
+ * Set by `setJSXParser` when JSX is enabled, allowing JSX elements
+ * in expression position.
+ */
+let parseJSXFn: ((lexer: Lexer) => AST.Expression) | null = null;
+
+/**
  * Register the block statement parser function.
  * Called by parser.ts during initialization to break the
  * circular dependency between expressions and statements modules.
@@ -57,6 +64,18 @@ export const setBlockStatementParser = (
   fn: (lexer: Lexer) => AST.BlockStatement,
 ): void => {
   parseBlockStatementFn = fn;
+};
+
+/**
+ * Register the JSX parser function.
+ * Called by parser.ts when JSX mode is enabled.
+ *
+ * @param fn - The JSX parser function, or null to disable.
+ */
+export const setJSXParser = (
+  fn: ((lexer: Lexer) => AST.Expression) | null,
+): void => {
+  parseJSXFn = fn;
 };
 
 /**
@@ -315,6 +334,16 @@ export const parsePrimaryExpression = (lexer: Lexer): AST.Expression => {
 
     case TokenType.Class:
       return parseClassExpr(lexer);
+
+    case TokenType.LessThan: {
+      if (parseJSXFn !== null) {
+        return parseJSXFn(lexer);
+      }
+      const ltName = tokenTypeName(token.type);
+      throw new SyntaxError(
+        `Unexpected token ${ltName} at position ${token.start}`,
+      );
+    }
 
     default: {
       const name = tokenTypeName(token.type);

--- a/src/parser/jsx.ts
+++ b/src/parser/jsx.ts
@@ -1,0 +1,670 @@
+/**
+ * JSX parsing module for the Steamroller parser.
+ *
+ * Handles JSX elements, fragments, attributes, spread attributes,
+ * expression containers, text content, member expressions, and
+ * namespaced names.
+ *
+ * JSX parsing is enabled via the `jsx` option in ParseOptions.
+ * When `<` is encountered in expression position and JSX is enabled,
+ * this module attempts to parse a JSX element or fragment.
+ *
+ * @module parser/jsx
+ */
+
+import type * as AST from "../ast/types.js";
+import type { Lexer } from "./lexer.js";
+import { TokenType } from "./token-types.js";
+
+/**
+ * Context required for JSX parsing, providing access to the lexer
+ * and the expression parser for embedded expressions.
+ */
+export interface JSXParserContext {
+  readonly lexer: Lexer;
+  readonly parseAssignmentExpression: () => AST.Expression;
+}
+
+/**
+ * Check if a character code is valid for a JSX identifier start.
+ * JSX identifiers allow letters, underscore, and dollar sign.
+ *
+ * @param code - The character code to test.
+ * @returns True if valid JSX identifier start.
+ */
+const isJSXIdentStart = (code: number): boolean => {
+  if (code === 0x24 || code === 0x5f) return true; // $ _
+  if (code >= 0x41 && code <= 0x5a) return true; // A-Z
+  if (code >= 0x61 && code <= 0x7a) return true; // a-z
+  if (code >= 0xc0 && code !== 0xd7 && code !== 0xf7) return true;
+  return false;
+};
+
+/**
+ * Check if a character code is valid for JSX identifier continuation.
+ * JSX identifiers additionally allow digits and hyphens.
+ *
+ * @param code - The character code to test.
+ * @returns True if valid JSX identifier part.
+ */
+const isJSXIdentPart = (code: number): boolean => {
+  if (isJSXIdentStart(code)) return true;
+  if (code >= 0x30 && code <= 0x39) return true; // 0-9
+  if (code === 0x2d) return true; // hyphen
+  return false;
+};
+
+/**
+ * Read a JSX identifier name directly from source.
+ * JSX identifiers can contain hyphens unlike JS identifiers.
+ *
+ * @param source - The full source string.
+ * @param startPos - The position to begin reading from.
+ * @returns The identifier name and end position.
+ */
+const readJSXIdentifier = (
+  source: string,
+  startPos: number,
+): { readonly name: string; readonly endPos: number } => {
+  let pos = startPos;
+  if (pos >= source.length || !isJSXIdentStart(source.charCodeAt(pos))) {
+    return { name: "", endPos: pos };
+  }
+  pos++;
+  while (pos < source.length && isJSXIdentPart(source.charCodeAt(pos))) {
+    pos++;
+  }
+  return { name: source.slice(startPos, pos), endPos: pos };
+};
+
+/**
+ * Parse a JSX element or fragment starting at `<`.
+ *
+ * Determines whether this is a fragment (`<>`) or named element (`<Tag`),
+ * then delegates to the appropriate parser.
+ *
+ * @param ctx - The JSX parser context.
+ * @returns The parsed JSXElement or JSXFragment.
+ */
+export const parseJSXElementOrFragment = (
+  ctx: JSXParserContext,
+): AST.JSXElement | AST.JSXFragment => {
+  const lexer = ctx.lexer;
+  const source = lexer.source;
+  const start = lexer.token.start;
+
+  // Consume the `<` token
+  lexer.next();
+
+  // Check for fragment: <>
+  if (lexer.is(TokenType.GreaterThan)) {
+    return parseJSXFragment(ctx, start);
+  }
+
+  // Parse element
+  return parseJSXElement(ctx, start);
+};
+
+/**
+ * Parse a JSX fragment: <>children</>
+ *
+ * Current token should be `>` (the closing of `<>`).
+ *
+ * @param ctx - The JSX parser context.
+ * @param start - The start position of the opening `<`.
+ * @returns The parsed JSXFragment.
+ */
+const parseJSXFragment = (
+  ctx: JSXParserContext,
+  start: number,
+): AST.JSXFragment => {
+  const lexer = ctx.lexer;
+  const openEnd = lexer.token.end;
+
+  const openingFragment: AST.JSXOpeningFragment = Object.freeze({
+    type: "JSXOpeningFragment" as const,
+    start,
+    end: openEnd,
+  });
+
+  // Position right after > for children parsing
+  lexer.setPosition(openEnd);
+
+  // Parse children until we hit `</>`
+  const children = parseJSXChildren(ctx);
+
+  // Parse closing fragment `</>`
+  // We must handle `</` as raw source to avoid regex disambiguation issues
+  const closeStart = lexer.token.start;
+  const source = lexer.source;
+  if (
+    source.charCodeAt(closeStart) !== 0x3c ||
+    source.charCodeAt(closeStart + 1) !== 0x2f
+  ) {
+    throw new SyntaxError(`Expected '</>' at position ${closeStart}`);
+  }
+  // Skip past `</`
+  let closePos = closeStart + 2;
+  // Expect `>`
+  if (source.charCodeAt(closePos) !== 0x3e) {
+    throw new SyntaxError(
+      `Expected '>' in closing fragment at position ${closePos}`,
+    );
+  }
+  closePos++;
+  const closeEnd = closePos;
+  lexer.setPosition(closePos);
+
+  const closingFragment: AST.JSXClosingFragment = Object.freeze({
+    type: "JSXClosingFragment" as const,
+    start: closeStart,
+    end: closeEnd,
+  });
+
+  return Object.freeze({
+    type: "JSXFragment" as const,
+    start,
+    end: closeEnd,
+    openingFragment,
+    closingFragment,
+    children: Object.freeze(children),
+  });
+};
+
+/**
+ * Parse a JSX element: <Tag attrs>children</Tag> or <Tag attrs />
+ *
+ * The `<` has already been consumed. Parses the element name, attributes,
+ * determines if self-closing, and if not, parses children and closing tag.
+ *
+ * @param ctx - The JSX parser context.
+ * @param start - The start position of the opening `<`.
+ * @returns The parsed JSXElement.
+ */
+const parseJSXElement = (
+  ctx: JSXParserContext,
+  start: number,
+): AST.JSXElement => {
+  const lexer = ctx.lexer;
+  const source = lexer.source;
+
+  // Parse element name (identifier, member expression, or namespaced)
+  const name = parseJSXElementName(ctx);
+
+  // Parse attributes
+  const attributes = parseJSXAttributes(ctx);
+
+  // Check for self-closing: />
+  const selfClosing = lexer.is(TokenType.Slash);
+  if (selfClosing) {
+    lexer.next(); // consume /
+  }
+
+  if (!lexer.is(TokenType.GreaterThan)) {
+    throw new SyntaxError(
+      `Expected '>' after JSX opening element at position ${lexer.token.start}`,
+    );
+  }
+  const openEnd = lexer.token.end;
+  // Don't call lexer.next() here - instead use setPosition to control where children start
+
+  const openingElement: AST.JSXOpeningElement = Object.freeze({
+    type: "JSXOpeningElement" as const,
+    start,
+    end: openEnd,
+    name,
+    attributes: Object.freeze(attributes),
+    selfClosing,
+  });
+
+  if (selfClosing) {
+    lexer.next(); // consume > for self-closing
+    return Object.freeze({
+      type: "JSXElement" as const,
+      start,
+      end: openEnd,
+      openingElement,
+      closingElement: null,
+      children: Object.freeze([]),
+    });
+  }
+
+  // For non-self-closing, position right after > for children parsing
+  lexer.setPosition(openEnd);
+
+  // Parse children
+  const children = parseJSXChildren(ctx);
+
+  // Parse closing tag: </Tag>
+  // Handle `</` as raw source to avoid regex disambiguation issues
+  const closeStart = lexer.token.start;
+  const closeSrc = lexer.source;
+  if (
+    closeSrc.charCodeAt(closeStart) !== 0x3c ||
+    closeSrc.charCodeAt(closeStart + 1) !== 0x2f
+  ) {
+    throw new SyntaxError(`Expected closing tag at position ${closeStart}`);
+  }
+  // Skip past `</` and rescan from there
+  lexer.setPosition(closeStart + 2);
+
+  const closingName = parseJSXElementName(ctx);
+  const closeEnd = lexer.token.end;
+
+  if (!lexer.is(TokenType.GreaterThan)) {
+    throw new SyntaxError(
+      `Expected '>' after JSX closing element at position ${lexer.token.start}`,
+    );
+  }
+  lexer.next(); // consume >
+
+  // Validate matching tags
+  const openName = jsxNameToString(name);
+  const closeName = jsxNameToString(closingName);
+  if (openName !== closeName) {
+    throw new SyntaxError(
+      `JSX element tag mismatch: opening <${openName}> but closing </${closeName}> at position ${closeStart}`,
+    );
+  }
+
+  const closingElement: AST.JSXClosingElement = Object.freeze({
+    type: "JSXClosingElement" as const,
+    start: closeStart,
+    end: closeEnd,
+    name: closingName,
+  });
+
+  return Object.freeze({
+    type: "JSXElement" as const,
+    start,
+    end: closeEnd,
+    openingElement,
+    closingElement,
+    children: Object.freeze(children),
+  });
+};
+
+/**
+ * Convert a JSX name node to a string for tag matching.
+ *
+ * @param name - The JSX name node.
+ * @returns The string representation.
+ */
+const jsxNameToString = (
+  name: AST.JSXIdentifier | AST.JSXMemberExpression | AST.JSXNamespacedName,
+): string => {
+  if (name.type === "JSXIdentifier") {
+    return name.name;
+  }
+  if (name.type === "JSXNamespacedName") {
+    return `${name.namespace.name}:${name.name.name}`;
+  }
+  // JSXMemberExpression
+  const parts: Array<string> = [];
+  let current: AST.JSXIdentifier | AST.JSXMemberExpression = name;
+  // Iteratively collect parts from right to left
+  const stack: Array<string> = [];
+  while (current.type === "JSXMemberExpression") {
+    stack.push(current.property.name);
+    current = current.object;
+  }
+  stack.push(current.name);
+  stack.reverse();
+  return stack.join(".");
+};
+
+/**
+ * Parse a JSX element name: identifier, member expression, or namespaced name.
+ *
+ * @param ctx - The JSX parser context.
+ * @returns The parsed name node.
+ */
+const parseJSXElementName = (
+  ctx: JSXParserContext,
+): AST.JSXIdentifier | AST.JSXMemberExpression | AST.JSXNamespacedName => {
+  const lexer = ctx.lexer;
+  const source = lexer.source;
+  const startPos = lexer.token.start;
+
+  // Read initial identifier using raw source scanning
+  const { name, endPos } = readJSXIdentifier(source, startPos);
+  if (name === "") {
+    throw new SyntaxError(`Expected JSX identifier at position ${startPos}`);
+  }
+
+  // Advance lexer past the identifier
+  lexer.setPosition(endPos);
+
+  let result:
+    | AST.JSXIdentifier
+    | AST.JSXMemberExpression
+    | AST.JSXNamespacedName = Object.freeze({
+    type: "JSXIdentifier" as const,
+    start: startPos,
+    end: endPos,
+    name,
+  });
+
+  // Check for namespaced name: ns:tag
+  if (lexer.is(TokenType.Colon)) {
+    const nsIdent = result as AST.JSXIdentifier;
+    lexer.next(); // consume :
+    const nameStart = lexer.token.start;
+    const sub = readJSXIdentifier(source, nameStart);
+    if (sub.name === "") {
+      throw new SyntaxError(
+        `Expected JSX identifier after ':' at position ${nameStart}`,
+      );
+    }
+    lexer.setPosition(sub.endPos);
+    const nameIdent: AST.JSXIdentifier = Object.freeze({
+      type: "JSXIdentifier" as const,
+      start: nameStart,
+      end: sub.endPos,
+      name: sub.name,
+    });
+    return Object.freeze({
+      type: "JSXNamespacedName" as const,
+      start: startPos,
+      end: sub.endPos,
+      namespace: nsIdent,
+      name: nameIdent,
+    });
+  }
+
+  // Check for member expression: Obj.Prop.Sub
+  while (lexer.is(TokenType.Dot)) {
+    lexer.next(); // consume .
+    const propStart = lexer.token.start;
+    const prop = readJSXIdentifier(source, propStart);
+    if (prop.name === "") {
+      throw new SyntaxError(
+        `Expected JSX identifier after '.' at position ${propStart}`,
+      );
+    }
+    lexer.setPosition(prop.endPos);
+    const propIdent: AST.JSXIdentifier = Object.freeze({
+      type: "JSXIdentifier" as const,
+      start: propStart,
+      end: prop.endPos,
+      name: prop.name,
+    });
+    result = Object.freeze({
+      type: "JSXMemberExpression" as const,
+      start: startPos,
+      end: prop.endPos,
+      object: result as AST.JSXIdentifier | AST.JSXMemberExpression,
+      property: propIdent,
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Parse JSX attributes until `>` or `/` is encountered.
+ *
+ * @param ctx - The JSX parser context.
+ * @returns Array of parsed attributes.
+ */
+const parseJSXAttributes = (
+  ctx: JSXParserContext,
+): Array<AST.JSXAttribute | AST.JSXSpreadAttribute> => {
+  const lexer = ctx.lexer;
+  const source = lexer.source;
+  const attrs: Array<AST.JSXAttribute | AST.JSXSpreadAttribute> = [];
+
+  while (
+    !lexer.is(TokenType.GreaterThan) &&
+    !lexer.is(TokenType.Slash) &&
+    !lexer.is(TokenType.EOF)
+  ) {
+    // Spread attribute: {...expr}
+    if (lexer.is(TokenType.LeftBrace)) {
+      const spreadStart = lexer.token.start;
+      lexer.next(); // consume {
+      if (!lexer.is(TokenType.Ellipsis)) {
+        throw new SyntaxError(
+          `Expected '...' in JSX spread attribute at position ${lexer.token.start}`,
+        );
+      }
+      lexer.next(); // consume ...
+      const argument = ctx.parseAssignmentExpression();
+      const spreadEnd = lexer.token.end;
+      if (!lexer.is(TokenType.RightBrace)) {
+        throw new SyntaxError(
+          `Expected '}' after JSX spread attribute at position ${lexer.token.start}`,
+        );
+      }
+      lexer.next(); // consume }
+      attrs.push(
+        Object.freeze({
+          type: "JSXSpreadAttribute" as const,
+          start: spreadStart,
+          end: spreadEnd,
+          argument,
+        }),
+      );
+      continue;
+    }
+
+    // Named attribute: name="value" or name={expr}
+    const attrStart = lexer.token.start;
+    const attrNameResult = readJSXIdentifier(source, attrStart);
+    if (attrNameResult.name === "") {
+      // Not an attribute, break out
+      break;
+    }
+    lexer.setPosition(attrNameResult.endPos);
+
+    let attrName: AST.JSXIdentifier | AST.JSXNamespacedName = Object.freeze({
+      type: "JSXIdentifier" as const,
+      start: attrStart,
+      end: attrNameResult.endPos,
+      name: attrNameResult.name,
+    });
+
+    // Check for namespaced attribute: ns:name
+    if (lexer.is(TokenType.Colon)) {
+      const nsIdent = attrName as AST.JSXIdentifier;
+      lexer.next(); // consume :
+      const subStart = lexer.token.start;
+      const sub = readJSXIdentifier(source, subStart);
+      if (sub.name === "") {
+        throw new SyntaxError(
+          `Expected identifier after ':' in JSX attribute at position ${subStart}`,
+        );
+      }
+      lexer.setPosition(sub.endPos);
+      const subIdent: AST.JSXIdentifier = Object.freeze({
+        type: "JSXIdentifier" as const,
+        start: subStart,
+        end: sub.endPos,
+        name: sub.name,
+      });
+      attrName = Object.freeze({
+        type: "JSXNamespacedName" as const,
+        start: attrStart,
+        end: sub.endPos,
+        namespace: nsIdent,
+        name: subIdent,
+      });
+    }
+
+    // Check for value: = "string" or ={expr}
+    let value:
+      | AST.Literal
+      | AST.JSXExpressionContainer
+      | AST.JSXElement
+      | AST.JSXFragment
+      | null = null;
+    if (lexer.is(TokenType.Equals)) {
+      lexer.next(); // consume =
+
+      if (lexer.is(TokenType.StringLiteral)) {
+        // String value
+        const strToken = lexer.next();
+        value = Object.freeze({
+          type: "Literal" as const,
+          start: strToken.start,
+          end: strToken.end,
+          value: strToken.value as string,
+          raw: strToken.raw,
+        });
+      } else if (lexer.is(TokenType.LeftBrace)) {
+        // Expression container value
+        value = parseJSXExpressionContainer(ctx);
+      } else if (lexer.is(TokenType.LessThan)) {
+        // JSX element as value
+        value = parseJSXElementOrFragment(ctx);
+      } else {
+        throw new SyntaxError(
+          `Expected attribute value at position ${lexer.token.start}`,
+        );
+      }
+    }
+
+    const attrEnd = value !== null ? value.end : attrName.end;
+    attrs.push(
+      Object.freeze({
+        type: "JSXAttribute" as const,
+        start: attrStart,
+        end: attrEnd,
+        name: attrName,
+        value,
+      }),
+    );
+  }
+
+  return attrs;
+};
+
+/**
+ * Parse JSX children between opening and closing tags.
+ *
+ * Children can be: text, {expression}, or nested JSX elements/fragments.
+ * Parsing stops when `</` is encountered.
+ *
+ * This function reads directly from source to handle JSX text content
+ * which is not tokenizable by the normal JS lexer.
+ *
+ * @param ctx - The JSX parser context.
+ * @returns Array of child nodes.
+ */
+const parseJSXChildren = (
+  ctx: JSXParserContext,
+): Array<
+  AST.JSXElement | AST.JSXFragment | AST.JSXExpressionContainer | AST.JSXText
+> => {
+  const lexer = ctx.lexer;
+  const source = lexer.source;
+  const children: Array<
+    AST.JSXElement | AST.JSXFragment | AST.JSXExpressionContainer | AST.JSXText
+  > = [];
+
+  // Use raw source position from the current token as our read cursor
+  let pos = lexer.token.start;
+
+  while (pos < source.length) {
+    const ch = source.charCodeAt(pos);
+
+    // Check for `<` - either closing tag `</` or nested element `<`
+    if (ch === 0x3c) {
+      // Check for closing tag: `</`
+      if (pos + 1 < source.length && source.charCodeAt(pos + 1) === 0x2f) {
+        // Set lexer position so the caller can see we're at `</`
+        lexer.setPosition(pos);
+        break;
+      }
+      // Nested JSX element or fragment
+      lexer.setPosition(pos);
+      children.push(parseJSXElementOrFragment(ctx));
+      pos = lexer.token.start;
+      continue;
+    }
+
+    // Expression container: {expr}
+    if (ch === 0x7b) {
+      lexer.setPosition(pos);
+      children.push(parseJSXExpressionContainer(ctx));
+      pos = lexer.token.start;
+      continue;
+    }
+
+    // JSX text: everything until `<` or `{`
+    const textStart = pos;
+    while (pos < source.length) {
+      const c = source.charCodeAt(pos);
+      if (c === 0x3c || c === 0x7b) break; // < or {
+      pos++;
+    }
+
+    if (pos > textStart) {
+      const raw = source.slice(textStart, pos);
+      children.push(
+        Object.freeze({
+          type: "JSXText" as const,
+          start: textStart,
+          end: pos,
+          value: raw,
+          raw,
+        }),
+      );
+    }
+  }
+
+  // If we're at EOF, set the lexer there
+  if (pos >= source.length) {
+    lexer.setPosition(pos);
+  }
+
+  return children;
+};
+
+/**
+ * Parse a JSX expression container: {expr} or {}
+ *
+ * @param ctx - The JSX parser context.
+ * @returns The parsed JSXExpressionContainer.
+ */
+const parseJSXExpressionContainer = (
+  ctx: JSXParserContext,
+): AST.JSXExpressionContainer => {
+  const lexer = ctx.lexer;
+  const start = lexer.token.start;
+  lexer.next(); // consume {
+
+  // Check for empty expression: {}
+  if (lexer.is(TokenType.RightBrace)) {
+    const end = lexer.token.end;
+    lexer.next(); // consume }
+    const emptyExpr: AST.JSXEmptyExpression = Object.freeze({
+      type: "JSXEmptyExpression" as const,
+      start: start + 1,
+      end: end - 1,
+    });
+    return Object.freeze({
+      type: "JSXExpressionContainer" as const,
+      start,
+      end,
+      expression: emptyExpr,
+    });
+  }
+
+  const expression = ctx.parseAssignmentExpression();
+
+  if (!lexer.is(TokenType.RightBrace)) {
+    throw new SyntaxError(
+      `Expected '}' in JSX expression container at position ${lexer.token.start}`,
+    );
+  }
+  const end = lexer.token.end;
+  lexer.next(); // consume }
+
+  return Object.freeze({
+    type: "JSXExpressionContainer" as const,
+    start,
+    end,
+    expression,
+  });
+};

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -120,7 +120,7 @@ const createEofToken = (pos: number): Token => {
  */
 export class Lexer {
   /** The full source text being lexed. */
-  private source: string;
+  private _source: string;
   /** Current byte offset in source. */
   private pos: number;
   /** The current (most recently scanned) token. */
@@ -148,7 +148,7 @@ export class Lexer {
    * @param allowHashBang - Whether to allow a hashbang (#!) at source start.
    */
   constructor(source: string, strict: boolean, allowHashBang: boolean = false) {
-    this.source = source;
+    this._source = source;
     this.pos = 0;
     this.hadLineTerminator = false;
     this.strict = strict;
@@ -169,6 +169,13 @@ export class Lexer {
 
     // Scan the first token
     this.currentToken = this.scan();
+  }
+
+  /**
+   * Get the full source text being lexed.
+   */
+  get source(): string {
+    return this._source;
   }
 
   /**
@@ -301,6 +308,21 @@ export class Lexer {
   }
 
   /**
+   * Set the lexer position and rescan the current token.
+   *
+   * Used by the JSX parser to advance past raw-scanned identifiers.
+   * Sets previousTokenType to Identifier to ensure `/` is treated as
+   * division (not regex start) in subsequent scans.
+   *
+   * @param newPos - The new byte offset to resume scanning from.
+   */
+  setPosition(newPos: number): void {
+    this.pos = newPos;
+    this.previousTokenType = TokenType.Identifier;
+    this.currentToken = this.scan();
+  }
+
+  /**
    * The main scanning method. Skips whitespace and comments, then
    * dispatches to the appropriate scanner based on the next character.
    *
@@ -312,13 +334,13 @@ export class Lexer {
     this.hadLineTerminator = skipResult;
 
     // Check for EOF
-    if (this.pos >= this.source.length) {
+    if (this.pos >= this._source.length) {
       return createEofToken(this.pos);
     }
 
     // Handle template continuation when inside ${...}
     // When we see a } and templateDepth > 0, we scan the rest of the template
-    const code = this.source.charCodeAt(this.pos);
+    const code = this._source.charCodeAt(this.pos);
 
     // Dispatch based on the first character
     // Identifiers and keywords: a-z, A-Z, _, $, and Unicode
@@ -328,21 +350,21 @@ export class Lexer {
 
     // Numeric literals: 0-9 or . followed by digit
     if (isDigit(code)) {
-      const result = scanNumericLiteral(this.source, this.pos, this.strict);
+      const result = scanNumericLiteral(this._source, this.pos, this.strict);
       this.pos = result.end;
       return result.token;
     }
 
     // String literals: ' or "
     if (code === 0x27 || code === 0x22) {
-      const result = scanStringLiteral(this.source, this.pos, this.strict);
+      const result = scanStringLiteral(this._source, this.pos, this.strict);
       this.pos = result.end;
       return result.token;
     }
 
     // Template literals: `
     if (code === 0x60) {
-      const result = scanTemplateLiteral(this.source, this.pos, true);
+      const result = scanTemplateLiteral(this._source, this.pos, true);
       this.pos = result.end;
       // If we got a TemplateHead, increment template depth
       if (result.token.type === TokenType.TemplateHead) {
@@ -354,11 +376,11 @@ export class Lexer {
     // Dot followed by digit is a numeric literal (.5)
     if (code === 0x2e) {
       const nextCode =
-        this.pos + 1 < this.source.length
-          ? this.source.charCodeAt(this.pos + 1)
+        this.pos + 1 < this._source.length
+          ? this._source.charCodeAt(this.pos + 1)
           : -1;
       if (isDigit(nextCode)) {
-        const result = scanNumericLiteral(this.source, this.pos, this.strict);
+        const result = scanNumericLiteral(this._source, this.pos, this.strict);
         this.pos = result.end;
         return result.token;
       }
@@ -368,7 +390,7 @@ export class Lexer {
     if (code === 0x2f) {
       // Check if this is a regex
       if (isRegExpStart(this.previousTokenType)) {
-        const result = scanRegExpLiteral(this.source, this.pos);
+        const result = scanRegExpLiteral(this._source, this.pos);
         this.pos = result.end;
         return result.token;
       }
@@ -378,7 +400,7 @@ export class Lexer {
     // Right brace inside template: continue scanning the template
     if (code === 0x7d && this.templateDepth > 0) {
       this.templateDepth--;
-      const result = scanTemplateLiteral(this.source, this.pos, false);
+      const result = scanTemplateLiteral(this._source, this.pos, false);
       this.pos = result.end;
       // If we got a TemplateMiddle, increment depth back
       if (result.token.type === TokenType.TemplateMiddle) {
@@ -388,7 +410,7 @@ export class Lexer {
     }
 
     // Punctuators and operators
-    const punctResult = scanPunctuator(this.source, this.pos);
+    const punctResult = scanPunctuator(this._source, this.pos);
     if (punctResult !== null) {
       this.pos = punctResult.end;
       return punctResult.token;
@@ -396,7 +418,7 @@ export class Lexer {
 
     // Unknown character
     throw new SyntaxError(
-      `Unexpected character '${this.source[this.pos]}' at position ${this.pos}`,
+      `Unexpected character '${this._source[this.pos]}' at position ${this.pos}`,
     );
   }
 
@@ -411,8 +433,8 @@ export class Lexer {
     const start = this.pos;
     this.pos++;
 
-    while (this.pos < this.source.length) {
-      const code = this.source.charCodeAt(this.pos);
+    while (this.pos < this._source.length) {
+      const code = this._source.charCodeAt(this.pos);
       if (isIdentifierPart(code)) {
         this.pos++;
       } else {
@@ -420,7 +442,7 @@ export class Lexer {
       }
     }
 
-    const raw = this.source.slice(start, this.pos);
+    const raw = this._source.slice(start, this.pos);
     const keywordInfo = lookupKeyword(raw);
 
     if (keywordInfo !== undefined) {
@@ -461,33 +483,33 @@ export class Lexer {
   private skipWhitespaceAndComments(): boolean {
     let hadLT = false;
 
-    while (this.pos < this.source.length) {
+    while (this.pos < this._source.length) {
       // Skip whitespace (including line terminators)
-      const wsResult = skipWhitespace(this.source, this.pos);
+      const wsResult = skipWhitespace(this._source, this.pos);
       if (wsResult.hadLineTerminator) {
         hadLT = true;
       }
       this.pos = wsResult.end;
 
       // Check if at a comment
-      if (this.pos >= this.source.length) {
+      if (this.pos >= this._source.length) {
         break;
       }
 
-      const c0 = this.source.charCodeAt(this.pos);
+      const c0 = this._source.charCodeAt(this.pos);
       if (c0 !== 0x2f) {
         // Not a slash, done skipping
         break;
       }
 
       const c1 =
-        this.pos + 1 < this.source.length
-          ? this.source.charCodeAt(this.pos + 1)
+        this.pos + 1 < this._source.length
+          ? this._source.charCodeAt(this.pos + 1)
           : -1;
 
       if (c1 === 0x2f) {
         // Line comment //
-        const result = scanLineComment(this.source, this.pos);
+        const result = scanLineComment(this._source, this.pos);
         this.pos = result.end;
         // The line terminator after the comment will be caught by the next
         // whitespace skip iteration
@@ -496,7 +518,7 @@ export class Lexer {
 
       if (c1 === 0x2a) {
         // Block comment /* */
-        const result = scanBlockComment(this.source, this.pos);
+        const result = scanBlockComment(this._source, this.pos);
         if (result.hadLineTerminator) {
           hadLT = true;
         }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -24,7 +24,10 @@ import {
   parseExpression as parseExpressionModule,
   parseAssignmentExpression as parseAssignmentExpressionModule,
   setBlockStatementParser,
+  setJSXParser,
 } from "./expressions.js";
+import { parseJSXElementOrFragment } from "./jsx.js";
+import type { JSXParserContext } from "./jsx.js";
 import {
   parseBlockStatement as parseBlockStmt,
   parseEmptyStatement,
@@ -45,6 +48,12 @@ import {
   parseExpressionStatement,
 } from "./statements.js";
 import type { ParserContext as StatementsContext } from "./statements.js";
+import {
+  createParseError,
+  skipToStatementBoundary,
+  ErrorCollector,
+} from "./diagnostics.js";
+import type { ParseError } from "./diagnostics.js";
 
 /**
  * Options for the parser.
@@ -56,6 +65,18 @@ export interface ParseOptions {
   readonly allowHashBang?: boolean;
   /** The ECMAScript version to target. Defaults to 2024. */
   readonly ecmaVersion?: number;
+  /** Whether to enable JSX syntax parsing. Defaults to false. */
+  readonly jsx?: boolean;
+  /** Whether to collect errors instead of throwing. Defaults to false. */
+  readonly recoverable?: boolean;
+}
+
+/**
+ * Result of a recoverable parse operation.
+ */
+export interface RecoverableParseResult {
+  readonly program: AST.Program;
+  readonly errors: ReadonlyArray<ParseError>;
 }
 
 /**
@@ -71,6 +92,14 @@ export class Parser implements DeclarationsContext, StatementsContext {
   sourceType: "module" | "script";
   /** Whether `in` operator is allowed in expressions (false in for-loop headers). */
   allowIn: boolean;
+  /** Whether JSX parsing is enabled. */
+  readonly jsxEnabled: boolean;
+  /** Whether recoverable mode is active. */
+  readonly recoverable: boolean;
+  /** The original source text for error diagnostics. */
+  readonly source: string;
+  /** Collected errors in recoverable mode. */
+  readonly errorCollector: ErrorCollector;
 
   /**
    * Create a new Parser for the given source text.
@@ -84,12 +113,29 @@ export class Parser implements DeclarationsContext, StatementsContext {
     const isStrict = sourceType === "module";
 
     this.sourceType = sourceType;
+    this.source = source;
     this.lexer = new Lexer(source, isStrict, allowHashBang);
     this.allowIn = true;
+    this.jsxEnabled = options?.jsx ?? false;
+    this.recoverable = options?.recoverable ?? false;
+    this.errorCollector = new ErrorCollector();
 
     // Register block statement parser for function/class expression bodies.
     // The lexer parameter is ignored since this parser instance owns the lexer.
     setBlockStatementParser((_lex: Lexer) => this.parseBlockStatement());
+
+    // Register JSX parser when enabled
+    if (this.jsxEnabled) {
+      setJSXParser((_lex: Lexer) => {
+        const jsxCtx: JSXParserContext = {
+          lexer: this.lexer,
+          parseAssignmentExpression: () => this.parseAssignmentExpression(),
+        };
+        return parseJSXElementOrFragment(jsxCtx) as unknown as AST.Expression;
+      });
+    } else {
+      setJSXParser(null);
+    }
   }
 
   /**
@@ -147,7 +193,8 @@ export class Parser implements DeclarationsContext, StatementsContext {
    * Parse the complete program.
    *
    * Iteratively parses statements and declarations until EOF is reached,
-   * producing a Program AST node.
+   * producing a Program AST node. In recoverable mode, catches parse errors
+   * and skips to the next statement boundary.
    *
    * @returns The root Program AST node.
    */
@@ -157,8 +204,26 @@ export class Parser implements DeclarationsContext, StatementsContext {
 
     // Parse statements/declarations until EOF
     while (!this.lexer.is(TokenType.EOF)) {
-      const stmt = this.parseStatement();
-      body.push(stmt);
+      if (this.recoverable) {
+        try {
+          const stmt = this.parseStatement();
+          body.push(stmt);
+        } catch (err: unknown) {
+          if (err instanceof SyntaxError) {
+            this.errorCollector.addError(
+              err.message,
+              this.lexer.token.start,
+              this.source,
+            );
+            skipToStatementBoundary(this.lexer);
+          } else {
+            throw err;
+          }
+        }
+      } else {
+        const stmt = this.parseStatement();
+        body.push(stmt);
+      }
     }
 
     const end = this.lexer.token.end;
@@ -351,4 +416,23 @@ export class Parser implements DeclarationsContext, StatementsContext {
 export const parse = (source: string, options?: ParseOptions): AST.Program => {
   const parser = new Parser(source, options);
   return parser.parseProgram();
+};
+
+/**
+ * Parse source text in recoverable mode, collecting errors.
+ *
+ * Returns a partial AST alongside all collected parse errors.
+ * Non-recoverable errors (e.g., non-SyntaxError) will still throw.
+ *
+ * @param source - The source text to parse.
+ * @param options - Optional parse configuration (recoverable is forced true).
+ * @returns A result containing the partial program and array of errors.
+ */
+export const parseRecoverable = (
+  source: string,
+  options?: ParseOptions,
+): RecoverableParseResult => {
+  const parser = new Parser(source, { ...options, recoverable: true });
+  const program = parser.parseProgram();
+  return { program, errors: Object.freeze([...parser.errorCollector.errors]) };
 };

--- a/tests/unit/parser/diagnostics.test.ts
+++ b/tests/unit/parser/diagnostics.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for error recovery and diagnostics module.
+ *
+ * @module tests/unit/parser/diagnostics
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createParseError,
+  positionToLineColumn,
+  skipToStatementBoundary,
+  ErrorCollector,
+} from "../../../src/parser/diagnostics.js";
+import type { ParseError } from "../../../src/parser/diagnostics.js";
+import { parse, parseRecoverable } from "../../../src/parser/parser.js";
+import type { RecoverableParseResult } from "../../../src/parser/parser.js";
+import { Lexer } from "../../../src/parser/lexer.js";
+import { TokenType } from "../../../src/parser/token-types.js";
+
+describe("Diagnostics", () => {
+  describe("positionToLineColumn", () => {
+    it("returns line 1, column 0 for position 0", () => {
+      const loc = positionToLineColumn("hello", 0);
+      expect(loc.line).toBe(1);
+      expect(loc.column).toBe(0);
+    });
+
+    it("computes correct line for multiline source", () => {
+      const source = "abc\ndef\nghi";
+      const loc = positionToLineColumn(source, 4); // 'd' on line 2
+      expect(loc.line).toBe(2);
+      expect(loc.column).toBe(0);
+    });
+
+    it("computes correct column on second line", () => {
+      const source = "abc\ndef\nghi";
+      const loc = positionToLineColumn(source, 6); // 'f' on line 2, col 2
+      expect(loc.line).toBe(2);
+      expect(loc.column).toBe(2);
+    });
+
+    it("handles third line", () => {
+      const source = "abc\ndef\nghi";
+      const loc = positionToLineColumn(source, 8); // 'g' on line 3
+      expect(loc.line).toBe(3);
+      expect(loc.column).toBe(0);
+    });
+
+    it("handles position at end of source", () => {
+      const source = "abc";
+      const loc = positionToLineColumn(source, 3);
+      expect(loc.line).toBe(1);
+      expect(loc.column).toBe(3);
+    });
+  });
+
+  describe("createParseError", () => {
+    it("creates error with position and location", () => {
+      const source = "const x = ;";
+      const error = createParseError("Unexpected token", 10, source);
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error.pos).toBe(10);
+      expect(error.loc.line).toBe(1);
+      expect(error.loc.column).toBe(10);
+    });
+
+    it("includes line and column in message", () => {
+      const source = "abc\ndef";
+      const error = createParseError("Bad token", 5, source);
+      expect(error.message).toContain("(2:1)");
+    });
+
+    it("includes a code frame", () => {
+      const source = "const x = ;\nconst y = 2;";
+      const error = createParseError("Unexpected", 10, source);
+      expect(error.frame).toContain("|");
+      expect(error.frame).toContain("^");
+    });
+
+    it("frame shows the error line with marker", () => {
+      const source = "line1\nline2\nline3";
+      const error = createParseError("Error here", 6, source);
+      // position 6 is 'l' on line 2, col 0
+      expect(error.frame).toContain(">");
+      expect(error.frame).toContain("^");
+    });
+
+    it("provides correct loc for first character", () => {
+      const error = createParseError("Start", 0, "hello");
+      expect(error.loc.line).toBe(1);
+      expect(error.loc.column).toBe(0);
+    });
+  });
+
+  describe("skipToStatementBoundary", () => {
+    it("skips to semicolon and consumes it", () => {
+      const lexer = new Lexer("bad stuff ; good", true);
+      skipToStatementBoundary(lexer);
+      // After skipping, should be at 'good'
+      expect(lexer.token.type).toBe(TokenType.Identifier);
+    });
+
+    it("skips to right brace without consuming it", () => {
+      const lexer = new Lexer("bad stuff }", true);
+      skipToStatementBoundary(lexer);
+      expect(lexer.token.type).toBe(TokenType.RightBrace);
+    });
+
+    it("skips to keyword that starts a statement", () => {
+      const lexer = new Lexer("bad stuff const x = 1", true);
+      skipToStatementBoundary(lexer);
+      expect(lexer.token.type).toBe(TokenType.Const);
+    });
+
+    it("stops at EOF if no boundary found", () => {
+      const lexer = new Lexer("x y z", true);
+      skipToStatementBoundary(lexer);
+      expect(lexer.token.type).toBe(TokenType.EOF);
+    });
+
+    it("skips to if keyword", () => {
+      const lexer = new Lexer("bad if (true) {}", true);
+      skipToStatementBoundary(lexer);
+      expect(lexer.token.type).toBe(TokenType.If);
+    });
+  });
+
+  describe("ErrorCollector", () => {
+    it("starts with no errors", () => {
+      const collector = new ErrorCollector();
+      expect(collector.hasErrors).toBe(false);
+      expect(collector.errors.length).toBe(0);
+    });
+
+    it("collects errors", () => {
+      const collector = new ErrorCollector();
+      collector.addError("first error", 0, "source");
+      collector.addError("second error", 5, "source");
+      expect(collector.hasErrors).toBe(true);
+      expect(collector.errors.length).toBe(2);
+    });
+
+    it("errors include position and location", () => {
+      const collector = new ErrorCollector();
+      collector.addError("test", 4, "abc\ndef");
+      const err = collector.errors[0];
+      expect(err.pos).toBe(4);
+      expect(err.loc.line).toBe(2);
+      expect(err.loc.column).toBe(0);
+    });
+
+    it("errors include code frame", () => {
+      const collector = new ErrorCollector();
+      collector.addError("test", 0, "const x = 1;");
+      expect(collector.errors[0].frame).toContain("^");
+    });
+  });
+
+  describe("recoverable mode via parseRecoverable", () => {
+    it("collects multiple errors and produces partial AST", () => {
+      // Two bad statements with a good one in between
+      const source = "const x = ;\nconst y = 2;\nconst z = ;";
+      const result: RecoverableParseResult = parseRecoverable(source);
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Should have at least the valid statement in the AST
+      expect(result.program.body.length).toBeGreaterThan(0);
+      expect(result.program.type).toBe("Program");
+    });
+
+    it("produces complete AST when no errors", () => {
+      const source = "const x = 1;\nconst y = 2;";
+      const result = parseRecoverable(source);
+      expect(result.errors.length).toBe(0);
+      expect(result.program.body.length).toBe(2);
+    });
+
+    it("still produces partial AST with errors", () => {
+      const source = "const a = 1;\n@@@\nconst b = 2;";
+      const result = parseRecoverable(source);
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Should contain at least one valid declaration
+      const validStmts = result.program.body.filter(
+        (s) => s.type === "VariableDeclaration",
+      );
+      expect(validStmts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("error messages include location info", () => {
+      const source = "const x = ;";
+      const result = parseRecoverable(source);
+      expect(result.errors.length).toBeGreaterThan(0);
+      const err = result.errors[0];
+      expect(err.loc.line).toBeGreaterThanOrEqual(1);
+      expect(err.loc.column).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("non-recoverable mode (default)", () => {
+    it("throws on first error by default", () => {
+      const source = "const x = ;";
+      expect(() => parse(source)).toThrow(SyntaxError);
+    });
+
+    it("throws immediately without collecting errors", () => {
+      const source = "const x = ;\nconst y = ;";
+      expect(() => parse(source)).toThrow(SyntaxError);
+    });
+  });
+
+  describe("integration with createParseError", () => {
+    it("error is throwable as SyntaxError", () => {
+      const error = createParseError("test", 0, "code");
+      expect(() => {
+        throw error;
+      }).toThrow(SyntaxError);
+    });
+
+    it("error has all expected properties", () => {
+      const error = createParseError("bad token", 5, "hello\nworld");
+      expect(typeof error.pos).toBe("number");
+      expect(typeof error.loc).toBe("object");
+      expect(typeof error.loc.line).toBe("number");
+      expect(typeof error.loc.column).toBe("number");
+      expect(typeof error.frame).toBe("string");
+      expect(error.message).toContain("bad token");
+    });
+  });
+});

--- a/tests/unit/parser/jsx.test.ts
+++ b/tests/unit/parser/jsx.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Unit tests for JSX parsing module.
+ *
+ * @module tests/unit/parser/jsx
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../../src/parser/parser.js";
+import type * as AST from "../../../src/ast/types.js";
+
+/**
+ * Helper to parse JSX expression statements.
+ */
+const parseJSX = (code: string): AST.Expression => {
+  const program = parse(code, { jsx: true });
+  const stmt = program.body[0] as AST.ExpressionStatement;
+  return stmt.expression;
+};
+
+describe("JSX Parser", () => {
+  describe("self-closing elements", () => {
+    it("parses a simple self-closing tag", () => {
+      const expr = parseJSX("<Foo />;") as unknown as AST.JSXElement;
+      expect(expr.type).toBe("JSXElement");
+      expect(expr.openingElement.selfClosing).toBe(true);
+      expect(expr.closingElement).toBeNull();
+      const name = expr.openingElement.name as AST.JSXIdentifier;
+      expect(name.type).toBe("JSXIdentifier");
+      expect(name.name).toBe("Foo");
+    });
+
+    it("parses a self-closing tag with no space before /", () => {
+      const expr = parseJSX("<Bar/>;") as unknown as AST.JSXElement;
+      expect(expr.type).toBe("JSXElement");
+      expect(expr.openingElement.selfClosing).toBe(true);
+      const name = expr.openingElement.name as AST.JSXIdentifier;
+      expect(name.name).toBe("Bar");
+    });
+
+    it("parses a lowercase self-closing tag", () => {
+      const expr = parseJSX("<div />;") as unknown as AST.JSXElement;
+      expect(expr.type).toBe("JSXElement");
+      const name = expr.openingElement.name as AST.JSXIdentifier;
+      expect(name.name).toBe("div");
+    });
+
+    it("parses a tag with hyphens in the name", () => {
+      const expr = parseJSX("<my-component />;") as unknown as AST.JSXElement;
+      const name = expr.openingElement.name as AST.JSXIdentifier;
+      expect(name.name).toBe("my-component");
+    });
+  });
+
+  describe("elements with children", () => {
+    it("parses element with text children", () => {
+      const expr = parseJSX("<div>text</div>;") as unknown as AST.JSXElement;
+      expect(expr.type).toBe("JSXElement");
+      expect(expr.openingElement.selfClosing).toBe(false);
+      expect(expr.closingElement).not.toBeNull();
+      expect(expr.children.length).toBe(1);
+      const text = expr.children[0] as AST.JSXText;
+      expect(text.type).toBe("JSXText");
+      expect(text.value).toBe("text");
+    });
+
+    it("parses element with multiple text segments and expressions", () => {
+      const expr = parseJSX(
+        "<p>hello {name} world</p>;",
+      ) as unknown as AST.JSXElement;
+      expect(expr.children.length).toBe(3);
+      expect((expr.children[0] as AST.JSXText).type).toBe("JSXText");
+      expect((expr.children[1] as AST.JSXExpressionContainer).type).toBe(
+        "JSXExpressionContainer",
+      );
+      expect((expr.children[2] as AST.JSXText).type).toBe("JSXText");
+    });
+  });
+
+  describe("fragments", () => {
+    it("parses empty fragment", () => {
+      const expr = parseJSX("<></>;") as unknown as AST.JSXFragment;
+      expect(expr.type).toBe("JSXFragment");
+      expect(expr.children.length).toBe(0);
+    });
+
+    it("parses fragment with content", () => {
+      const expr = parseJSX("<>content</>;") as unknown as AST.JSXFragment;
+      expect(expr.type).toBe("JSXFragment");
+      expect(expr.children.length).toBe(1);
+      const text = expr.children[0] as AST.JSXText;
+      expect(text.value).toBe("content");
+    });
+
+    it("parses fragment with nested elements", () => {
+      const expr = parseJSX(
+        "<><span /><div /></>;",
+      ) as unknown as AST.JSXFragment;
+      expect(expr.type).toBe("JSXFragment");
+      expect(expr.children.length).toBe(2);
+    });
+  });
+
+  describe("attributes", () => {
+    it("parses string attribute", () => {
+      const expr = parseJSX('<Foo a="1" />;') as unknown as AST.JSXElement;
+      const attrs = expr.openingElement.attributes;
+      expect(attrs.length).toBe(1);
+      const attr = attrs[0] as AST.JSXAttribute;
+      expect(attr.type).toBe("JSXAttribute");
+      const attrName = attr.name as AST.JSXIdentifier;
+      expect(attrName.name).toBe("a");
+      const val = attr.value as AST.Literal;
+      expect(val.type).toBe("Literal");
+      expect(val.value).toBe("1");
+    });
+
+    it("parses expression attribute", () => {
+      const expr = parseJSX("<Foo b={2} />;") as unknown as AST.JSXElement;
+      const attrs = expr.openingElement.attributes;
+      expect(attrs.length).toBe(1);
+      const attr = attrs[0] as AST.JSXAttribute;
+      const val = attr.value as AST.JSXExpressionContainer;
+      expect(val.type).toBe("JSXExpressionContainer");
+    });
+
+    it("parses multiple attributes", () => {
+      const expr = parseJSX(
+        '<Foo a="1" b={2} />;',
+      ) as unknown as AST.JSXElement;
+      const attrs = expr.openingElement.attributes;
+      expect(attrs.length).toBe(2);
+    });
+
+    it("parses boolean attribute (no value)", () => {
+      const expr = parseJSX("<Foo disabled />;") as unknown as AST.JSXElement;
+      const attrs = expr.openingElement.attributes;
+      expect(attrs.length).toBe(1);
+      const attr = attrs[0] as AST.JSXAttribute;
+      expect(attr.value).toBeNull();
+    });
+  });
+
+  describe("spread attributes", () => {
+    it("parses spread attribute", () => {
+      const expr = parseJSX("<Foo {...props} />;") as unknown as AST.JSXElement;
+      const attrs = expr.openingElement.attributes;
+      expect(attrs.length).toBe(1);
+      const spread = attrs[0] as AST.JSXSpreadAttribute;
+      expect(spread.type).toBe("JSXSpreadAttribute");
+      expect(spread.argument.type).toBe("Identifier");
+    });
+
+    it("parses spread alongside named attributes", () => {
+      const expr = parseJSX(
+        '<Foo a="x" {...props} b={1} />;',
+      ) as unknown as AST.JSXElement;
+      const attrs = expr.openingElement.attributes;
+      expect(attrs.length).toBe(3);
+      expect(attrs[0].type).toBe("JSXAttribute");
+      expect(attrs[1].type).toBe("JSXSpreadAttribute");
+      expect(attrs[2].type).toBe("JSXAttribute");
+    });
+  });
+
+  describe("expression containers", () => {
+    it("parses expression in children", () => {
+      const expr = parseJSX("<div>{x}</div>;") as unknown as AST.JSXElement;
+      expect(expr.children.length).toBe(1);
+      const container = expr.children[0] as AST.JSXExpressionContainer;
+      expect(container.type).toBe("JSXExpressionContainer");
+      const inner = container.expression as AST.Identifier;
+      expect(inner.type).toBe("Identifier");
+      expect(inner.name).toBe("x");
+    });
+
+    it("parses empty expression container", () => {
+      const expr = parseJSX("<div>{}</div>;") as unknown as AST.JSXElement;
+      const container = expr.children[0] as AST.JSXExpressionContainer;
+      expect(container.expression.type).toBe("JSXEmptyExpression");
+    });
+
+    it("parses complex expression in container", () => {
+      const expr = parseJSX("<div>{a + b}</div>;") as unknown as AST.JSXElement;
+      const container = expr.children[0] as AST.JSXExpressionContainer;
+      expect(container.expression.type).toBe("BinaryExpression");
+    });
+  });
+
+  describe("member expression tags", () => {
+    it("parses simple member expression tag", () => {
+      const expr = parseJSX("<Foo.Bar />;") as unknown as AST.JSXElement;
+      const name = expr.openingElement.name as AST.JSXMemberExpression;
+      expect(name.type).toBe("JSXMemberExpression");
+      const obj = name.object as AST.JSXIdentifier;
+      expect(obj.name).toBe("Foo");
+      expect(name.property.name).toBe("Bar");
+    });
+
+    it("parses nested member expression tag", () => {
+      const expr = parseJSX("<A.B.C />;") as unknown as AST.JSXElement;
+      const name = expr.openingElement.name as AST.JSXMemberExpression;
+      expect(name.type).toBe("JSXMemberExpression");
+      expect(name.property.name).toBe("C");
+      const inner = name.object as AST.JSXMemberExpression;
+      expect(inner.type).toBe("JSXMemberExpression");
+      expect(inner.property.name).toBe("B");
+      const obj = inner.object as AST.JSXIdentifier;
+      expect(obj.name).toBe("A");
+    });
+  });
+
+  describe("namespaced names", () => {
+    it("parses namespaced tag name", () => {
+      const expr = parseJSX("<ns:tag />;") as unknown as AST.JSXElement;
+      const name = expr.openingElement.name as AST.JSXNamespacedName;
+      expect(name.type).toBe("JSXNamespacedName");
+      expect(name.namespace.name).toBe("ns");
+      expect(name.name.name).toBe("tag");
+    });
+
+    it("parses namespaced attribute name", () => {
+      const expr = parseJSX(
+        '<div xml:lang="en" />;',
+      ) as unknown as AST.JSXElement;
+      const attr = expr.openingElement.attributes[0] as AST.JSXAttribute;
+      const attrName = attr.name as AST.JSXNamespacedName;
+      expect(attrName.type).toBe("JSXNamespacedName");
+      expect(attrName.namespace.name).toBe("xml");
+      expect(attrName.name.name).toBe("lang");
+    });
+  });
+
+  describe("nested JSX", () => {
+    it("parses nested elements", () => {
+      const expr = parseJSX(
+        "<div><span /></div>;",
+      ) as unknown as AST.JSXElement;
+      expect(expr.children.length).toBe(1);
+      const child = expr.children[0] as unknown as AST.JSXElement;
+      expect(child.type).toBe("JSXElement");
+      const childName = child.openingElement.name as AST.JSXIdentifier;
+      expect(childName.name).toBe("span");
+    });
+
+    it("parses deeply nested elements", () => {
+      const expr = parseJSX(
+        "<a><b><c /></b></a>;",
+      ) as unknown as AST.JSXElement;
+      const b = expr.children[0] as unknown as AST.JSXElement;
+      expect(b.type).toBe("JSXElement");
+      const c = b.children[0] as unknown as AST.JSXElement;
+      expect(c.type).toBe("JSXElement");
+      expect(c.openingElement.selfClosing).toBe(true);
+    });
+
+    it("parses multiple children elements", () => {
+      const expr = parseJSX(
+        "<div><a /><b /><c /></div>;",
+      ) as unknown as AST.JSXElement;
+      expect(expr.children.length).toBe(3);
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws on unclosed tag", () => {
+      expect(() => parseJSX("<div>;")).toThrow();
+    });
+
+    it("throws on mismatched tags", () => {
+      expect(() => parseJSX("<div></span>;")).toThrow(/mismatch/);
+    });
+
+    it("throws on missing identifier after dot", () => {
+      expect(() => parseJSX("<Foo. />;")).toThrow();
+    });
+
+    it("throws on missing expression in spread", () => {
+      expect(() => parseJSX("<Foo {abc} />;")).toThrow();
+    });
+  });
+
+  describe("JSX disabled", () => {
+    it("throws when JSX is not enabled and < encountered in expression", () => {
+      expect(() => parse("<div />;", { jsx: false })).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **JSX parsing** (`src/parser/jsx.ts`): Full JSX syntax support including elements, fragments, self-closing tags, attributes (string, expression, spread), expression containers, text content, member expression tags (`<Foo.Bar />`), and namespaced names (`<ns:tag />`). Enabled via `jsx: true` in ParseOptions.
- **Error recovery/diagnostics** (`src/parser/diagnostics.ts`): `createParseError` produces SyntaxErrors with byte offset, line/column location, and code frames. `parseRecoverable` collects multiple errors while producing a partial AST. `skipToStatementBoundary` enables error recovery by advancing past malformed statements.
- **Lexer enhancements** (`src/parser/lexer.ts`): Added `source` getter and `setPosition` method for raw source scanning needed by JSX text/closing tag parsing.

Closes #47
Closes #63

## Test plan
- [x] 30 JSX tests: self-closing, children, fragments, attributes, spread, expressions, member tags, namespaced names, nested elements, error cases
- [x] 27 diagnostics tests: position-to-line/column, createParseError, skipToStatementBoundary, ErrorCollector, recoverable mode, non-recoverable mode
- [x] All 2497 existing tests pass
- [x] TypeScript strict mode: clean typecheck
- [x] Prettier: all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)