### PR TITLE
feat: implement ModuleInfo registry and module cache system

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,7 @@ export { defineConfig } from "./define-config.js";
 export type { RollupOptions, RollupOptionsFunction } from "./define-config.js";
 export { parseAst, parseAstAsync } from "./parse-ast.js";
 export type { ParseAstOptions } from "./parse-ast.js";
+export type { ModuleInfo, ResolvedId } from "./types.js";
+export { ModuleInfoRegistry } from "./module/module-info-registry.js";
+export { RollupCache, PluginCache } from "./module/cache.js";
+export type { CachedModuleData, RollupCacheData } from "./module/cache.js";

--- a/src/module/cache.ts
+++ b/src/module/cache.ts
@@ -1,0 +1,174 @@
+/**
+ * @module module/cache
+ * @description Module cache system for incremental rebuilds.
+ * Provides RollupCache for module-level caching with expiry,
+ * and PluginCache for per-plugin key-value storage.
+ */
+
+/** Cached data for a single module. */
+export interface CachedModuleData {
+  readonly code: string;
+  readonly ast: unknown;
+  readonly dependencies: ReadonlyArray<string>;
+  readonly transformDependencies: ReadonlyArray<string>;
+  readonly meta: Readonly<Record<string, unknown>>;
+  readonly syntheticNamedExports: boolean | string;
+  readonly moduleSideEffects: boolean | "no-treeshake";
+}
+
+/** Serialized cache state for persistence between builds. */
+export interface RollupCacheData {
+  readonly modules: ReadonlyArray<CachedModuleData & { readonly id: string }>;
+  readonly plugins?: Readonly<Record<string, ReadonlyArray<unknown>>>;
+}
+
+/**
+ * Cache for module data across incremental rebuilds.
+ * Tracks access times to purge stale entries.
+ */
+export class RollupCache {
+  private readonly modules: Map<string, CachedModuleData>;
+  private buildCount: number;
+  private readonly lastAccessed: Map<string, number>;
+
+  constructor(data?: RollupCacheData) {
+    this.modules = new Map();
+    this.buildCount = 0;
+    this.lastAccessed = new Map();
+
+    if (data !== undefined) {
+      const moduleList = data.modules;
+      for (let i = 0; i < moduleList.length; i++) {
+        const entry = moduleList[i];
+        const cached: CachedModuleData = {
+          code: entry.code,
+          ast: entry.ast,
+          dependencies: entry.dependencies,
+          transformDependencies: entry.transformDependencies,
+          meta: entry.meta,
+          syntheticNamedExports: entry.syntheticNamedExports,
+          moduleSideEffects: entry.moduleSideEffects,
+        };
+        this.modules.set(entry.id, cached);
+        this.lastAccessed.set(entry.id, this.buildCount);
+      }
+    }
+  }
+
+  /** Retrieve cached data for a module by id. */
+  getModule(id: string): CachedModuleData | undefined {
+    const mod = this.modules.get(id);
+    if (mod !== undefined) {
+      this.lastAccessed.set(id, this.buildCount);
+    }
+    return mod;
+  }
+
+  /** Store cached data for a module. */
+  setModule(id: string, data: CachedModuleData): void {
+    this.modules.set(id, data);
+    this.lastAccessed.set(id, this.buildCount);
+  }
+
+  /** Check if a module is cached. */
+  hasModule(id: string): boolean {
+    return this.modules.has(id);
+  }
+
+  /** Remove a module from the cache. */
+  deleteModule(id: string): boolean {
+    this.lastAccessed.delete(id);
+    return this.modules.delete(id);
+  }
+
+  /**
+   * Purge entries not accessed within the given number of builds.
+   * An entry is expired if (buildCount - lastAccessed) >= expiry.
+   */
+  purgeExpired(expiry: number): void {
+    const ids = Array.from(this.lastAccessed.keys());
+    for (let i = 0; i < ids.length; i++) {
+      const id = ids[i];
+      const lastBuild = this.lastAccessed.get(id);
+      if (lastBuild !== undefined && this.buildCount - lastBuild >= expiry) {
+        this.modules.delete(id);
+        this.lastAccessed.delete(id);
+      }
+    }
+  }
+
+  /** Increment the build counter. Call at the start of each build. */
+  incrementBuild(): void {
+    this.buildCount++;
+  }
+
+  /** Get the current build count. */
+  getBuildCount(): number {
+    return this.buildCount;
+  }
+
+  /** Get the number of cached modules. */
+  get size(): number {
+    return this.modules.size;
+  }
+
+  /** Serialize the cache for persistence. */
+  serialize(): RollupCacheData {
+    const modules: Array<CachedModuleData & { readonly id: string }> = [];
+    for (const [id, data] of this.modules) {
+      modules.push({
+        id,
+        code: data.code,
+        ast: data.ast,
+        dependencies: data.dependencies,
+        transformDependencies: data.transformDependencies,
+        meta: data.meta,
+        syntheticNamedExports: data.syntheticNamedExports,
+        moduleSideEffects: data.moduleSideEffects,
+      });
+    }
+    return { modules };
+  }
+}
+
+/**
+ * Per-plugin key-value cache.
+ * Implements the PluginCache interface from types.ts.
+ */
+export class PluginCache {
+  private readonly store: Map<string, unknown>;
+
+  constructor() {
+    this.store = new Map();
+  }
+
+  /** Retrieve a value by key. Throws if key does not exist. */
+  get<T = unknown>(id: string): T {
+    if (!this.store.has(id)) {
+      throw new Error(
+        `PluginCache.get: no entry found for key "${id}". Use has() to check existence first.`,
+      );
+    }
+    return this.store.get(id) as T;
+  }
+
+  /** Store a value by key. */
+  set<T = unknown>(id: string, value: T): void {
+    this.store.set(id, value);
+  }
+
+  /** Check if a key exists in the cache. */
+  has(id: string): boolean {
+    return this.store.has(id);
+  }
+
+  /** Delete a key from the cache. Returns true if the key existed. */
+  delete(id: string): boolean {
+    return this.store.delete(id);
+  }
+
+  /** Get the number of entries in the cache. */
+  get size(): number {
+    return this.store.size;
+  }
+}

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -6,3 +6,6 @@
 export { Module } from "./Module.js";
 export type { ImportDescriptor, ExportDescriptor } from "./Module.js";
 export { ExternalModule } from "./ExternalModule.js";
