### PR TITLE
feat: source map composition and output modes

### DIFF
--- a/src/sourcemap/compose.ts
+++ b/src/sourcemap/compose.ts
@@ -1,0 +1,305 @@
+/**
+ * Source map composition for multi-transform pipelines.
+ *
+ * When multiple transforms are applied (e.g., plugin transforms), their
+ * source maps must be composed/remapped to trace back to the original source.
+ *
+ * @module sourcemap/compose
+ */
+
+import { decodeMappings, encodeMappings } from "./vlq.js";
+
+/**
+ * A decoded source map with structured numeric mappings.
+ */
+export interface DecodedSourceMap {
+  readonly version: 3;
+  readonly sources: ReadonlyArray<string>;
+  readonly sourcesContent?: ReadonlyArray<string | null>;
+  readonly names: ReadonlyArray<string>;
+  readonly mappings: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+}
+
+/**
+ * A raw source map with VLQ-encoded mappings string.
+ */
+export interface RawSourceMap {
+  readonly version: 3;
+  readonly sources: ReadonlyArray<string>;
+  readonly sourcesContent?: ReadonlyArray<string | null>;
+  readonly names: ReadonlyArray<string>;
+  readonly mappings: string;
+}
+
+/**
+ * Decode a raw source map's VLQ mappings into numeric arrays.
+ * Converts relative segment values to absolute positions.
+ */
+export const decodeSourceMap = (map: RawSourceMap): DecodedSourceMap => {
+  const relativeMappings = decodeMappings(map.mappings);
+  const absoluteMappings: Array<Array<Array<number>>> = [];
+
+  let prevSourceIndex = 0;
+  let prevOriginalLine = 0;
+  let prevOriginalColumn = 0;
+  let prevNameIndex = 0;
+
+  for (let lineIdx = 0; lineIdx < relativeMappings.length; lineIdx++) {
+    const line = relativeMappings[lineIdx];
+    const absoluteLine: Array<Array<number>> = [];
+    let prevGeneratedColumn = 0;
+
+    for (let segIdx = 0; segIdx < line.length; segIdx++) {
+      const segment = line[segIdx];
+      const absoluteSegment: Array<number> = [];
+
+      // Generated column (relative within line)
+      prevGeneratedColumn += segment[0];
+      absoluteSegment.push(prevGeneratedColumn);
+
+      if (segment.length >= 4) {
+        // Source index
+        prevSourceIndex += segment[1];
+        absoluteSegment.push(prevSourceIndex);
+
+        // Original line
+        prevOriginalLine += segment[2];
+        absoluteSegment.push(prevOriginalLine);
+
+        // Original column
+        prevOriginalColumn += segment[3];
+        absoluteSegment.push(prevOriginalColumn);
+
+        // Name index (optional 5th field)
+        if (segment.length >= 5) {
+          prevNameIndex += segment[4];
+          absoluteSegment.push(prevNameIndex);
+        }
+      }
+
+      absoluteLine.push(absoluteSegment);
+    }
+
+    absoluteMappings.push(absoluteLine);
+  }
+
+  return {
+    version: 3,
+    sources: map.sources,
+    sourcesContent: map.sourcesContent,
+    names: map.names,
+    mappings: absoluteMappings,
+  };
+};
+
+/**
+ * Encode a decoded source map back to a raw source map with VLQ mappings.
+ * Converts absolute positions back to relative segment values.
+ */
+export const encodeSourceMap = (map: DecodedSourceMap): RawSourceMap => {
+  const relativeMappings: Array<Array<Array<number>>> = [];
+
+  let prevSourceIndex = 0;
+  let prevOriginalLine = 0;
+  let prevOriginalColumn = 0;
+  let prevNameIndex = 0;
+
+  for (let lineIdx = 0; lineIdx < map.mappings.length; lineIdx++) {
+    const line = map.mappings[lineIdx];
+    const relativeLine: Array<Array<number>> = [];
+    let prevGeneratedColumn = 0;
+
+    for (let segIdx = 0; segIdx < line.length; segIdx++) {
+      const segment = line[segIdx];
+      const relativeSegment: Array<number> = [];
+
+      // Generated column (relative within line)
+      relativeSegment.push(segment[0] - prevGeneratedColumn);
+      prevGeneratedColumn = segment[0];
+
+      if (segment.length >= 4) {
+        // Source index
+        relativeSegment.push(segment[1] - prevSourceIndex);
+        prevSourceIndex = segment[1];
+
+        // Original line
+        relativeSegment.push(segment[2] - prevOriginalLine);
+        prevOriginalLine = segment[2];
+
+        // Original column
+        relativeSegment.push(segment[3] - prevOriginalColumn);
+        prevOriginalColumn = segment[3];
+
+        // Name index (optional 5th field)
+        if (segment.length >= 5) {
+          relativeSegment.push(segment[4] - prevNameIndex);
+          prevNameIndex = segment[4];
+        }
+      }
+
+      relativeLine.push(relativeSegment);
+    }
+
+    relativeMappings.push(relativeLine);
+  }
+
+  return {
+    version: 3,
+    sources: map.sources,
+    sourcesContent: map.sourcesContent,
+    names: map.names,
+    mappings: encodeMappings(relativeMappings),
+  };
+};
+
+/**
+ * Binary search for the last segment in a line whose generated column
+ * is less than or equal to the target column.
+ */
+const findSegmentForColumn = (
+  segments: ReadonlyArray<ReadonlyArray<number>>,
+  targetColumn: number,
+): ReadonlyArray<number> | null => {
+  let low = 0;
+  let high = segments.length - 1;
+  let result: ReadonlyArray<number> | null = null;
+
+  for (; low <= high; ) {
+    const mid = (low + high) >>> 1;
+    const midColumn = segments[mid][0];
+
+    if (midColumn <= targetColumn) {
+      result = segments[mid];
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Compose/remap two source maps: if transform A produces mapA and
+ * transform B (applied to A's output) produces mapB, the composed map
+ * traces from B's output back to A's original input.
+ *
+ * Both maps must be in decoded (absolute) form.
+ */
+export const composeSourceMaps = (
+  mapA: DecodedSourceMap,
+  mapB: DecodedSourceMap,
+): DecodedSourceMap => {
+  const composedMappings: Array<Array<Array<number>>> = [];
+  const composedSources: Array<string> = [...mapA.sources];
+  const composedSourcesContent: Array<string | null> = mapA.sourcesContent
+    ? [...mapA.sourcesContent]
+    : [];
+  const composedNames: Array<string> = [...mapA.names];
+
+  // Build name index lookup for mapA
+  const nameIndexMap = new Map<string, number>();
+  for (let i = 0; i < composedNames.length; i++) {
+    nameIndexMap.set(composedNames[i], i);
+  }
+
+  for (let lineIdx = 0; lineIdx < mapB.mappings.length; lineIdx++) {
+    const lineB = mapB.mappings[lineIdx];
+    const composedLine: Array<Array<number>> = [];
+
+    for (let segIdx = 0; segIdx < lineB.length; segIdx++) {
+      const segB = lineB[segIdx];
+
+      // Segment with only generated column (no source info)
+      if (segB.length < 4) {
+        composedLine.push([segB[0]]);
+        continue;
+      }
+
+      // segB maps to a position in mapA's output
+      // segB[1] = source index in mapB (should be 0 for single-source chains)
+      // segB[2] = original line in mapA's output
+      // segB[3] = original column in mapA's output
+      const targetLine = segB[2];
+      const targetColumn = segB[3];
+
+      // Look up this position in mapA
+      if (targetLine < mapA.mappings.length) {
+        const lineA = mapA.mappings[targetLine];
+        const segA = findSegmentForColumn(lineA, targetColumn);
+
+        if (segA !== null && segA.length >= 4) {
+          // Found the original position in mapA
+          const composedSegment: Array<number> = [
+            segB[0], // generated column in final output
+            segA[1], // source index from mapA
+            segA[2], // original line from mapA
+            segA[3], // original column from mapA
+          ];
+
+          // Prefer name from mapA if available, otherwise from mapB
+          if (segA.length >= 5) {
+            composedSegment.push(segA[4]);
+          } else if (segB.length >= 5) {
+            const nameB = mapB.names[segB[4]];
+            if (nameB !== undefined) {
+              let nameIdx = nameIndexMap.get(nameB);
+              if (nameIdx === undefined) {
+                nameIdx = composedNames.length;
+                composedNames.push(nameB);
+                nameIndexMap.set(nameB, nameIdx);
+              }
+              composedSegment.push(nameIdx);
+            }
+          }
+
+          composedLine.push(composedSegment);
+        } else {
+          // No mapping found in mapA; emit segment without source info
+          composedLine.push([segB[0]]);
+        }
+      } else {
+        // Target line beyond mapA's range
+        composedLine.push([segB[0]]);
+      }
+    }
+
+    composedMappings.push(composedLine);
+  }
+
+  return {
+    version: 3,
+    sources: composedSources,
+    sourcesContent:
+      composedSourcesContent.length > 0 ? composedSourcesContent : undefined,
+    names: composedNames,
+    mappings: composedMappings,
+  };
+};
+
+/**
+ * Compose multiple source maps in order (transforms applied left to right).
+ * Filters out null entries. Returns null if no valid maps remain.
+ */
+export const composeMultipleMaps = (
+  maps: ReadonlyArray<DecodedSourceMap | null>,
+): DecodedSourceMap | null => {
+  const validMaps: Array<DecodedSourceMap> = [];
+  for (let i = 0; i < maps.length; i++) {
+    const map = maps[i];
+    if (map !== null) {
+      validMaps.push(map);
+    }
+  }
+
+  if (validMaps.length === 0) {
+    return null;
+  }
+
+  let result = validMaps[0];
+  for (let i = 1; i < validMaps.length; i++) {
+    result = composeSourceMaps(result, validMaps[i]);
+  }
+
+  return result;
+};

--- a/src/sourcemap/output.ts
+++ b/src/sourcemap/output.ts
@@ -1,0 +1,164 @@
+/**
+ * Source map output mode handling.
+ *
+ * Supports multiple output modes: normal (external file with comment),
+ * inline (data URL), hidden (no comment), and disabled (no map).
+ *
+ * @module sourcemap/output
+ */
+
+import type { RawSourceMap } from "./compose.js";
+
+/**
+ * Source map output mode:
+ * - true: normal mode (external .map file, appends sourceMappingURL comment)
+ * - 'inline': embeds the source map as a base64 data URL in the code
+ * - 'hidden': generates the .map file but does not append a comment
+ * - false: disables source map generation entirely
+ */
+export type SourcemapMode = boolean | "inline" | "hidden";
+
+/**
+ * Configuration options for source map output generation.
+ */
+export interface SourcemapOutputOptions {
+  readonly mode: SourcemapMode;
+  readonly file?: string;
+  readonly sourcemapBaseUrl?: string;
+  readonly sourcemapExcludeSources?: boolean;
+  readonly sourcemapDebugIds?: boolean;
+  readonly sourcemapFile?: string;
+  readonly sourcemapPathTransform?: (path: string, mapPath: string) => string;
+  readonly sourcemapIgnoreList?: (path: string, mapPath: string) => boolean;
+}
+
+/**
+ * Result of source map output generation.
+ */
+export interface SourcemapOutputResult {
+  readonly code: string;
+  readonly map: RawSourceMap | null;
+  readonly mapFileName: string | null;
+}
+
+/**
+ * Process a source map by applying path transforms, ignore list,
+ * source exclusion, debug IDs, and base URL configuration.
+ */
+const processSourceMap = (
+  map: RawSourceMap,
+  options: SourcemapOutputOptions,
+): RawSourceMap => {
+  const mapPath = options.sourcemapFile ?? `${options.file ?? "unknown"}.map`;
+  let sources = [...map.sources];
+  let sourcesContent = map.sourcesContent ? [...map.sourcesContent] : undefined;
+  const ignoreList: Array<number> = [];
+
+  // Apply base URL to sources
+  if (options.sourcemapBaseUrl) {
+    const baseUrl = options.sourcemapBaseUrl.endsWith("/")
+      ? options.sourcemapBaseUrl
+      : `${options.sourcemapBaseUrl}/`;
+    sources = sources.map((source) => `${baseUrl}${source}`);
+  }
+
+  // Apply path transform
+  if (options.sourcemapPathTransform) {
+    const transform = options.sourcemapPathTransform;
+    sources = sources.map((source) => transform(source, mapPath));
+  }
+
+  // Build ignore list
+  if (options.sourcemapIgnoreList) {
+    const ignoreCheck = options.sourcemapIgnoreList;
+    for (let i = 0; i < sources.length; i++) {
+      if (ignoreCheck(sources[i], mapPath)) {
+        ignoreList.push(i);
+      }
+    }
+  }
+
+  // Exclude sources content if configured
+  if (options.sourcemapExcludeSources) {
+    sourcesContent = undefined;
+  }
+
+  const result: Record<string, unknown> = {
+    version: 3 as const,
+    sources,
+    names: map.names,
+    mappings: map.mappings,
+  };
+
+  if (sourcesContent !== undefined) {
+    result["sourcesContent"] = sourcesContent;
+  }
+
+  if (ignoreList.length > 0) {
+    result["x_google_ignoreList"] = ignoreList;
+  }
+
+  if (options.sourcemapDebugIds) {
+    // Generate a deterministic debug ID based on mappings content
+    result["debugId"] = generateDebugId(map.mappings);
+  }
+
+  return result as unknown as RawSourceMap;
+};
+
+/**
+ * Generate a deterministic debug ID from mappings content.
+ * Uses a simple hash to produce a UUID-like identifier.
+ */
+const generateDebugId = (mappings: string): string => {
+  let hash = 0;
+  for (let i = 0; i < mappings.length; i++) {
+    const char = mappings.charCodeAt(i);
+    hash = ((hash << 5) - hash + char) | 0;
+  }
+  const hex = Math.abs(hash).toString(16).padStart(8, "0");
+  return `${hex.slice(0, 8)}-${hex.slice(0, 4)}-4${hex.slice(1, 4)}-8${hex.slice(0, 3)}-${hex.slice(0, 12).padEnd(12, "0")}`;
+};
+
+/**
+ * Generate the source map output based on the configured mode.
+ *
+ * @param map - The raw source map to output
+ * @param code - The generated code string
+ * @param options - Output configuration options
+ * @returns The processed code, map, and map file name
+ */
+export const generateSourcemapOutput = (
+  map: RawSourceMap,
+  code: string,
+  options: SourcemapOutputOptions,
+): SourcemapOutputResult => {
+  if (!options.mode) {
+    return { code, map: null, mapFileName: null };
+  }
+
+  // Apply transforms: path transform, ignore list, exclude sources, debug IDs
+  const processedMap = processSourceMap(map, options);
+
+  if (options.mode === "inline") {
+    // Append inline source map as data URL
+    const encoded = Buffer.from(JSON.stringify(processedMap)).toString(
+      "base64",
+    );
+    const inlineCode = `${code}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${encoded}`;
+    return { code: inlineCode, map: null, mapFileName: null };
+  }
+
+  if (options.mode === "hidden") {
+    // Don't append sourceMappingURL comment
+    const mapFileName =
+      options.sourcemapFile ?? `${options.file ?? "unknown"}.map`;
+    return { code, map: processedMap, mapFileName };
+  }
+
+  // Normal mode (true): append sourceMappingURL comment
+  const mapFileName =
+    options.sourcemapFile ?? `${options.file ?? "unknown"}.map`;
+  const withComment = `${code}\n//# sourceMappingURL=${mapFileName}`;
+  return { code: withComment, map: processedMap, mapFileName };
+};

--- a/tests/unit/sourcemap/compose.test.ts
+++ b/tests/unit/sourcemap/compose.test.ts
@@ -1,0 +1,632 @@
+/**
+ * Tests for source map composition.
+ *
+ * @module tests/unit/sourcemap/compose
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  decodeSourceMap,
+  encodeSourceMap,
+  composeSourceMaps,
+  composeMultipleMaps,
+  type DecodedSourceMap,
+  type RawSourceMap,
+} from "../../../src/sourcemap/compose.js";
+
+describe("sourcemap/compose", () => {
+  describe("decodeSourceMap", () => {
+    it("should decode a simple raw source map to absolute positions", () => {
+      const raw: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: "AAAA,EAAC;ACDE",
+      };
+
+      const decoded = decodeSourceMap(raw);
+
+      expect(decoded.version).toBe(3);
+      expect(decoded.sources).toEqual(["input.js"]);
+      expect(decoded.names).toEqual([]);
+      expect(decoded.mappings.length).toBe(2);
+      // First line, first segment: [0, 0, 0, 0]
+      expect(decoded.mappings[0][0]).toEqual([0, 0, 0, 0]);
+    });
+
+    it("should handle empty mappings", () => {
+      const raw: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: "",
+      };
+
+      const decoded = decodeSourceMap(raw);
+
+      expect(decoded.mappings).toEqual([[]]);
+    });
+
+    it("should decode mappings with multiple segments per line", () => {
+      const raw: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: "AAAA,EAAC,GAAE",
+      };
+
+      const decoded = decodeSourceMap(raw);
+
+      expect(decoded.mappings[0].length).toBe(3);
+      // First segment: col=0, source=0, origLine=0, origCol=0
+      expect(decoded.mappings[0][0]).toEqual([0, 0, 0, 0]);
+      // Second segment: col=0+2=2, source=0, origLine=0+0=0, origCol=0+1=1
+      expect(decoded.mappings[0][1]).toEqual([2, 0, 0, 1]);
+      // Third segment: col=2+3=5, source=0, origLine=0+0=0, origCol=1+2=3
+      expect(decoded.mappings[0][2]).toEqual([5, 0, 0, 3]);
+    });
+
+    it("should decode mappings with name index", () => {
+      const raw: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: ["foo"],
+        mappings: "AAAAA",
+      };
+
+      const decoded = decodeSourceMap(raw);
+
+      expect(decoded.mappings[0][0]).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it("should preserve sourcesContent", () => {
+      const raw: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        sourcesContent: ["const x = 1;"],
+        names: [],
+        mappings: "AAAA",
+      };
+
+      const decoded = decodeSourceMap(raw);
+
+      expect(decoded.sourcesContent).toEqual(["const x = 1;"]);
+    });
+
+    it("should handle multiple lines with empty lines", () => {
+      const raw: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: "AAAA;;AACA",
+      };
+
+      const decoded = decodeSourceMap(raw);
+
+      expect(decoded.mappings.length).toBe(3);
+      expect(decoded.mappings[1]).toEqual([]);
+    });
+
+    it("should handle segments with only generated column", () => {
+      const raw: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: "A",
+      };
+
+      const decoded = decodeSourceMap(raw);
+
+      expect(decoded.mappings[0][0]).toEqual([0]);
+    });
+  });
+
+  describe("encodeSourceMap", () => {
+    it("should encode a decoded source map back to raw form", () => {
+      const decoded: DecodedSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const raw = encodeSourceMap(decoded);
+
+      expect(raw.version).toBe(3);
+      expect(raw.sources).toEqual(["input.js"]);
+      expect(raw.mappings).toBe("AAAA");
+    });
+
+    it("should encode multiple segments per line", () => {
+      const decoded: DecodedSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: [
+          [
+            [0, 0, 0, 0],
+            [5, 0, 0, 5],
+          ],
+        ],
+      };
+
+      const raw = encodeSourceMap(decoded);
+
+      // Second segment: col delta=5, source delta=0, line delta=0, col delta=5
+      expect(raw.mappings).toBe("AAAA,KAAK");
+    });
+
+    it("should encode multiple lines", () => {
+      const decoded: DecodedSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]], [[0, 0, 1, 0]]],
+      };
+
+      const raw = encodeSourceMap(decoded);
+
+      expect(raw.mappings).toContain(";");
+    });
+
+    it("should encode empty lines", () => {
+      const decoded: DecodedSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]], [], [[0, 0, 2, 0]]],
+      };
+
+      const raw = encodeSourceMap(decoded);
+
+      expect(raw.mappings).toContain(";;");
+    });
+
+    it("should round-trip decode then encode", () => {
+      const original: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        sourcesContent: ["const x = 1;\nconst y = 2;"],
+        names: ["x"],
+        mappings: "AAAAA,EAAC;ACDE",
+      };
+
+      const decoded = decodeSourceMap(original);
+      const reEncoded = encodeSourceMap(decoded);
+
+      expect(reEncoded.mappings).toBe(original.mappings);
+      expect(reEncoded.sources).toEqual(original.sources);
+      expect(reEncoded.names).toEqual(original.names);
+    });
+
+    it("should encode segments with name index", () => {
+      const decoded: DecodedSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: ["foo"],
+        mappings: [[[0, 0, 0, 0, 0]]],
+      };
+
+      const raw = encodeSourceMap(decoded);
+      const reDecoded = decodeSourceMap(raw);
+
+      expect(reDecoded.mappings[0][0]).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it("should preserve sourcesContent in encoded map", () => {
+      const decoded: DecodedSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        sourcesContent: ["hello"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const raw = encodeSourceMap(decoded);
+
+      expect(raw.sourcesContent).toEqual(["hello"]);
+    });
+  });
+
+  describe("composeSourceMaps", () => {
+    it("should compose two simple identity-like maps", () => {
+      // mapA: line 0, col 0 -> source 0, line 0, col 0
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        sourcesContent: ["const x = 1;"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      // mapB: line 0, col 0 -> source 0, line 0, col 0 (in mapA's output)
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.version).toBe(3);
+      expect(composed.sources).toEqual(["original.js"]);
+      expect(composed.mappings[0][0][0]).toBe(0); // generated col
+      expect(composed.mappings[0][0][1]).toBe(0); // source index
+      expect(composed.mappings[0][0][2]).toBe(0); // original line
+      expect(composed.mappings[0][0][3]).toBe(0); // original col
+    });
+
+    it("should compose maps with column offsets", () => {
+      // mapA: col 0 -> orig col 0, col 5 -> orig col 10
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [
+          [
+            [0, 0, 0, 0],
+            [5, 0, 0, 10],
+          ],
+        ],
+      };
+
+      // mapB: col 0 -> intermediate col 5 (which maps to orig col 10 in mapA)
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 5]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.mappings[0][0]).toEqual([0, 0, 0, 10]);
+    });
+
+    it("should compose maps with line offsets", () => {
+      // mapA: line 0 -> orig line 0, line 1 -> orig line 5
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]], [[0, 0, 5, 0]]],
+      };
+
+      // mapB: maps to line 1 in mapA's output
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 1, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.mappings[0][0][2]).toBe(5); // original line from mapA
+    });
+
+    it("should handle segments without source info in mapB", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0], [5, 0, 0, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.mappings[0][0]).toEqual([0]);
+      expect(composed.mappings[0][1].length).toBeGreaterThanOrEqual(4);
+    });
+
+    it("should handle target line beyond mapA range", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      // mapB references line 99 which doesn't exist in mapA
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 99, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      // Should fall back to segment without source info
+      expect(composed.mappings[0][0]).toEqual([0]);
+    });
+
+    it("should handle empty line in mapA during lookup", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]], [], [[0, 0, 2, 0]]],
+      };
+
+      // mapB references line 1 which is empty in mapA
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 1, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      // Empty line means no segment found
+      expect(composed.mappings[0][0]).toEqual([0]);
+    });
+
+    it("should preserve names from mapA", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: ["myVar"],
+        mappings: [[[0, 0, 0, 0, 0]]],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.names).toContain("myVar");
+      expect(composed.mappings[0][0][4]).toBe(0);
+    });
+
+    it("should merge names from mapB when mapA has none", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: ["renamedVar"],
+        mappings: [[[0, 0, 0, 0, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.names).toContain("renamedVar");
+    });
+
+    it("should compose A -> B -> C (three transforms)", () => {
+      // A maps col 0 -> orig col 0
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [
+          [
+            [0, 0, 0, 0],
+            [10, 0, 0, 20],
+          ],
+        ],
+      };
+
+      // B maps col 0 -> A output col 10
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["a-output.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 10]]],
+      };
+
+      // C maps col 0 -> B output col 0
+      const mapC: DecodedSourceMap = {
+        version: 3,
+        sources: ["b-output.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const ab = composeSourceMaps(mapA, mapB);
+      const abc = composeSourceMaps(ab, mapC);
+
+      // Should trace back to original col 20
+      expect(abc.mappings[0][0][3]).toBe(20);
+      expect(abc.sources).toEqual(["original.js"]);
+    });
+
+    it("should handle multiple sources in mapA", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["file1.js", "file2.js"],
+        names: [],
+        mappings: [
+          [
+            [0, 0, 0, 0],
+            [10, 1, 5, 3],
+          ],
+        ],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 10]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.sources).toEqual(["file1.js", "file2.js"]);
+      expect(composed.mappings[0][0][1]).toBe(1); // source index 1
+      expect(composed.mappings[0][0][2]).toBe(5); // line from file2
+      expect(composed.mappings[0][0][3]).toBe(3); // col from file2
+    });
+
+    it("should preserve sourcesContent from mapA", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        sourcesContent: ["const x = 1;"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.sourcesContent).toEqual(["const x = 1;"]);
+    });
+
+    it("should handle mapA without sourcesContent", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const composed = composeSourceMaps(mapA, mapB);
+
+      expect(composed.sourcesContent).toBeUndefined();
+    });
+  });
+
+  describe("composeMultipleMaps", () => {
+    it("should return null for empty array", () => {
+      const result = composeMultipleMaps([]);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for array of all nulls", () => {
+      const result = composeMultipleMaps([null, null, null]);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return the single map if only one non-null", () => {
+      const map: DecodedSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const result = composeMultipleMaps([null, map, null]);
+
+      expect(result).toEqual(map);
+    });
+
+    it("should compose multiple maps in order", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [
+          [
+            [0, 0, 0, 0],
+            [10, 0, 0, 20],
+          ],
+        ],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["a-output.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 10]]],
+      };
+
+      const mapC: DecodedSourceMap = {
+        version: 3,
+        sources: ["b-output.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+
+      const result = composeMultipleMaps([mapA, mapB, mapC]);
+
+      expect(result).not.toBeNull();
+      expect(result!.mappings[0][0][3]).toBe(20);
+    });
+
+    it("should filter out nulls between valid maps", () => {
+      const mapA: DecodedSourceMap = {
+        version: 3,
+        sources: ["original.js"],
+        names: [],
+        mappings: [
+          [
+            [0, 0, 0, 0],
+            [5, 0, 0, 10],
+          ],
+        ],
+      };
+
+      const mapB: DecodedSourceMap = {
+        version: 3,
+        sources: ["intermediate.js"],
+        names: [],
+        mappings: [[[0, 0, 0, 5]]],
+      };
+
+      const result = composeMultipleMaps([mapA, null, mapB]);
+
+      expect(result).not.toBeNull();
+      expect(result!.mappings[0][0][3]).toBe(10);
+    });
+
+    it("should compose identity maps correctly", () => {
+      // Identity map: each position maps to itself
+      const identity: DecodedSourceMap = {
+        version: 3,
+        sources: ["file.js"],
+        names: [],
+        mappings: [
+          [
+            [0, 0, 0, 0],
+            [5, 0, 0, 5],
+            [10, 0, 0, 10],
+          ],
+        ],
+      };
+
+      const result = composeMultipleMaps([identity, identity]);
+
+      expect(result).not.toBeNull();
+      // Composing identity with identity should still map to same positions
+      expect(result!.mappings[0][0][3]).toBe(0);
+      expect(result!.mappings[0][1][3]).toBe(5);
+      expect(result!.mappings[0][2][3]).toBe(10);
+    });
+  });
+});

--- a/tests/unit/sourcemap/output.test.ts
+++ b/tests/unit/sourcemap/output.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Tests for source map output modes.
+ *
+ * @module tests/unit/sourcemap/output
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateSourcemapOutput,
+  type SourcemapMode,
+  type SourcemapOutputOptions,
+} from "../../../src/sourcemap/output.js";
+import type { RawSourceMap } from "../../../src/sourcemap/compose.js";
+
+const createTestMap = (): RawSourceMap => ({
+  version: 3,
+  sources: ["input.js"],
+  sourcesContent: ["const x = 1;"],
+  names: ["x"],
+  mappings: "AAAA",
+});
+
+describe("sourcemap/output", () => {
+  describe("generateSourcemapOutput - mode: false", () => {
+    it("should return code unchanged with no map", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = { mode: false, file: "out.js" };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.code).toBe(code);
+      expect(result.map).toBeNull();
+      expect(result.mapFileName).toBeNull();
+    });
+
+    it("should not append any comment when disabled", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = { mode: false };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.code).not.toContain("sourceMappingURL");
+    });
+  });
+
+  describe("generateSourcemapOutput - mode: true (normal)", () => {
+    it("should append sourceMappingURL comment", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = { mode: true, file: "out.js" };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.code).toContain("//# sourceMappingURL=out.js.map");
+      expect(result.map).not.toBeNull();
+      expect(result.mapFileName).toBe("out.js.map");
+    });
+
+    it("should use sourcemapFile when specified", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapFile: "custom.map",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.code).toContain("//# sourceMappingURL=custom.map");
+      expect(result.mapFileName).toBe("custom.map");
+    });
+
+    it("should fallback to unknown.map when no file specified", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = { mode: true };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.mapFileName).toBe("unknown.map");
+    });
+
+    it("should include sources and names in output map", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = { mode: true, file: "out.js" };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map!.sources).toEqual(["input.js"]);
+      expect(result.map!.names).toEqual(["x"]);
+      expect(result.map!.mappings).toBe("AAAA");
+    });
+  });
+
+  describe("generateSourcemapOutput - mode: 'inline'", () => {
+    it("should embed source map as base64 data URL", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: "inline",
+        file: "out.js",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.code).toContain(
+        "//# sourceMappingURL=data:application/json;charset=utf-8;base64,",
+      );
+      expect(result.map).toBeNull();
+      expect(result.mapFileName).toBeNull();
+    });
+
+    it("should produce a valid base64-encoded JSON map", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: "inline",
+        file: "out.js",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const base64Part = result.code.split("base64,")[1];
+      const decoded = JSON.parse(
+        Buffer.from(base64Part, "base64").toString("utf-8"),
+      );
+
+      expect(decoded.version).toBe(3);
+      expect(decoded.sources).toBeDefined();
+      expect(decoded.mappings).toBeDefined();
+    });
+
+    it("should not produce a separate map file", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: "inline",
+        file: "out.js",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map).toBeNull();
+      expect(result.mapFileName).toBeNull();
+    });
+  });
+
+  describe("generateSourcemapOutput - mode: 'hidden'", () => {
+    it("should not append sourceMappingURL comment", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: "hidden",
+        file: "out.js",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.code).toBe(code);
+      expect(result.code).not.toContain("sourceMappingURL");
+    });
+
+    it("should still produce the map and map file name", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: "hidden",
+        file: "out.js",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map).not.toBeNull();
+      expect(result.mapFileName).toBe("out.js.map");
+    });
+
+    it("should use sourcemapFile when specified in hidden mode", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: "hidden",
+        file: "out.js",
+        sourcemapFile: "hidden.map",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.mapFileName).toBe("hidden.map");
+    });
+  });
+
+  describe("processSourceMap - path transforms", () => {
+    it("should apply sourcemapPathTransform to sources", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapPathTransform: (path: string) => `transformed/${path}`,
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map!.sources).toEqual(["transformed/input.js"]);
+    });
+
+    it("should pass map path to path transform", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const receivedPaths: Array<[string, string]> = [];
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapPathTransform: (path: string, mapPath: string) => {
+          receivedPaths.push([path, mapPath]);
+          return path;
+        },
+      };
+
+      generateSourcemapOutput(map, code, options);
+
+      expect(receivedPaths[0][1]).toBe("out.js.map");
+    });
+
+    it("should apply sourcemapBaseUrl to sources", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapBaseUrl: "https://example.com/sources",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map!.sources).toEqual([
+        "https://example.com/sources/input.js",
+      ]);
+    });
+
+    it("should handle sourcemapBaseUrl with trailing slash", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapBaseUrl: "https://example.com/sources/",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map!.sources).toEqual([
+        "https://example.com/sources/input.js",
+      ]);
+    });
+
+    it("should apply base URL before path transform", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapBaseUrl: "https://cdn.example.com",
+        sourcemapPathTransform: (path: string) => path.toUpperCase(),
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map!.sources).toEqual(["HTTPS://CDN.EXAMPLE.COM/INPUT.JS"]);
+    });
+  });
+
+  describe("processSourceMap - ignore list", () => {
+    it("should build x_google_ignoreList from predicate", () => {
+      const map: RawSourceMap = {
+        version: 3,
+        sources: ["src/app.js", "node_modules/lib.js", "src/util.js"],
+        sourcesContent: ["a", "b", "c"],
+        names: [],
+        mappings: "AAAA",
+      };
+      const code = "bundled code";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapIgnoreList: (path: string) => path.includes("node_modules"),
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["x_google_ignoreList"]).toEqual([1]);
+    });
+
+    it("should not include x_google_ignoreList when no sources match", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapIgnoreList: () => false,
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["x_google_ignoreList"]).toBeUndefined();
+    });
+
+    it("should pass map path to ignore list predicate", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const receivedMapPaths: Array<string> = [];
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapFile: "custom.js.map",
+        sourcemapIgnoreList: (_path: string, mapPath: string) => {
+          receivedMapPaths.push(mapPath);
+          return false;
+        },
+      };
+
+      generateSourcemapOutput(map, code, options);
+
+      expect(receivedMapPaths[0]).toBe("custom.js.map");
+    });
+  });
+
+  describe("processSourceMap - exclude sources", () => {
+    it("should remove sourcesContent when excludeSources is true", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapExcludeSources: true,
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["sourcesContent"]).toBeUndefined();
+    });
+
+    it("should keep sourcesContent when excludeSources is false", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapExcludeSources: false,
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["sourcesContent"]).toEqual(["const x = 1;"]);
+    });
+
+    it("should keep sourcesContent when excludeSources is undefined", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["sourcesContent"]).toEqual(["const x = 1;"]);
+    });
+  });
+
+  describe("processSourceMap - debug IDs", () => {
+    it("should add debugId when sourcemapDebugIds is true", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapDebugIds: true,
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["debugId"]).toBeDefined();
+      expect(typeof resultMap["debugId"]).toBe("string");
+    });
+
+    it("should not add debugId when sourcemapDebugIds is false", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapDebugIds: false,
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["debugId"]).toBeUndefined();
+    });
+
+    it("should generate deterministic debug IDs for same input", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "out.js",
+        sourcemapDebugIds: true,
+      };
+
+      const result1 = generateSourcemapOutput(map, code, options);
+      const result2 = generateSourcemapOutput(map, code, options);
+
+      const map1 = result1.map as unknown as Record<string, unknown>;
+      const map2 = result2.map as unknown as Record<string, unknown>;
+      expect(map1["debugId"]).toBe(map2["debugId"]);
+    });
+  });
+
+  describe("processSourceMap - map without sourcesContent", () => {
+    it("should handle map without sourcesContent gracefully", () => {
+      const map: RawSourceMap = {
+        version: 3,
+        sources: ["input.js"],
+        names: [],
+        mappings: "AAAA",
+      };
+      const code = "const x = 1;";
+      const options: SourcemapOutputOptions = { mode: true, file: "out.js" };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map).not.toBeNull();
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["sourcesContent"]).toBeUndefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty code string", () => {
+      const map = createTestMap();
+      const options: SourcemapOutputOptions = { mode: true, file: "out.js" };
+
+      const result = generateSourcemapOutput(map, "", options);
+
+      expect(result.code).toContain("//# sourceMappingURL=out.js.map");
+    });
+
+    it("should handle inline mode with empty code", () => {
+      const map = createTestMap();
+      const options: SourcemapOutputOptions = {
+        mode: "inline",
+        file: "out.js",
+      };
+
+      const result = generateSourcemapOutput(map, "", options);
+
+      expect(result.code).toContain("//# sourceMappingURL=data:");
+    });
+
+    it("should work with all options combined", () => {
+      const map: RawSourceMap = {
+        version: 3,
+        sources: ["src/app.js", "node_modules/dep.js"],
+        sourcesContent: ["app code", "dep code"],
+        names: ["fn"],
+        mappings: "AAAA",
+      };
+      const code = "bundled();";
+      const options: SourcemapOutputOptions = {
+        mode: true,
+        file: "dist/bundle.js",
+        sourcemapBaseUrl: "https://cdn.example.com",
+        sourcemapExcludeSources: true,
+        sourcemapDebugIds: true,
+        sourcemapPathTransform: (path: string) =>
+          path.replace("https://cdn.example.com/", "../"),
+        sourcemapIgnoreList: (path: string) => path.includes("node_modules"),
+      };
+
+      const result = generateSourcemapOutput(map, code, options);
+
+      expect(result.map).not.toBeNull();
+      expect(result.code).toContain("//# sourceMappingURL=");
+      const resultMap = result.map as unknown as Record<string, unknown>;
+      expect(resultMap["sourcesContent"]).toBeUndefined();
+      expect(resultMap["debugId"]).toBeDefined();
+    });
+
+    it("should handle mode as SourcemapMode type correctly", () => {
+      const map = createTestMap();
+      const code = "const x = 1;";
+
+      const modes: ReadonlyArray<SourcemapMode> = [
+        true,
+        false,
+        "inline",
+        "hidden",
+      ];
+
+      for (let i = 0; i < modes.length; i++) {
+        const options: SourcemapOutputOptions = {
+          mode: modes[i],
+          file: "out.js",
+        };
+        const result = generateSourcemapOutput(map, code, options);
+        expect(result.code).toBeDefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements source map composition (`src/sourcemap/compose.ts`) for multi-transform pipelines, enabling maps from sequential transforms to be remapped back to original source positions
- Implements source map output modes (`src/sourcemap/output.ts`) supporting normal (external file), inline (base64 data URL), hidden (no comment), and disabled modes with path transforms, ignore lists, debug IDs, and base URL configuration
- 63 new tests covering decode/encode round-trips, multi-map composition, all output modes, path transforms, ignore lists, and edge cases

Closes #67
Closes #69

## Test plan

- [x] All 63 new unit tests pass
- [x] Full test suite (3114 tests) passes
- [x] TypeScript strict mode typecheck passes
- [x] 100% coverage on new source files (`compose.ts`, `output.ts`)
- [x] Prettier formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)