### PR TITLE
feat: implement syntheticNamedExports

### DIFF
--- a/src/module/synthetic-exports.ts
+++ b/src/module/synthetic-exports.ts
@@ -1,0 +1,137 @@
+/**
+ * @module module/synthetic-exports
+ * @description Implements syntheticNamedExports support for CommonJS interop.
+ * Provides fallback namespace resolution, validation, and code generation
+ * helpers for modules that expose named exports synthetically through a
+ * namespace object (typically the default export).
+ */
+
+import {
+  EXTERNAL_SYNTHETIC_EXPORTS,
+  SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT,
+} from "../utils/error-codes.js";
+
+/** Describes a synthetic export resolution result. */
+export interface SyntheticExportResolution {
+  readonly type: "synthetic";
+  readonly fallbackExport: string;
+  readonly requestedName: string;
+}
+
+/** Validation error returned when syntheticNamedExports is misconfigured. */
+export interface SyntheticExportValidationError {
+  readonly code: string;
+  readonly message: string;
+}
+
+/**
+ * Determine the fallback export name from a syntheticNamedExports option.
+ *
+ * @param syntheticNamedExports - The module's syntheticNamedExports config.
+ * @returns The fallback export name, or null if synthetic exports are disabled.
+ */
+export const getFallbackExportName = (
+  syntheticNamedExports: boolean | string,
+): string | null => {
+  if (syntheticNamedExports === true) {
+    return "default";
+  }
+  if (typeof syntheticNamedExports === "string") {
+    return syntheticNamedExports;
+  }
+  return null;
+};
+
+/**
+ * Check if a named import can be resolved synthetically.
+ *
+ * When a module has syntheticNamedExports enabled and does not explicitly
+ * export the requested name, this function determines whether the import
+ * can be fulfilled by accessing it as a property of the fallback export.
+ *
+ * @param requestedName - The binding name being imported.
+ * @param moduleExports - The list of actual exports from the module.
+ * @param syntheticNamedExports - The module's syntheticNamedExports config.
+ * @returns A SyntheticExportResolution if synthetic resolution applies, or null.
+ */
+export const resolveSyntheticExport = (
+  requestedName: string,
+  moduleExports: ReadonlyArray<string>,
+  syntheticNamedExports: boolean | string,
+): SyntheticExportResolution | null => {
+  // If the module actually exports this name, no synthetic resolution needed
+  if (moduleExports.includes(requestedName)) {
+    return null;
+  }
+
+  const fallback = getFallbackExportName(syntheticNamedExports);
+  if (fallback === null) {
+    return null;
+  }
+
+  // The fallback export must exist in the module
+  if (!moduleExports.includes(fallback)) {
+    return null;
+  }
+
+  return { type: "synthetic", fallbackExport: fallback, requestedName };
+};
+
+/**
+ * Validate syntheticNamedExports configuration for a module.
+ *
+ * Returns a validation error if the configuration is invalid (e.g., an
+ * external module with synthetic exports, or a missing fallback export).
+ *
+ * @param moduleId - The module identifier for error messages.
+ * @param syntheticNamedExports - The module's syntheticNamedExports config.
+ * @param moduleExports - The list of actual exports from the module.
+ * @param isExternal - Whether the module is external.
+ * @returns A validation error object, or null if configuration is valid.
+ */
+export const validateSyntheticExports = (
+  moduleId: string,
+  syntheticNamedExports: boolean | string,
+  moduleExports: ReadonlyArray<string>,
+  isExternal: boolean,
+): SyntheticExportValidationError | null => {
+  if (!syntheticNamedExports) {
+    return null;
+  }
+
+  if (isExternal) {
+    return {
+      code: EXTERNAL_SYNTHETIC_EXPORTS,
+      message: `External module '${moduleId}' cannot have syntheticNamedExports`,
+    };
+  }
+
+  const fallback = getFallbackExportName(syntheticNamedExports);
+  if (fallback !== null && !moduleExports.includes(fallback)) {
+    return {
+      code: SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT,
+      message: `Module '${moduleId}' has syntheticNamedExports set to '${fallback}' but does not export '${fallback}'`,
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Generate the code transformation for a synthetic import access.
+ *
+ * For a module with syntheticNamedExports, an import like:
+ *   import { foo } from './mod'
+ * becomes a property access on the fallback binding:
+ *   const foo = mod_default.foo
+ *
+ * @param fallbackBinding - The local binding name for the fallback export.
+ * @param requestedName - The originally requested import name.
+ * @returns The property access expression string.
+ */
+export const generateSyntheticAccess = (
+  fallbackBinding: string,
+  requestedName: string,
+): string => {
+  return `${fallbackBinding}.${requestedName}`;
+};

--- a/tests/unit/module/synthetic-exports.test.ts
+++ b/tests/unit/module/synthetic-exports.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @module tests/unit/module/synthetic-exports
+ * @description Unit tests for syntheticNamedExports resolution, validation,
+ * and code generation utilities.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  generateSyntheticAccess,
+  getFallbackExportName,
+  resolveSyntheticExport,
+  validateSyntheticExports,
+} from "../../../src/module/synthetic-exports.js";
+import {
+  EXTERNAL_SYNTHETIC_EXPORTS,
+  SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT,
+} from "../../../src/utils/error-codes.js";
+
+describe("getFallbackExportName", () => {
+  it("returns 'default' when syntheticNamedExports is true", () => {
+    expect(getFallbackExportName(true)).toBe("default");
+  });
+
+  it("returns the string value when syntheticNamedExports is a string", () => {
+    expect(getFallbackExportName("__module")).toBe("__module");
+  });
+
+  it("returns the string value for empty string", () => {
+    expect(getFallbackExportName("")).toBe("");
+  });
+
+  it("returns null when syntheticNamedExports is false", () => {
+    expect(getFallbackExportName(false)).toBeNull();
+  });
+
+  it("returns the provided custom namespace name", () => {
+    expect(getFallbackExportName("namespace")).toBe("namespace");
+  });
+});
+
+describe("resolveSyntheticExport", () => {
+  it("returns null if the module actually exports the requested name", () => {
+    const result = resolveSyntheticExport(
+      "foo",
+      ["foo", "bar", "default"],
+      true,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when syntheticNamedExports is false", () => {
+    const result = resolveSyntheticExport("foo", ["default"], false);
+    expect(result).toBeNull();
+  });
+
+  it("returns a resolution when the name is not exported and fallback exists", () => {
+    const result = resolveSyntheticExport("foo", ["default", "bar"], true);
+    expect(result).toEqual({
+      type: "synthetic",
+      fallbackExport: "default",
+      requestedName: "foo",
+    });
+  });
+
+  it("uses a custom fallback name from string config", () => {
+    const result = resolveSyntheticExport("baz", ["__module"], "__module");
+    expect(result).toEqual({
+      type: "synthetic",
+      fallbackExport: "__module",
+      requestedName: "baz",
+    });
+  });
+
+  it("returns null if the fallback export does not exist in module exports", () => {
+    const result = resolveSyntheticExport("foo", ["bar", "baz"], true);
+    expect(result).toBeNull();
+  });
+
+  it("returns null if the fallback export name is not in the exports array", () => {
+    const result = resolveSyntheticExport("foo", ["bar"], "missing");
+    expect(result).toBeNull();
+  });
+
+  it("returns resolution with type 'synthetic'", () => {
+    const result = resolveSyntheticExport("x", ["default"], true);
+    expect(result?.type).toBe("synthetic");
+  });
+
+  it("handles empty exports array", () => {
+    const result = resolveSyntheticExport("foo", [], true);
+    expect(result).toBeNull();
+  });
+
+  it("handles empty string fallback export name", () => {
+    const result = resolveSyntheticExport("foo", [""], "");
+    expect(result).toEqual({
+      type: "synthetic",
+      fallbackExport: "",
+      requestedName: "foo",
+    });
+  });
+});
+
+describe("validateSyntheticExports", () => {
+  it("returns null when syntheticNamedExports is false", () => {
+    const result = validateSyntheticExports("./mod", false, ["default"], false);
+    expect(result).toBeNull();
+  });
+
+  it("returns an error for external modules with syntheticNamedExports", () => {
+    const result = validateSyntheticExports("lodash", true, ["default"], true);
+    expect(result).toEqual({
+      code: EXTERNAL_SYNTHETIC_EXPORTS,
+      message: "External module 'lodash' cannot have syntheticNamedExports",
+    });
+  });
+
+  it("returns an error for external modules with string syntheticNamedExports", () => {
+    const result = validateSyntheticExports(
+      "lodash",
+      "__module",
+      ["__module"],
+      true,
+    );
+    expect(result).toEqual({
+      code: EXTERNAL_SYNTHETIC_EXPORTS,
+      message: "External module 'lodash' cannot have syntheticNamedExports",
+    });
+  });
+
+  it("returns an error when the fallback export is missing", () => {
+    const result = validateSyntheticExports(
+      "./mod",
+      true,
+      ["foo", "bar"],
+      false,
+    );
+    expect(result).toEqual({
+      code: SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT,
+      message:
+        "Module './mod' has syntheticNamedExports set to 'default' but does not export 'default'",
+    });
+  });
+
+  it("returns an error when custom fallback export is missing", () => {
+    const result = validateSyntheticExports(
+      "./mod",
+      "__ns",
+      ["default", "foo"],
+      false,
+    );
+    expect(result).toEqual({
+      code: SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT,
+      message:
+        "Module './mod' has syntheticNamedExports set to '__ns' but does not export '__ns'",
+    });
+  });
+
+  it("returns null when configuration is valid with true", () => {
+    const result = validateSyntheticExports(
+      "./mod",
+      true,
+      ["default", "foo"],
+      false,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when configuration is valid with custom string", () => {
+    const result = validateSyntheticExports(
+      "./mod",
+      "__ns",
+      ["__ns", "foo"],
+      false,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty string syntheticNamedExports (falsy)", () => {
+    const result = validateSyntheticExports("./mod", "", ["default"], false);
+    expect(result).toBeNull();
+  });
+
+  it("includes moduleId in error messages", () => {
+    const result = validateSyntheticExports(
+      "/path/to/module.js",
+      true,
+      [],
+      true,
+    );
+    expect(result?.message).toContain("/path/to/module.js");
+  });
+});
+
+describe("generateSyntheticAccess", () => {
+  it("produces correct property access for simple names", () => {
+    expect(generateSyntheticAccess("mod_default", "foo")).toBe(
+      "mod_default.foo",
+    );
+  });
+
+  it("produces correct property access for underscore names", () => {
+    expect(generateSyntheticAccess("_ns", "_private")).toBe("_ns._private");
+  });
+
+  it("produces correct property access with dollar sign names", () => {
+    expect(generateSyntheticAccess("$mod", "$value")).toBe("$mod.$value");
+  });
+
+  it("handles single character names", () => {
+    expect(generateSyntheticAccess("a", "b")).toBe("a.b");
+  });
+
+  it("handles longer binding and property names", () => {
+    expect(
+      generateSyntheticAccess("myModule_namespace", "someExportedValue"),
+    ).toBe("myModule_namespace.someExportedValue");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/module/synthetic-exports.ts` with four utility functions for CommonJS interop via synthetic named exports: `getFallbackExportName`, `resolveSyntheticExport`, `validateSyntheticExports`, and `generateSyntheticAccess`
- Full unit test coverage in `tests/unit/module/synthetic-exports.test.ts` (28 tests, 100% coverage on the new module)
- Uses existing error codes `EXTERNAL_SYNTHETIC_EXPORTS` and `SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT`

## Test plan
- [x] All 28 unit tests pass
- [x] TypeScript strict mode passes with no errors
- [x] Prettier formatting verified
- [x] 100% statement/branch/function/line coverage on new file

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)