+export { ModuleInfoRegistry } from "./module-info-registry.js";
+export { RollupCache, PluginCache } from "./cache.js";
+export type { CachedModuleData, RollupCacheData } from "./cache.js";

--- a/src/module/module-info-registry.ts
+++ b/src/module/module-info-registry.ts
@@ -1,0 +1,71 @@
+/**
+ * @module module/module-info-registry
+ * @description Registry for querying ModuleInfo from the plugin context.
+ * Provides getModuleInfo and getModuleIds for the PluginContext API.
+ */
+
+import type { ModuleInfo } from "../types.js";
+import type { Module } from "./Module.js";
+
+/**
+ * Stores Module instances and provides ModuleInfo lookups
+ * compatible with the Rollup PluginContext API.
+ */
+export class ModuleInfoRegistry {
+  private readonly modules: Map<string, Module>;
+
+  constructor() {
+    this.modules = new Map();
+  }
+
+  /** Register a module in the registry. */
+  addModule(mod: Module): void {
+    this.modules.set(mod.id, mod);
+  }
+
+  /** Remove a module from the registry by id. */
+  removeModule(id: string): boolean {
+    return this.modules.delete(id);
+  }
+
+  /** Check if a module exists in the registry. */
+  hasModule(id: string): boolean {
+    return this.modules.has(id);
+  }
+
+  /** Get the raw Module instance (internal use). */
+  getModule(id: string): Module | undefined {
+    return this.modules.get(id);
+  }
+
+  /**
+   * Get ModuleInfo for a given module id.
+   * Returns null if the module is not in the registry.
+   * Compatible with PluginContext.getModuleInfo signature.
+   */
+  getModuleInfo(id: string): ModuleInfo | null {
+    const mod = this.modules.get(id);
+    if (mod === undefined) {
+      return null;
+    }
+    return mod.toModuleInfo();
+  }
+
+  /**
+   * Get an iterator over all registered module ids.
+   * Compatible with PluginContext.getModuleIds signature.
+   */
+  getModuleIds(): IterableIterator<string> {
+    return this.modules.keys();
+  }
+
+  /** Get the number of registered modules. */
+  get size(): number {
+    return this.modules.size;
+  }
+
+  /** Clear all modules from the registry. */
+  clear(): void {
+    this.modules.clear();
+  }
+}

