### PR TITLE
feat: implement RollupFsModule filesystem abstraction

### DIFF
--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @module fs
+ * @description Filesystem abstraction layer for steamroller.
+ * Re-exports types and the default Node.js adapter.
+ */
+
+export type { FsDirectoryEntry, FsModule, FsStats } from "./types.js";
+export { createNodeFs } from "./node-fs.js";

--- a/src/fs/node-fs.ts
+++ b/src/fs/node-fs.ts
@@ -1,0 +1,32 @@
+/**
+ * @module fs/node-fs
+ * @description Default Node.js filesystem adapter implementing the FsModule
+ * interface. Wraps `node:fs/promises` operations for use by the bundler.
+ */
+
+import { readFile, readdir, realpath, stat as fsStat } from "node:fs/promises";
+import type { FsModule, FsStats } from "./types.js";
+
+/**
+ * Creates a filesystem module backed by Node.js `fs/promises`.
+ * This is the default adapter used when no custom filesystem is provided.
+ *
+ * @returns A complete FsModule implementation using the real filesystem.
+ */
+export const createNodeFs = (): FsModule => ({
+  readFile: (path: string, encoding: "utf-8"): Promise<string> =>
+    readFile(path, { encoding }),
+
+  readdir: (path: string): Promise<ReadonlyArray<string>> => readdir(path),
+
+  realpath: (path: string): Promise<string> => realpath(path),
+
+  stat: async (path: string): Promise<FsStats> => {
+    const stats = await fsStat(path);
+    return {
+      isDirectory: (): boolean => stats.isDirectory(),
+      isFile: (): boolean => stats.isFile(),
+      isSymbolicLink: (): boolean => stats.isSymbolicLink(),
+    };
+  },
+});

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -1,0 +1,39 @@
+/**
+ * @module fs/types
+ * @description Filesystem abstraction types for steamroller.
+ * Provides interfaces for virtual filesystem operations that can be
+ * overridden by plugins for custom file access patterns.
+ */
+
+/**
+ * File stat information returned by the filesystem abstraction.
+ * Mirrors the subset of node:fs Stats used by the bundler.
+ */
+export interface FsStats {
+  readonly isDirectory: () => boolean;
+  readonly isFile: () => boolean;
+  readonly isSymbolicLink: () => boolean;
+}
+
+/**
+ * Directory entry returned when listing directory contents.
+ * Provides both the entry name and type-checking methods.
+ */
+export interface FsDirectoryEntry {
+  readonly isDirectory: () => boolean;
+  readonly isFile: () => boolean;
+  readonly name: string;
+}
+
+/**
+ * Virtual filesystem module interface for custom file access.
+ * Provides the minimal set of filesystem operations needed by the bundler.
+ * Only `readFile` is required; all other methods are optional and will
+ * fall back to defaults if not provided.
+ */
+export interface FsModule {
+  readonly readFile: (path: string, encoding: "utf-8") => Promise<string>;
+  readonly readdir?: (path: string) => Promise<ReadonlyArray<string>>;
+  readonly realpath?: (path: string) => Promise<string>;
+  readonly stat?: (path: string) => Promise<FsStats>;
+}

--- a/tests/unit/fs/index.test.ts
+++ b/tests/unit/fs/index.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @module tests/unit/fs/index
+ * @description Tests for the fs module barrel export.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createNodeFs } from "../../../src/fs/index.js";
+import type {
+  FsDirectoryEntry,
+  FsModule,
+  FsStats,
+} from "../../../src/fs/index.js";
+
+describe("fs/index", () => {
+  it("should export createNodeFs function", () => {
+    expect(createNodeFs).toBeTypeOf("function");
+  });
+
+  it("should return a valid FsModule from createNodeFs", () => {
+    const fs: FsModule = createNodeFs();
+
+    expect(fs.readFile).toBeTypeOf("function");
+    expect(fs.readdir).toBeTypeOf("function");
+    expect(fs.realpath).toBeTypeOf("function");
+    expect(fs.stat).toBeTypeOf("function");
+  });
+
+  it("should export FsStats type that is assignable", () => {
+    const stats: FsStats = {
+      isDirectory: () => false,
+      isFile: () => true,
+      isSymbolicLink: () => false,
+    };
+
+    expect(stats.isFile()).toBe(true);
+  });
+
+  it("should export FsDirectoryEntry type that is assignable", () => {
+    const entry: FsDirectoryEntry = {
+      isDirectory: () => false,
+      isFile: () => true,
+      name: "test.ts",
+    };
+
+    expect(entry.name).toBe("test.ts");
+  });
+});

