### PR TITLE
feat: implement VLQ codec

### DIFF
--- a/src/sourcemap/vlq.ts
+++ b/src/sourcemap/vlq.ts
@@ -1,0 +1,167 @@
+/**
+ * VLQ (Variable-Length Quantity) encoding/decoding for source maps.
+ *
+ * Implements the Base64 VLQ encoding used in source map mappings strings,
+ * as specified in the Source Map Revision 3 proposal.
+ */
+
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+const charToInt = new Map<string, number>();
+for (let i = 0; i < BASE64_CHARS.length; i++) {
+  charToInt.set(BASE64_CHARS[i], i);
+}
+
+const VLQ_BASE_SHIFT = 5;
+const VLQ_BASE = 1 << VLQ_BASE_SHIFT; // 32
+const VLQ_BASE_MASK = VLQ_BASE - 1; // 0b11111
+const VLQ_CONTINUATION_BIT = VLQ_BASE; // 0b100000
+
+/**
+ * Convert an integer to sign-magnitude representation for VLQ encoding.
+ * The least significant bit stores the sign (1 = negative).
+ */
+const toVlqSigned = (value: number): number => {
+  return value < 0 ? (-value << 1) + 1 : (value << 1) + 0;
+};
+
+/**
+ * Convert from sign-magnitude VLQ representation back to a signed integer.
+ */
+const fromVlqSigned = (value: number): number => {
+  const isNegative = (value & 1) === 1;
+  const shifted = value >> 1;
+  return isNegative ? -shifted : shifted;
+};
+
+/**
+ * Encode a single integer to a Base64 VLQ string.
+ */
+export const encodeVlq = (value: number): string => {
+  let vlq = toVlqSigned(value);
+  let encoded = "";
+
+  // Iteratively extract 5-bit digits with continuation bits
+  for (;;) {
+    let digit = vlq & VLQ_BASE_MASK;
+    vlq >>>= VLQ_BASE_SHIFT;
+    if (vlq > 0) {
+      digit |= VLQ_CONTINUATION_BIT;
+    }
+    encoded += BASE64_CHARS[digit];
+    if (vlq <= 0) {
+      break;
+    }
+  }
+
+  return encoded;
+};
+
+/**
+ * Decode a single VLQ value from an encoded string starting at a given position.
+ * Returns the decoded value and the number of characters consumed.
+ */
+export const decodeVlq = (
+  encoded: string,
+  pos: number,
+): { readonly value: number; readonly length: number } => {
+  let result = 0;
+  let shift = 0;
+  let continuation = true;
+  let charsConsumed = 0;
+
+  // Iteratively read 6-bit characters, extract 5-bit payload + continuation bit
+  for (let i = pos; continuation && i < encoded.length; i++) {
+    const char = encoded[i];
+    const digit = charToInt.get(char);
+    if (digit === undefined) {
+      throw new Error(`Invalid Base64 VLQ character: ${char}`);
+    }
+    charsConsumed++;
+    continuation = (digit & VLQ_CONTINUATION_BIT) !== 0;
+    result += (digit & VLQ_BASE_MASK) << shift;
+    shift += VLQ_BASE_SHIFT;
+  }
+
+  if (continuation) {
+    throw new Error("Unexpected end of VLQ encoded string");
+  }
+
+  return { value: fromVlqSigned(result), length: charsConsumed };
+};
+
+/**
+ * Encode a segment (array of field values) to a VLQ string.
+ */
+export const encodeSegment = (segment: ReadonlyArray<number>): string => {
+  let result = "";
+  for (let i = 0; i < segment.length; i++) {
+    result += encodeVlq(segment[i]);
+  }
+  return result;
+};
+
+/**
+ * Decode a full source map mappings string into a structured representation.
+ * Returns an array of lines, each containing an array of segments,
+ * each segment being an array of relative field values.
+ */
+export const decodeMappings = (
+  mappings: string,
+): ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>> => {
+  const lines: Array<ReadonlyArray<ReadonlyArray<number>>> = [];
+  const lineStrings = mappings.split(";");
+
+  for (let lineIdx = 0; lineIdx < lineStrings.length; lineIdx++) {
+    const lineStr = lineStrings[lineIdx];
+    const segments: Array<ReadonlyArray<number>> = [];
+
+    if (lineStr.length === 0) {
+      lines.push(segments);
+      continue;
+    }
+
+    const segmentStrings = lineStr.split(",");
+    for (let segIdx = 0; segIdx < segmentStrings.length; segIdx++) {
+      const segStr = segmentStrings[segIdx];
+      const fields: Array<number> = [];
+      let pos = 0;
+
+      for (; pos < segStr.length; ) {
+        const decoded = decodeVlq(segStr, pos);
+        fields.push(decoded.value);
+        pos += decoded.length;
+      }
+
+      segments.push(fields);
+    }
+
+    lines.push(segments);
+  }
+
+  return lines;
+};
+
+/**
+ * Encode a structured mappings representation back to a mappings string.
+ * This is the inverse of decodeMappings.
+ */
+export const encodeMappings = (
+  decoded: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>,
+): string => {
+  const lineStrings: Array<string> = [];
+
+  for (let lineIdx = 0; lineIdx < decoded.length; lineIdx++) {
+    const line = decoded[lineIdx];
+    const segmentStrings: Array<string> = [];
+
+    for (let segIdx = 0; segIdx < line.length; segIdx++) {
+      segmentStrings.push(encodeSegment(line[segIdx]));
+    }
+
+    lineStrings.push(segmentStrings.join(","));
+  }
+
+  return lineStrings.join(";");
+};