--- a/tests/unit/module/cache.test.ts
+++ b/tests/unit/module/cache.test.ts
@@ -1,0 +1,331 @@
+/**
+ * @module tests/unit/module/cache
+ * @description Unit tests for RollupCache and PluginCache.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { RollupCache, PluginCache } from "../../../src/module/cache.js";
+import type {
+  CachedModuleData,
+  RollupCacheData,
+} from "../../../src/module/cache.js";
+
+const createModuleData = (
+  overrides?: Partial<CachedModuleData>,
+): CachedModuleData => ({
+  code: "const x = 1;",
+  ast: { type: "Program", body: [], sourceType: "module" },
+  dependencies: ["./dep-a.ts"],
+  transformDependencies: [],
+  meta: {},
+  syntheticNamedExports: false,
+  moduleSideEffects: true,
+  ...overrides,
+});
+
+describe("RollupCache", () => {
+  let cache: RollupCache;
+
+  beforeEach(() => {
+    cache = new RollupCache();
+  });
+
+  describe("constructor", () => {
+    it("should create an empty cache", () => {
+      expect(cache.size).toBe(0);
+      expect(cache.getBuildCount()).toBe(0);
+    });
+
+    it("should initialize from RollupCacheData", () => {
+      const data: RollupCacheData = {
+        modules: [
+          { id: "./a.ts", ...createModuleData() },
+          { id: "./b.ts", ...createModuleData({ code: "const y = 2;" }) },
+        ],
+      };
+      const loaded = new RollupCache(data);
+      expect(loaded.size).toBe(2);
+      expect(loaded.hasModule("./a.ts")).toBe(true);
+      expect(loaded.hasModule("./b.ts")).toBe(true);
+    });
+
+    it("should handle empty modules array", () => {
+      const loaded = new RollupCache({ modules: [] });
+      expect(loaded.size).toBe(0);
+    });
+  });
+
+  describe("getModule", () => {
+    it("should return undefined for missing module", () => {
+      expect(cache.getModule("./missing.ts")).toBeUndefined();
+    });
+
+    it("should return cached module data", () => {
+      const data = createModuleData();
+      cache.setModule("./a.ts", data);
+      const result = cache.getModule("./a.ts");
+      expect(result).toEqual(data);
+    });
+
+    it("should update lastAccessed on get", () => {
+      cache.setModule("./a.ts", createModuleData());
+      cache.incrementBuild();
+      cache.incrementBuild();
+      // Access updates the timestamp, so it should survive purge
+      cache.getModule("./a.ts");
+      cache.purgeExpired(3);
+      expect(cache.hasModule("./a.ts")).toBe(true);
+    });
+  });
+
+  describe("setModule", () => {
+    it("should store module data", () => {
+      const data = createModuleData();
+      cache.setModule("./a.ts", data);
+      expect(cache.size).toBe(1);
+      expect(cache.getModule("./a.ts")).toEqual(data);
+    });
+
+    it("should overwrite existing entries", () => {
+      cache.setModule("./a.ts", createModuleData({ code: "old" }));
+      cache.setModule("./a.ts", createModuleData({ code: "new" }));
+      expect(cache.size).toBe(1);
+      expect(cache.getModule("./a.ts")!.code).toBe("new");
+    });
+  });
+
+  describe("hasModule", () => {
+    it("should return false for missing modules", () => {
+      expect(cache.hasModule("./missing.ts")).toBe(false);
+    });
+
+    it("should return true for existing modules", () => {
+      cache.setModule("./a.ts", createModuleData());
+      expect(cache.hasModule("./a.ts")).toBe(true);
+    });
+  });
+
+  describe("deleteModule", () => {
+    it("should remove existing module", () => {
+      cache.setModule("./a.ts", createModuleData());
+      const result = cache.deleteModule("./a.ts");
+      expect(result).toBe(true);
+      expect(cache.size).toBe(0);
+    });
+
+    it("should return false for missing module", () => {
+      expect(cache.deleteModule("./missing.ts")).toBe(false);
+    });
+  });
+
+  describe("incrementBuild", () => {
+    it("should increment the build counter", () => {
+      expect(cache.getBuildCount()).toBe(0);
+      cache.incrementBuild();
+      expect(cache.getBuildCount()).toBe(1);
+      cache.incrementBuild();
+      expect(cache.getBuildCount()).toBe(2);
+    });
+  });
+
+  describe("purgeExpired", () => {
+    it("should not purge recently accessed modules", () => {
+      cache.setModule("./a.ts", createModuleData());
+      cache.incrementBuild();
+      cache.purgeExpired(3);
+      expect(cache.hasModule("./a.ts")).toBe(true);
+    });
+
+    it("should purge modules older than expiry builds", () => {
+      cache.setModule("./old.ts", createModuleData());
+      cache.incrementBuild();
+      cache.incrementBuild();
+      cache.incrementBuild();
+      cache.purgeExpired(3);
+      expect(cache.hasModule("./old.ts")).toBe(false);
+    });
+
+    it("should keep modules accessed within expiry window", () => {
+      cache.setModule("./a.ts", createModuleData());
+      cache.incrementBuild();
+      cache.getModule("./a.ts"); // refresh access
+      cache.incrementBuild();
+      cache.incrementBuild();
+      cache.purgeExpired(3);
+      expect(cache.hasModule("./a.ts")).toBe(true);
+    });
+
+    it("should purge selectively", () => {
+      cache.setModule("./old.ts", createModuleData());
+      cache.incrementBuild();
+      cache.incrementBuild();
+      cache.setModule("./new.ts", createModuleData());
+      cache.incrementBuild();
+      cache.purgeExpired(3);
+      expect(cache.hasModule("./old.ts")).toBe(false);
+      expect(cache.hasModule("./new.ts")).toBe(true);
+    });
+
+    it("should handle expiry of 1 (immediate)", () => {
+      cache.setModule("./a.ts", createModuleData());
+      cache.incrementBuild();
+      cache.purgeExpired(1);
+      expect(cache.hasModule("./a.ts")).toBe(false);
+    });
+
+    it("should not purge anything with large expiry", () => {
+      cache.setModule("./a.ts", createModuleData());
+      cache.incrementBuild();
+      cache.incrementBuild();
+      cache.purgeExpired(100);
+      expect(cache.hasModule("./a.ts")).toBe(true);
+    });
+  });
+
+  describe("serialize", () => {
+    it("should serialize empty cache", () => {
+      const result = cache.serialize();
+      expect(result.modules).toEqual([]);
+    });
+
+    it("should serialize all cached modules", () => {
+      const dataA = createModuleData({ code: "a" });
+      const dataB = createModuleData({ code: "b" });
+      cache.setModule("./a.ts", dataA);
+      cache.setModule("./b.ts", dataB);
+
+      const result = cache.serialize();
+      expect(result.modules).toHaveLength(2);
+
+      const ids = result.modules.map((m) => m.id);
+      expect(ids).toContain("./a.ts");
+      expect(ids).toContain("./b.ts");
+
+      const moduleA = result.modules.find((m) => m.id === "./a.ts");
+      expect(moduleA!.code).toBe("a");
+      expect(moduleA!.dependencies).toEqual(["./dep-a.ts"]);
+    });
+
+    it("should round-trip through constructor", () => {
+      cache.setModule("./a.ts", createModuleData({ code: "hello" }));
+      cache.setModule("./b.ts", createModuleData({ code: "world" }));
+
+      const serialized = cache.serialize();
+      const restored = new RollupCache(serialized);
+
+      expect(restored.size).toBe(2);
+      expect(restored.getModule("./a.ts")!.code).toBe("hello");
+      expect(restored.getModule("./b.ts")!.code).toBe("world");
+    });
+  });
+
+  describe("size", () => {
+    it("should reflect module count", () => {
+      expect(cache.size).toBe(0);
+      cache.setModule("./a.ts", createModuleData());
+      expect(cache.size).toBe(1);
+      cache.setModule("./b.ts", createModuleData());
+      expect(cache.size).toBe(2);
+      cache.deleteModule("./a.ts");
+      expect(cache.size).toBe(1);
+    });
+  });
+});
+
+describe("PluginCache", () => {
+  let pluginCache: PluginCache;
+
+  beforeEach(() => {
+    pluginCache = new PluginCache();
+  });
+
+  describe("set and get", () => {
+    it("should store and retrieve string values", () => {
+      pluginCache.set("key1", "value1");
+      expect(pluginCache.get<string>("key1")).toBe("value1");
+    });
+
+    it("should store and retrieve numeric values", () => {
+      pluginCache.set("count", 42);
+      expect(pluginCache.get<number>("count")).toBe(42);
+    });
+
+    it("should store and retrieve object values", () => {
+      const obj = { nested: { data: [1, 2, 3] } };
+      pluginCache.set("obj", obj);
+      expect(pluginCache.get("obj")).toEqual(obj);
+    });
+
+    it("should store null values", () => {
+      pluginCache.set("nullable", null);
+      expect(pluginCache.get("nullable")).toBeNull();
+    });
+
+    it("should overwrite existing values", () => {
+      pluginCache.set("key", "old");
+      pluginCache.set("key", "new");
+      expect(pluginCache.get<string>("key")).toBe("new");
+    });
+  });
+
+  describe("get (error cases)", () => {
+    it("should throw for missing keys", () => {
+      expect(() => pluginCache.get("missing")).toThrow(
+        'PluginCache.get: no entry found for key "missing"',
+      );
+    });
+  });
+
+  describe("has", () => {
+    it("should return false for missing keys", () => {
+      expect(pluginCache.has("missing")).toBe(false);
+    });
+
+    it("should return true for existing keys", () => {
+      pluginCache.set("exists", true);
+      expect(pluginCache.has("exists")).toBe(true);
+    });
+
+    it("should return true for keys with falsy values", () => {
+      pluginCache.set("zero", 0);
+      pluginCache.set("empty", "");
+      pluginCache.set("null", null);
+      expect(pluginCache.has("zero")).toBe(true);
+      expect(pluginCache.has("empty")).toBe(true);
+      expect(pluginCache.has("null")).toBe(true);
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete existing keys and return true", () => {
+      pluginCache.set("key", "value");
+      const result = pluginCache.delete("key");
+      expect(result).toBe(true);
+      expect(pluginCache.has("key")).toBe(false);
+    });
+
+    it("should return false for missing keys", () => {
+      expect(pluginCache.delete("missing")).toBe(false);
+    });
+
+    it("should make get throw after deletion", () => {
+      pluginCache.set("key", "value");
+      pluginCache.delete("key");
+      expect(() => pluginCache.get("key")).toThrow();
+    });
+  });
+
+  describe("size", () => {
+    it("should be 0 for new cache", () => {
+      expect(pluginCache.size).toBe(0);
+    });
+
+    it("should track additions and deletions", () => {
+      pluginCache.set("a", 1);
+      pluginCache.set("b", 2);
+      expect(pluginCache.size).toBe(2);
+      pluginCache.delete("a");
+      expect(pluginCache.size).toBe(1);
+    });
+  });
+});

--- a/tests/unit/module/module-info-registry.test.ts
+++ b/tests/unit/module/module-info-registry.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @module tests/unit/module/module-info-registry
+ * @description Unit tests for ModuleInfoRegistry.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { ModuleInfoRegistry } from "../../../src/module/module-info-registry.js";
+import { Module } from "../../../src/module/Module.js";
+
+describe("ModuleInfoRegistry", () => {
+  let registry: ModuleInfoRegistry;
+
+  beforeEach(() => {
+    registry = new ModuleInfoRegistry();
+  });
+
+  describe("addModule", () => {
+    it("should add a module to the registry", () => {
+      const mod = new Module("./src/index.ts", "const x = 1;", true);
+      registry.addModule(mod);
+      expect(registry.size).toBe(1);
+      expect(registry.hasModule("./src/index.ts")).toBe(true);
+    });
+
+    it("should overwrite existing module with same id", () => {
+      const mod1 = new Module("./a.ts", "const x = 1;", true);
+      const mod2 = new Module("./a.ts", "const y = 2;", false);
+      registry.addModule(mod1);
+      registry.addModule(mod2);
+      expect(registry.size).toBe(1);
+      const info = registry.getModuleInfo("./a.ts");
+      expect(info).not.toBeNull();
+      expect(info!.code).toBe("const y = 2;");
+    });
+  });
+
+  describe("removeModule", () => {
+    it("should remove an existing module", () => {
+      const mod = new Module("./a.ts", "const x = 1;", true);
+      registry.addModule(mod);
+      const result = registry.removeModule("./a.ts");
+      expect(result).toBe(true);
+      expect(registry.size).toBe(0);
+    });
+
+    it("should return false when removing non-existent module", () => {
+      const result = registry.removeModule("./nonexistent.ts");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("hasModule", () => {
+    it("should return true for registered modules", () => {
+      const mod = new Module("./a.ts", "const x = 1;", true);
+      registry.addModule(mod);
+      expect(registry.hasModule("./a.ts")).toBe(true);
+    });
+
+    it("should return false for unregistered modules", () => {
+      expect(registry.hasModule("./missing.ts")).toBe(false);
+    });
+  });
+
+  describe("getModule", () => {
+    it("should return the Module instance", () => {
+      const mod = new Module("./a.ts", "const x = 1;", true);
+      registry.addModule(mod);
+      const result = registry.getModule("./a.ts");
+      expect(result).toBe(mod);
+    });
+
+    it("should return undefined for missing modules", () => {
+      expect(registry.getModule("./missing.ts")).toBeUndefined();
+    });
+  });
+
+  describe("getModuleInfo", () => {
+    it("should return null for non-existent module", () => {
+      expect(registry.getModuleInfo("./missing.ts")).toBeNull();
+    });
+
+    it("should return ModuleInfo with correct shape", () => {
+      const mod = new Module(
+        "./entry.ts",
+        'import { foo } from "./foo";',
+        true,
+      );
+      registry.addModule(mod);
+
+      const info = registry.getModuleInfo("./entry.ts");
+      expect(info).not.toBeNull();
+      expect(info!.id).toBe("./entry.ts");
+      expect(info!.code).toBe('import { foo } from "./foo";');
+      expect(info!.isEntry).toBe(true);
+      expect(info!.isExternal).toBe(false);
+      expect(info!.isIncluded).toBe(false);
+      expect(info!.importedIds).toBeInstanceOf(Array);
+      expect(info!.importedIdResolutions).toBeInstanceOf(Array);
+      expect(info!.dynamicallyImportedIds).toBeInstanceOf(Array);
+      expect(info!.dynamicallyImportedIdResolutions).toBeInstanceOf(Array);
+      expect(info!.importers).toBeInstanceOf(Array);
+      expect(info!.dynamicImporters).toBeInstanceOf(Array);
+      expect(info!.meta).toBeDefined();
+      expect(typeof info!.syntheticNamedExports).toBe("boolean");
+      expect(typeof info!.moduleSideEffects).toBe("boolean");
+    });
+
+    it("should reflect module state changes", () => {
+      const mod = new Module("./a.ts", "const x = 1;", false);
+      registry.addModule(mod);
+
+      mod.isIncluded = true;
+      const info = registry.getModuleInfo("./a.ts");
+      expect(info!.isIncluded).toBe(true);
+    });
+  });
+
+  describe("getModuleIds", () => {
+    it("should return an empty iterator when no modules registered", () => {
+      const ids = Array.from(registry.getModuleIds());
+      expect(ids).toEqual([]);
+    });
+
+    it("should return all registered module ids", () => {
+      registry.addModule(new Module("./a.ts", "", false));
+      registry.addModule(new Module("./b.ts", "", false));
+      registry.addModule(new Module("./c.ts", "", true));
+
+      const ids = Array.from(registry.getModuleIds());
+      expect(ids).toHaveLength(3);
+      expect(ids).toContain("./a.ts");
+      expect(ids).toContain("./b.ts");
+      expect(ids).toContain("./c.ts");
+    });
+
+    it("should return an IterableIterator", () => {
+      registry.addModule(new Module("./a.ts", "", false));
+      const iter = registry.getModuleIds();
+      expect(typeof iter[Symbol.iterator]).toBe("function");
+      expect(typeof iter.next).toBe("function");
+    });
+  });
+
+  describe("size", () => {
+    it("should return 0 for empty registry", () => {
+      expect(registry.size).toBe(0);
+    });
+
+    it("should track additions", () => {
+      registry.addModule(new Module("./a.ts", "", false));
+      expect(registry.size).toBe(1);
+      registry.addModule(new Module("./b.ts", "", false));
+      expect(registry.size).toBe(2);
+    });
+  });
+
+  describe("clear", () => {
+    it("should remove all modules", () => {
+      registry.addModule(new Module("./a.ts", "", false));
+      registry.addModule(new Module("./b.ts", "", false));
+      registry.clear();
+      expect(registry.size).toBe(0);
+      expect(registry.hasModule("./a.ts")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Added `ModuleInfoRegistry` class (`src/module/module-info-registry.ts`) providing `getModuleInfo`/`getModuleIds` for the plugin context API
- Added `RollupCache` class (`src/module/cache.ts`) for incremental rebuild caching with build-count-based expiry
- Added `PluginCache` class for per-plugin key-value storage implementing the `PluginCache` interface from types.ts
- Exported `ModuleInfo`, `ResolvedId`, `ModuleInfoRegistry`, `RollupCache`, `PluginCache`, `CachedModuleData`, and `RollupCacheData` from public API

## Test plan

- [x] 54 new unit tests covering all public methods of ModuleInfoRegistry, RollupCache, and PluginCache
- [x] Full test suite passes (2749 tests, 51 files)
- [x] TypeScript strict mode passes with no errors
- [x] Prettier formatting verified

Closes #23
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)