--- a/tests/unit/fs/node-fs.test.ts
+++ b/tests/unit/fs/node-fs.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @module tests/unit/fs/node-fs
+ * @description Tests for the Node.js filesystem adapter.
+ */
+
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createNodeFs } from "../../../src/fs/node-fs.js";
+
+const WORKTREE_ROOT = resolve(import.meta.dirname, "../../..");
+
+describe("fs/node-fs", () => {
+  describe("createNodeFs", () => {
+    it("should return an object with all FsModule methods", () => {
+      const fs = createNodeFs();
+
+      expect(fs.readFile).toBeTypeOf("function");
+      expect(fs.readdir).toBeTypeOf("function");
+      expect(fs.realpath).toBeTypeOf("function");
+      expect(fs.stat).toBeTypeOf("function");
+    });
+  });
+
+  describe("readFile", () => {
+    it("should read a file and return its content as a string", async () => {
+      const fs = createNodeFs();
+      const content = await fs.readFile(
+        resolve(WORKTREE_ROOT, "package.json"),
+        "utf-8",
+      );
+
+      expect(content).toContain('"name": "steamroller"');
+    });
+
+    it("should reject for a non-existent file", async () => {
+      const fs = createNodeFs();
+
+      await expect(
+        fs.readFile("/non/existent/file.txt", "utf-8"),
+      ).rejects.toThrow();
+    });
+
+    it("should reject with ENOENT error code for missing files", async () => {
+      const fs = createNodeFs();
+
+      await expect(
+        fs.readFile("/non/existent/path.ts", "utf-8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  describe("readdir", () => {
+    it("should list directory contents as string array", async () => {
+      const fs = createNodeFs();
+      const entries = await fs.readdir!(resolve(WORKTREE_ROOT, "src"));
+
+      expect(Array.isArray(entries)).toBe(true);
+      expect(entries.length).toBeGreaterThan(0);
+      expect(entries).toContain("types.ts");
+      expect(entries).toContain("index.ts");
+    });
+
+    it("should reject for a non-existent directory", async () => {
+      const fs = createNodeFs();
+
+      await expect(fs.readdir!("/non/existent/directory")).rejects.toThrow();
+    });
+
+    it("should reject with ENOENT for missing directory", async () => {
+      const fs = createNodeFs();
+
+      await expect(
+        fs.readdir!("/non/existent/directory"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  describe("realpath", () => {
+    it("should resolve a path to its real absolute path", async () => {
+      const fs = createNodeFs();
+      const resolved = await fs.realpath!(WORKTREE_ROOT);
+
+      expect(resolved).toBe(WORKTREE_ROOT);
+    });
+
+    it("should resolve relative-like paths in absolute form", async () => {
+      const fs = createNodeFs();
+      const resolved = await fs.realpath!(resolve(WORKTREE_ROOT, "src/../src"));
+
+      expect(resolved).toBe(resolve(WORKTREE_ROOT, "src"));
+    });
+
+    it("should reject for a non-existent path", async () => {
+      const fs = createNodeFs();
+
+      await expect(fs.realpath!("/non/existent/path")).rejects.toThrow();
+    });
+
+    it("should reject with ENOENT for missing path", async () => {
+      const fs = createNodeFs();
+
+      await expect(fs.realpath!("/non/existent/path")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  describe("stat", () => {
+    it("should return stats for a file", async () => {
+      const fs = createNodeFs();
+      const stats = await fs.stat!(resolve(WORKTREE_ROOT, "package.json"));
+
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isDirectory()).toBe(false);
+      expect(stats.isSymbolicLink()).toBe(false);
+    });
+
+    it("should return stats for a directory", async () => {
+      const fs = createNodeFs();
+      const stats = await fs.stat!(resolve(WORKTREE_ROOT, "src"));
+
+      expect(stats.isFile()).toBe(false);
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
+    });
+
+    it("should reject for a non-existent path", async () => {
+      const fs = createNodeFs();
+
+      await expect(fs.stat!("/non/existent/file.ts")).rejects.toThrow();
+    });
+
+    it("should reject with ENOENT for missing path", async () => {
+      const fs = createNodeFs();
+
+      await expect(fs.stat!("/non/existent/file.ts")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+
+    it("should return methods that are callable multiple times", async () => {
+      const fs = createNodeFs();
+      const stats = await fs.stat!(resolve(WORKTREE_ROOT, "package.json"));
+
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isDirectory()).toBe(false);
+      expect(stats.isDirectory()).toBe(false);
+    });
+  });
+});

--- a/tests/unit/fs/types.test.ts
+++ b/tests/unit/fs/types.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @module tests/unit/fs/types
+ * @description Type-level and runtime verification of filesystem interfaces.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  FsDirectoryEntry,
+  FsModule,
+  FsStats,
+} from "../../../src/fs/types.js";
+
+describe("fs/types", () => {
+  describe("FsStats", () => {
+    it("should allow creation of a conforming FsStats object", () => {
+      const stats: FsStats = {
+        isDirectory: () => false,
+        isFile: () => true,
+        isSymbolicLink: () => false,
+      };
+
+      expect(stats.isDirectory()).toBe(false);
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
+    });
+
+    it("should allow directory stats", () => {
+      const stats: FsStats = {
+        isDirectory: () => true,
+        isFile: () => false,
+        isSymbolicLink: () => false,
+      };
+
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isFile()).toBe(false);
+    });
+
+    it("should allow symlink stats", () => {
+      const stats: FsStats = {
+        isDirectory: () => false,
+        isFile: () => false,
+        isSymbolicLink: () => true,
+      };
+
+      expect(stats.isSymbolicLink()).toBe(true);
+    });
+  });
+
+  describe("FsDirectoryEntry", () => {
+    it("should allow creation of a file entry", () => {
+      const entry: FsDirectoryEntry = {
+        isDirectory: () => false,
+        isFile: () => true,
+        name: "test.ts",
+      };
+
+      expect(entry.name).toBe("test.ts");
+      expect(entry.isFile()).toBe(true);
+      expect(entry.isDirectory()).toBe(false);
+    });
+
+    it("should allow creation of a directory entry", () => {
+      const entry: FsDirectoryEntry = {
+        isDirectory: () => true,
+        isFile: () => false,
+        name: "subdir",
+      };
+
+      expect(entry.name).toBe("subdir");
+      expect(entry.isDirectory()).toBe(true);
+      expect(entry.isFile()).toBe(false);
+    });
+  });
+
+  describe("FsModule", () => {
+    it("should allow a minimal FsModule with only readFile", () => {
+      const fs: FsModule = {
+        readFile: async (_path: string, _encoding: "utf-8") => "content",
+      };
+
+      expect(fs.readFile).toBeDefined();
+      expect(fs.readdir).toBeUndefined();
+      expect(fs.realpath).toBeUndefined();
+      expect(fs.stat).toBeUndefined();
+    });
+
+    it("should allow a complete FsModule with all methods", () => {
+      const fs: FsModule = {
+        readFile: async (_path: string, _encoding: "utf-8") => "content",
+        readdir: async (_path: string) => ["a.ts", "b.ts"],
+        realpath: async (_path: string) => "/resolved/path",
+        stat: async (_path: string) => ({
+          isDirectory: () => false,
+          isFile: () => true,
+          isSymbolicLink: () => false,
+        }),
+      };
+
+      expect(fs.readFile).toBeDefined();
+      expect(fs.readdir).toBeDefined();
+      expect(fs.realpath).toBeDefined();
+      expect(fs.stat).toBeDefined();
+    });
+
+    it("should resolve readFile with string content", async () => {
+      const fs: FsModule = {
+        readFile: async (_path: string, _encoding: "utf-8") =>
+          "file contents here",
+      };
+
+      const result = await fs.readFile("/some/path.ts", "utf-8");
+      expect(result).toBe("file contents here");
+    });
+
+    it("should resolve readdir with string array", async () => {
+      const fs: FsModule = {
+        readFile: async () => "",
+        readdir: async (_path: string) => ["index.ts", "utils.ts"],
+      };
+
+      const result = await fs.readdir!("/some/dir");
+      expect(result).toEqual(["index.ts", "utils.ts"]);
+    });
+
+    it("should resolve realpath with absolute path", async () => {
+      const fs: FsModule = {
+        readFile: async () => "",
+        realpath: async (_path: string) => "/absolute/resolved/path",
+      };
+
+      const result = await fs.realpath!("./relative");
+      expect(result).toBe("/absolute/resolved/path");
+    });
+
+    it("should resolve stat with FsStats", async () => {
+      const fs: FsModule = {
+        readFile: async () => "",
+        stat: async (_path: string) => ({
+          isDirectory: () => true,
+          isFile: () => false,
+          isSymbolicLink: () => false,
+        }),
+      };
+
+      const result = await fs.stat!("/some/dir");
+      expect(result.isDirectory()).toBe(true);
+      expect(result.isFile()).toBe(false);
+      expect(result.isSymbolicLink()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/fs/types.ts` with `FsModule`, `FsStats`, and `FsDirectoryEntry` interfaces for virtual filesystem abstraction
- Adds `src/fs/node-fs.ts` with `createNodeFs()` factory producing a Node.js `fs/promises`-backed adapter
- Adds `src/fs/index.ts` barrel export
- Full test suite in `tests/unit/fs/` with 100% coverage on runtime code (31 tests)

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] All 31 unit tests pass (types, node-fs, index)
- [x] 100% statement/branch/function/line coverage on `src/fs/`
- [x] Prettier formatting verified

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)