--- a/tests/unit/sourcemap/vlq.test.ts
+++ b/tests/unit/sourcemap/vlq.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeVlq,
+  decodeVlq,
+  encodeSegment,
+  decodeMappings,
+  encodeMappings,
+} from "../../../src/sourcemap/vlq.js";
+
+describe("encodeVlq", () => {
+  it('should encode 0 to "A"', () => {
+    expect(encodeVlq(0)).toBe("A");
+  });
+
+  it('should encode 1 to "C"', () => {
+    expect(encodeVlq(1)).toBe("C");
+  });
+
+  it('should encode -1 to "D"', () => {
+    expect(encodeVlq(-1)).toBe("D");
+  });
+
+  it("should encode small positive numbers", () => {
+    expect(encodeVlq(2)).toBe("E");
+    expect(encodeVlq(3)).toBe("G");
+    expect(encodeVlq(15)).toBe("e");
+  });
+
+  it("should encode small negative numbers", () => {
+    expect(encodeVlq(-2)).toBe("F");
+    expect(encodeVlq(-3)).toBe("H");
+    expect(encodeVlq(-15)).toBe("f");
+  });
+
+  it("should encode large positive numbers requiring continuation", () => {
+    // 16 = 0b10000 -> signed: 0b100000 -> needs two chars
+    expect(encodeVlq(16)).toBe("gB");
+    expect(encodeVlq(100)).toBe("oG");
+    expect(encodeVlq(1000)).toBe("w+B");
+  });
+
+  it("should encode large negative numbers requiring continuation", () => {
+    expect(encodeVlq(-16)).toBe("hB");
+    expect(encodeVlq(-100)).toBe("pG");
+    expect(encodeVlq(-1000)).toBe("x+B");
+  });
+});
+
+describe("decodeVlq", () => {
+  it('should decode "A" to 0', () => {
+    const result = decodeVlq("A", 0);
+    expect(result.value).toBe(0);
+    expect(result.length).toBe(1);
+  });
+
+  it('should decode "C" to 1', () => {
+    const result = decodeVlq("C", 0);
+    expect(result.value).toBe(1);
+    expect(result.length).toBe(1);
+  });
+
+  it('should decode "D" to -1', () => {
+    const result = decodeVlq("D", 0);
+    expect(result.value).toBe(-1);
+    expect(result.length).toBe(1);
+  });
+
+  it("should decode multi-character VLQ values", () => {
+    const result = decodeVlq("gB", 0);
+    expect(result.value).toBe(16);
+    expect(result.length).toBe(2);
+  });
+
+  it("should decode from a given position", () => {
+    const result = decodeVlq("ACE", 1);
+    expect(result.value).toBe(1);
+    expect(result.length).toBe(1);
+  });
+
+  it("should throw on invalid characters", () => {
+    expect(() => decodeVlq("!", 0)).toThrow("Invalid Base64 VLQ character");
+  });
+
+  it("should throw on unexpected end of string", () => {
+    // 'g' has continuation bit set but string ends
+    expect(() => decodeVlq("g", 0)).toThrow(
+      "Unexpected end of VLQ encoded string",
+    );
+  });
+
+  it("should round-trip with encodeVlq for various values", () => {
+    const testValues = [
+      0, 1, -1, 15, -15, 16, -16, 100, -100, 1000, -1000, 32767, -32768,
+    ];
+    for (const val of testValues) {
+      const encoded = encodeVlq(val);
+      const decoded = decodeVlq(encoded, 0);
+      expect(decoded.value).toBe(val);
+      expect(decoded.length).toBe(encoded.length);
+    }
+  });
+});
+
+describe("encodeSegment", () => {
+  it("should encode an empty segment", () => {
+    expect(encodeSegment([])).toBe("");
+  });
+
+  it("should encode a single-field segment", () => {
+    expect(encodeSegment([0])).toBe("A");
+    expect(encodeSegment([1])).toBe("C");
+  });
+
+  it("should encode a 4-field segment", () => {
+    // [0, 0, 0, 0] -> "AAAA"
+    expect(encodeSegment([0, 0, 0, 0])).toBe("AAAA");
+  });
+
+  it("should encode a 5-field segment", () => {
+    // [0, 0, 0, 0, 0] -> "AAAAA"
+    expect(encodeSegment([0, 0, 0, 0, 0])).toBe("AAAAA");
+  });
+
+  it("should encode a segment with mixed values", () => {
+    const segment = [1, 0, 0, 0];
+    const encoded = encodeSegment(segment);
+    expect(encoded).toBe("CAAA");
+  });
+
+  it("should round-trip with decodeVlq for complex segments", () => {
+    const segment = [5, -3, 10, -7, 2];
+    const encoded = encodeSegment(segment);
+
+    // Manually decode the segment
+    const decoded: Array<number> = [];
+    let pos = 0;
+    for (let i = 0; i < segment.length; i++) {
+      const result = decodeVlq(encoded, pos);
+      decoded.push(result.value);
+      pos += result.length;
+    }
+    expect(decoded).toEqual(segment);
+  });
+});
+
+describe("decodeMappings", () => {
+  it("should decode empty mappings string", () => {
+    const result = decodeMappings("");
+    expect(result).toEqual([[]]);
+  });
+
+  it("should decode a single segment", () => {
+    const result = decodeMappings("AAAA");
+    expect(result).toEqual([[[0, 0, 0, 0]]]);
+  });
+
+  it("should decode multiple segments on one line", () => {
+    const result = decodeMappings("AAAA,CAAA");
+    expect(result).toEqual([
+      [
+        [0, 0, 0, 0],
+        [1, 0, 0, 0],
+      ],
+    ]);
+  });
+
+  it("should decode multiple lines", () => {
+    const result = decodeMappings("AAAA;CAAA");
+    expect(result).toEqual([[[0, 0, 0, 0]], [[1, 0, 0, 0]]]);
+  });
+
+  it("should handle empty lines", () => {
+    const result = decodeMappings("AAAA;;CAAA");
+    expect(result).toEqual([[[0, 0, 0, 0]], [], [[1, 0, 0, 0]]]);
+  });
+
+  it("should decode a realistic mappings string", () => {
+    // A simple but realistic mapping
+    const mappings = "AACA,SAAS";
+    const result = decodeMappings(mappings);
+    expect(result.length).toBe(1);
+    expect(result[0].length).toBe(2);
+    expect(result[0][0]).toEqual([0, 0, 1, 0]);
+    expect(result[0][1]).toEqual([9, 0, 0, 9]);
+  });
+
+  it("should decode segments with 5 fields (names)", () => {
+    const mappings = "AAAAA";
+    const result = decodeMappings(mappings);
+    expect(result).toEqual([[[0, 0, 0, 0, 0]]]);
+  });
+
+  it("should decode segments with 1 field (column only)", () => {
+    const mappings = "A";
+    const result = decodeMappings(mappings);
+    expect(result).toEqual([[[0]]]);
+  });
+});
+
+describe("encodeMappings", () => {
+  it("should encode empty structure", () => {
+    expect(encodeMappings([[]])).toBe("");
+  });
+
+  it("should encode a single segment", () => {
+    expect(encodeMappings([[[0, 0, 0, 0]]])).toBe("AAAA");
+  });
+
+  it("should encode multiple segments", () => {
+    expect(
+      encodeMappings([
+        [
+          [0, 0, 0, 0],
+          [1, 0, 0, 0],
+        ],
+      ]),
+    ).toBe("AAAA,CAAA");
+  });
+
+  it("should encode multiple lines", () => {
+    expect(encodeMappings([[[0, 0, 0, 0]], [[1, 0, 0, 0]]])).toBe("AAAA;CAAA");
+  });
+
+  it("should encode empty lines", () => {
+    expect(encodeMappings([[[0, 0, 0, 0]], [], [[1, 0, 0, 0]]])).toBe(
+      "AAAA;;CAAA",
+    );
+  });
+
+  it("should round-trip with decodeMappings", () => {
+    const testCases = [
+      "AAAA",
+      "AAAA,CAAA",
+      "AAAA;CAAA",
+      "AAAA;;CAAA",
+      "AACA,SAAS",
+      "AAAAA",
+      "A",
+      "",
+    ];
+
+    for (const original of testCases) {
+      const decoded = decodeMappings(original);
+      const reencoded = encodeMappings(decoded);
+      expect(reencoded).toBe(original);
+    }
+  });
+
+  it("should round-trip a complex realistic mapping", () => {
+    // Multi-line mapping with various segment sizes
+    const original = "AAAA,IAAM,KAAK;AACA,MAAI;AACA";
+    const decoded = decodeMappings(original);
+    const reencoded = encodeMappings(decoded);
+    expect(reencoded).toBe(original);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements Base64 VLQ encoding/decoding for source map mappings (`src/sourcemap/vlq.ts`)
- Exports: `encodeVlq`, `decodeVlq`, `encodeSegment`, `decodeMappings`, `encodeMappings`
- Full unit test suite with 36 tests covering encode/decode, round-trips, edge cases, and error paths

## Test plan
- [x] All 36 unit tests pass (`npx vitest run tests/unit/sourcemap/vlq.test.ts`)
- [x] 100% code coverage on `src/sourcemap/vlq.ts`
- [x] TypeScript strict mode typecheck passes
- [x] Prettier formatting applied

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)