### PR TITLE
feat: tree-shaking presets, deoptimization, and log side effects

### DIFF
--- a/src/tree-shaking/deoptimize.ts
+++ b/src/tree-shaking/deoptimize.ts
@@ -1,0 +1,208 @@
+/**
+ * @module tree-shaking/deoptimize
+ * @description Deoptimization detection for tree-shaking. When eval() or arguments
+ * are used in a scope, all bindings in that scope (and parent scopes for eval) must
+ * be preserved, preventing tree-shaking of those bindings.
+ *
+ * Uses iterative stack-based AST traversal to detect these patterns without recursion.
+ */
+
+import type * as AST from "../ast/types.js";
+import type { Scope, Binding } from "./scope.js";
+
+/** Reason a scope was deoptimized. */
+export type DeoptimizationReason = "eval" | "arguments";
+
+/** Result of deoptimization analysis for a module. */
+export interface DeoptimizationResult {
+  readonly hasEval: boolean;
+  readonly hasArguments: boolean;
+  readonly deoptimizedScopes: ReadonlyArray<{
+    readonly scope: Scope;
+    readonly reason: DeoptimizationReason;
+  }>;
+}
+
+/**
+ * Detect whether an AST contains any direct eval() calls.
+ * Uses iterative stack-based traversal.
+ *
+ * @param ast - The parsed Program AST node.
+ * @returns true if a direct eval() call is found.
+ */
+export const detectEvalUsage = (ast: AST.Program): boolean => {
+  const stack: Array<AST.BaseNode> = [];
+
+  for (let i = ast.body.length - 1; i >= 0; i--) {
+    stack.push(ast.body[i] as AST.BaseNode);
+  }
+
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+
+    // Check for direct eval() call: CallExpression with Identifier callee named "eval"
+    if (node.type === "CallExpression") {
+      const call = node as unknown as {
+        readonly callee: AST.BaseNode;
+        readonly arguments: ReadonlyArray<AST.BaseNode>;
+      };
+      if (
+        call.callee.type === "Identifier" &&
+        (call.callee as unknown as AST.Identifier).name === "eval"
+      ) {
+        return true;
+      }
+    }
+
+    // Push child nodes onto stack
+    const keys = Object.keys(node);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (key === "type" || key === "start" || key === "end" || key === "loc") {
+        continue;
+      }
+      const val = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(val)) {
+        for (let j = val.length - 1; j >= 0; j--) {
+          const item = val[j] as unknown;
+          if (
+            item !== null &&
+            typeof item === "object" &&
+            (item as { type?: string }).type !== undefined
+          ) {
+            stack.push(item as AST.BaseNode);
+          }
+        }
+      } else if (
+        val !== null &&
+        typeof val === "object" &&
+        (val as { type?: string }).type !== undefined
+      ) {
+        stack.push(val as AST.BaseNode);
+      }
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Detect whether an AST contains any references to `arguments` inside
+ * non-arrow function bodies. Arrow functions do not have their own `arguments`.
+ * Uses iterative stack-based traversal.
+ *
+ * @param ast - The parsed Program AST node.
+ * @returns true if `arguments` is referenced in a non-arrow function.
+ */
+export const detectArgumentsUsage = (ast: AST.Program): boolean => {
+  /** Stack entry tracks whether we are inside a non-arrow function. */
+  interface TraversalEntry {
+    readonly node: AST.BaseNode;
+    readonly inNonArrowFunction: boolean;
+  }
+
+  const stack: Array<TraversalEntry> = [];
+
+  for (let i = ast.body.length - 1; i >= 0; i--) {
+    stack.push({
+      node: ast.body[i] as AST.BaseNode,
+      inNonArrowFunction: false,
+    });
+  }
+
+  while (stack.length > 0) {
+    const { node, inNonArrowFunction } = stack.pop()!;
+
+    // Check for `arguments` identifier inside a non-arrow function
+    if (
+      node.type === "Identifier" &&
+      (node as unknown as AST.Identifier).name === "arguments" &&
+      inNonArrowFunction
+    ) {
+      return true;
+    }
+
+    // Determine context for children
+    let childContext = inNonArrowFunction;
+    if (
+      node.type === "FunctionDeclaration" ||
+      node.type === "FunctionExpression"
+    ) {
+      childContext = true;
+    } else if (node.type === "ArrowFunctionExpression") {
+      // Arrow functions inherit parent's arguments context, don't set new one
+      childContext = false;
+    }
+
+    // Push child nodes
+    const keys = Object.keys(node);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (key === "type" || key === "start" || key === "end" || key === "loc") {
+        continue;
+      }
+      const val = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(val)) {
+        for (let j = val.length - 1; j >= 0; j--) {
+          const item = val[j] as unknown;
+          if (
+            item !== null &&
+            typeof item === "object" &&
+            (item as { type?: string }).type !== undefined
+          ) {
+            stack.push({
+              node: item as AST.BaseNode,
+              inNonArrowFunction: childContext,
+            });
+          }
+        }
+      } else if (
+        val !== null &&
+        typeof val === "object" &&
+        (val as { type?: string }).type !== undefined
+      ) {
+        stack.push({
+          node: val as AST.BaseNode,
+          inNonArrowFunction: childContext,
+        });
+      }
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Mark all bindings in a scope as included (cannot be tree-shaken).
+ * When reason is "eval", also marks all parent scope bindings.
+ * When reason is "arguments", only marks the given scope's bindings.
+ *
+ * @param scope - The scope to deoptimize.
+ * @param reason - The reason for deoptimization.
+ */
+export const deoptimizeScope = (
+  scope: Scope,
+  reason: DeoptimizationReason,
+): void => {
+  if (reason === "eval") {
+    // eval can access any binding in the current scope and all parent scopes
+    let current: Scope | null = scope;
+    while (current !== null) {
+      const bindings: IterableIterator<Binding> = current.bindings.values();
+      let entry = bindings.next();
+      while (!entry.done) {
+        entry.value.isIncluded = true;
+        entry = bindings.next();
+      }
+      current = current.parent;
+    }
+  } else {
+    // arguments: only the current function scope's parameter bindings
+    const bindings: IterableIterator<Binding> = scope.bindings.values();
+    let entry = bindings.next();
+    while (!entry.done) {
+      entry.value.isIncluded = true;
+      entry = bindings.next();
+    }
+  }
+};

--- a/src/tree-shaking/log-side-effects.ts
+++ b/src/tree-shaking/log-side-effects.ts
@@ -1,0 +1,124 @@
+/**
+ * @module tree-shaking/log-side-effects
+ * @description Experimental side effect logging for tree-shaking diagnostics.
+ *
+ * When `experimentalLogSideEffects: true` is set, logs the first side effect
+ * found in each module with a code frame showing the exact location.
+ */
+
+import type * as AST from "../ast/types.js";
+
+/** Error code used for side effect log entries. */
+export const FIRST_SIDE_EFFECT = "FIRST_SIDE_EFFECT";
+
+/** Structured log entry for a detected side effect. */
+export interface SideEffectLogEntry {
+  readonly code: typeof FIRST_SIDE_EFFECT;
+  readonly message: string;
+  readonly id: string;
+  readonly pos: number;
+  readonly loc: {
+    readonly file: string;
+    readonly line: number;
+    readonly column: number;
+  };
+  readonly frame: string;
+}
+
+/**
+ * Generate a code frame around a given position in the source.
+ * Shows up to 2 lines of context before and after the target line,
+ * with a caret indicating the exact column.
+ *
+ * @param source - The full module source text.
+ * @param line - The 1-based line number.
+ * @param column - The 0-based column number.
+ * @returns A formatted code frame string.
+ */
+export const generateCodeFrame = (
+  source: string,
+  line: number,
+  column: number,
+): string => {
+  const lines = source.split("\n");
+  const startLine = Math.max(0, line - 3);
+  const endLine = Math.min(lines.length - 1, line + 1);
+  const frameLines: Array<string> = [];
+
+  for (let i = startLine; i <= endLine; i++) {
+    const lineNum = i + 1;
+    const prefix = lineNum === line ? "> " : "  ";
+    frameLines.push(`${prefix}${lineNum} | ${lines[i]}`);
+    if (lineNum === line) {
+      const padding = " ".repeat(
+        column + prefix.length + String(lineNum).length + 3,
+      );
+      frameLines.push(`${padding}^`);
+    }
+  }
+
+  return frameLines.join("\n");
+};
+
+/**
+ * Compute line and column from an offset position in source text.
+ *
+ * @param source - The full source text.
+ * @param pos - The 0-based character offset.
+ * @returns Object with 1-based line and 0-based column.
+ */
+export const positionFromOffset = (
+  source: string,
+  pos: number,
+): { readonly line: number; readonly column: number } => {
+  let line = 1;
+  let lastNewline = -1;
+
+  for (let i = 0; i < pos && i < source.length; i++) {
+    if (source[i] === "\n") {
+      line++;
+      lastNewline = i;
+    }
+  }
+
+  return { line, column: pos - lastNewline - 1 };
+};
+
+/**
+ * Log the first side effect found in a module. Creates a structured log entry
+ * with a code frame showing the location of the side effect.
+ *
+ * @param moduleId - The module identifier (file path or virtual ID).
+ * @param sideEffectNodes - Array of AST nodes that have side effects.
+ * @param source - The full module source text.
+ * @returns The log entry, or null if no side effect nodes are provided.
+ */
+export const logFirstSideEffect = (
+  moduleId: string,
+  sideEffectNodes: ReadonlyArray<AST.BaseNode>,
+  source: string,
+): SideEffectLogEntry | null => {
+  if (sideEffectNodes.length === 0) {
+    return null;
+  }
+
+  const firstNode = sideEffectNodes[0];
+  const pos = firstNode.start;
+  const { line, column } = positionFromOffset(source, pos);
+  const frame = generateCodeFrame(source, line, column);
+
+  const entry: SideEffectLogEntry = {
+    code: FIRST_SIDE_EFFECT,
+    message: `First side effect in ${moduleId} at line ${line}, column ${column}`,
+    id: moduleId,
+    pos,
+    loc: {
+      file: moduleId,
+      line,
+      column,
+    },
+    frame,
+  };
+
+  return entry;
+};

--- a/src/tree-shaking/options.ts
+++ b/src/tree-shaking/options.ts
@@ -1,0 +1,161 @@
+/**
+ * @module tree-shaking/options
+ * @description Tree-shaking presets and options normalization.
+ *
+ * Provides preset configurations (smallest, safest, recommended) and a
+ * normalizer that converts user input (boolean, preset string, or partial
+ * options object) into a fully resolved NormalizedTreeshakingOptions.
+ */
+
+import type {
+  TreeshakingPreset,
+  TreeshakingOptions,
+  NormalizedTreeshakingOptions,
+  HasModuleSideEffects,
+  ModuleSideEffectsOption,
+} from "../types.js";
+
+/** Internal representation of a preset before moduleSideEffects normalization. */
+interface RawPresetOptions {
+  readonly annotations: boolean;
+  readonly correctVarValueBeforeDeclaration: boolean;
+  readonly manualPureFunctions: ReadonlyArray<string>;
+  readonly moduleSideEffects: boolean;
+  readonly propertyReadSideEffects: boolean | "always";
+  readonly tryCatchDeoptimization: boolean;
+  readonly unknownGlobalSideEffects: boolean;
+}
+
+/** Preset definitions for tree-shaking configuration. */
+const PRESETS: Readonly<Record<TreeshakingPreset, RawPresetOptions>> = {
+  smallest: {
+    annotations: true,
+    correctVarValueBeforeDeclaration: true,
+    manualPureFunctions: [],
+    moduleSideEffects: false,
+    propertyReadSideEffects: false,
+    tryCatchDeoptimization: false,
+    unknownGlobalSideEffects: false,
+  },
+  safest: {
+    annotations: true,
+    correctVarValueBeforeDeclaration: true,
+    manualPureFunctions: [],
+    moduleSideEffects: true,
+    propertyReadSideEffects: true,
+    tryCatchDeoptimization: true,
+    unknownGlobalSideEffects: true,
+  },
+  recommended: {
+    annotations: true,
+    correctVarValueBeforeDeclaration: false,
+    manualPureFunctions: [],
+    moduleSideEffects: true,
+    propertyReadSideEffects: true,
+    tryCatchDeoptimization: true,
+    unknownGlobalSideEffects: false,
+  },
+};
+
+/**
+ * Normalize a moduleSideEffects option into a predicate function.
+ *
+ * @param option - The user-provided moduleSideEffects value.
+ * @returns A predicate function (id, external) => boolean.
+ */
+export const normalizeModuleSideEffects = (
+  option: ModuleSideEffectsOption | undefined,
+): HasModuleSideEffects => {
+  if (option === undefined || option === true) {
+    return () => true;
+  }
+  if (option === false) {
+    return () => false;
+  }
+  if (option === "no-external") {
+    return (_id: string, external: boolean) => !external;
+  }
+  if (Array.isArray(option)) {
+    const set = new Set<string>(option as ReadonlyArray<string>);
+    return (id: string) => set.has(id);
+  }
+  // It's already a function
+  return option as HasModuleSideEffects;
+};
+
+/**
+ * Get a preset configuration by name.
+ *
+ * @param preset - The preset name.
+ * @returns The raw preset options.
+ */
+export const getPreset = (preset: TreeshakingPreset): RawPresetOptions => {
+  return PRESETS[preset];
+};
+
+/**
+ * Normalize tree-shaking input into fully resolved options.
+ *
+ * Accepts:
+ * - `true` or `undefined`: uses 'recommended' preset
+ * - `false`: returns false (tree-shaking disabled)
+ * - A preset string ('smallest' | 'safest' | 'recommended')
+ * - A partial TreeshakingOptions object (merged over recommended or specified preset)
+ *
+ * @param input - The user-provided tree-shaking configuration.
+ * @returns Normalized options or false if tree-shaking is disabled.
+ */
+export const normalizeTreeshakeOptions = (
+  input: boolean | TreeshakingPreset | TreeshakingOptions | undefined,
+): NormalizedTreeshakingOptions | false => {
+  if (input === false) {
+    return false;
+  }
+
+  if (input === true || input === undefined) {
+    const preset = PRESETS.recommended;
+    return {
+      annotations: preset.annotations,
+      correctVarValueBeforeDeclaration: preset.correctVarValueBeforeDeclaration,
+      manualPureFunctions: preset.manualPureFunctions,
+      moduleSideEffects: normalizeModuleSideEffects(preset.moduleSideEffects),
+      propertyReadSideEffects: preset.propertyReadSideEffects,
+      tryCatchDeoptimization: preset.tryCatchDeoptimization,
+      unknownGlobalSideEffects: preset.unknownGlobalSideEffects,
+    };
+  }
+
+  if (typeof input === "string") {
+    const preset = PRESETS[input];
+    return {
+      annotations: preset.annotations,
+      correctVarValueBeforeDeclaration: preset.correctVarValueBeforeDeclaration,
+      manualPureFunctions: preset.manualPureFunctions,
+      moduleSideEffects: normalizeModuleSideEffects(preset.moduleSideEffects),
+      propertyReadSideEffects: preset.propertyReadSideEffects,
+      tryCatchDeoptimization: preset.tryCatchDeoptimization,
+      unknownGlobalSideEffects: preset.unknownGlobalSideEffects,
+    };
+  }
+
+  // Partial options object — merge over base preset
+  const basePresetName: TreeshakingPreset = input.preset ?? "recommended";
+  const base = PRESETS[basePresetName];
+
+  return {
+    annotations: input.annotations ?? base.annotations,
+    correctVarValueBeforeDeclaration:
+      input.correctVarValueBeforeDeclaration ??
+      base.correctVarValueBeforeDeclaration,
+    manualPureFunctions: input.manualPureFunctions ?? base.manualPureFunctions,
+    moduleSideEffects: normalizeModuleSideEffects(
+      input.moduleSideEffects ?? base.moduleSideEffects,
+    ),
+    propertyReadSideEffects:
+      input.propertyReadSideEffects ?? base.propertyReadSideEffects,
+    tryCatchDeoptimization:
+      input.tryCatchDeoptimization ?? base.tryCatchDeoptimization,
+    unknownGlobalSideEffects:
+      input.unknownGlobalSideEffects ?? base.unknownGlobalSideEffects,
+  };
+};

--- a/tests/unit/tree-shaking/treeshake-options.test.ts
+++ b/tests/unit/tree-shaking/treeshake-options.test.ts
@@ -1,0 +1,663 @@
+/**
+ * @module tests/unit/tree-shaking/treeshake-options
+ * @description Unit tests for tree-shaking deoptimization, options normalization,
+ * and experimental side effect logging.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectEvalUsage,
+  detectArgumentsUsage,
+  deoptimizeScope,
+} from "../../../src/tree-shaking/deoptimize.js";
+import {
+  normalizeTreeshakeOptions,
+  normalizeModuleSideEffects,
+  getPreset,
+} from "../../../src/tree-shaking/options.js";
+import {
+  logFirstSideEffect,
+  generateCodeFrame,
+  positionFromOffset,
+  FIRST_SIDE_EFFECT,
+} from "../../../src/tree-shaking/log-side-effects.js";
+import { Scope } from "../../../src/tree-shaking/scope.js";
+import type { Program } from "../../../src/ast/types.js";
+
+// ============================================================
+// Test Helpers
+// ============================================================
+
+const createProgram = (body: ReadonlyArray<Record<string, unknown>>): Program =>
+  ({
+    type: "Program",
+    body,
+    sourceType: "module",
+    start: 0,
+    end: 100,
+  }) as unknown as Program;
+
+const id = (name: string): Record<string, unknown> => ({
+  type: "Identifier",
+  name,
+  start: 0,
+  end: name.length,
+});
+
+// ============================================================
+// Issue #46: eval/arguments deoptimization
+// ============================================================
+
+describe("deoptimize", () => {
+  describe("detectEvalUsage", () => {
+    it("returns true when eval() is called directly", () => {
+      const ast = createProgram([
+        {
+          type: "ExpressionStatement",
+          expression: {
+            type: "CallExpression",
+            callee: id("eval"),
+            arguments: [{ type: "Literal", value: "x + 1", start: 5, end: 12 }],
+            start: 0,
+            end: 13,
+          },
+          start: 0,
+          end: 14,
+        },
+      ]);
+      expect(detectEvalUsage(ast)).toBe(true);
+    });
+
+    it("returns false when eval is not called", () => {
+      const ast = createProgram([
+        {
+          type: "ExpressionStatement",
+          expression: {
+            type: "CallExpression",
+            callee: id("console"),
+            arguments: [],
+            start: 0,
+            end: 10,
+          },
+          start: 0,
+          end: 11,
+        },
+      ]);
+      expect(detectEvalUsage(ast)).toBe(false);
+    });
+
+    it("returns false for an empty program", () => {
+      const ast = createProgram([]);
+      expect(detectEvalUsage(ast)).toBe(false);
+    });
+
+    it("detects eval in nested function body", () => {
+      const ast = createProgram([
+        {
+          type: "FunctionDeclaration",
+          id: id("foo"),
+          params: [],
+          body: {
+            type: "BlockStatement",
+            body: [
+              {
+                type: "ExpressionStatement",
+                expression: {
+                  type: "CallExpression",
+                  callee: id("eval"),
+                  arguments: [
+                    { type: "Literal", value: "code", start: 30, end: 36 },
+                  ],
+                  start: 25,
+                  end: 37,
+                },
+                start: 25,
+                end: 38,
+              },
+            ],
+            start: 15,
+            end: 40,
+          },
+          start: 0,
+          end: 40,
+        },
+      ]);
+      expect(detectEvalUsage(ast)).toBe(true);
+    });
+
+    it("returns false when eval is used as an identifier but not called", () => {
+      const ast = createProgram([
+        {
+          type: "ExpressionStatement",
+          expression: id("eval"),
+          start: 0,
+          end: 4,
+        },
+      ]);
+      expect(detectEvalUsage(ast)).toBe(false);
+    });
+
+    it("returns false when a different function is called with eval-like argument", () => {
+      const ast = createProgram([
+        {
+          type: "ExpressionStatement",
+          expression: {
+            type: "CallExpression",
+            callee: id("notEval"),
+            arguments: [id("eval")],
+            start: 0,
+            end: 15,
+          },
+          start: 0,
+          end: 16,
+        },
+      ]);
+      expect(detectEvalUsage(ast)).toBe(false);
+    });
+  });
+
+  describe("detectArgumentsUsage", () => {
+    it("returns true when arguments is referenced in a non-arrow function", () => {
+      const ast = createProgram([
+        {
+          type: "FunctionDeclaration",
+          id: id("foo"),
+          params: [],
+          body: {
+            type: "BlockStatement",
+            body: [
+              {
+                type: "ExpressionStatement",
+                expression: id("arguments"),
+                start: 20,
+                end: 29,
+              },
+            ],
+            start: 15,
+            end: 30,
+          },
+          start: 0,
+          end: 30,
+        },
+      ]);
+      expect(detectArgumentsUsage(ast)).toBe(true);
+    });
+
+    it("returns false when arguments is at module level", () => {
+      const ast = createProgram([
+        {
+          type: "ExpressionStatement",
+          expression: id("arguments"),
+          start: 0,
+          end: 9,
+        },
+      ]);
+      expect(detectArgumentsUsage(ast)).toBe(false);
+    });
+
+    it("returns false for arrow function using arguments", () => {
+      // Arrow functions don't have their own arguments, so references
+      // to `arguments` inside an arrow at module level are not in a non-arrow function
+      const ast = createProgram([
+        {
+          type: "ExpressionStatement",
+          expression: {
+            type: "ArrowFunctionExpression",
+            params: [],
+            body: {
+              type: "BlockStatement",
+              body: [
+                {
+                  type: "ExpressionStatement",
+                  expression: id("arguments"),
+                  start: 20,
+                  end: 29,
+                },
+              ],
+              start: 15,
+              end: 30,
+            },
+            start: 5,
+            end: 30,
+          },
+          start: 0,
+          end: 31,
+        },
+      ]);
+      expect(detectArgumentsUsage(ast)).toBe(false);
+    });
+
+    it("returns true for function expression using arguments", () => {
+      const ast = createProgram([
+        {
+          type: "ExpressionStatement",
+          expression: {
+            type: "FunctionExpression",
+            id: null,
+            params: [],
+            body: {
+              type: "BlockStatement",
+              body: [
+                {
+                  type: "ExpressionStatement",
+                  expression: id("arguments"),
+                  start: 20,
+                  end: 29,
+                },
+              ],
+              start: 15,
+              end: 30,
+            },
+            start: 5,
+            end: 30,
+          },
+          start: 0,
+          end: 31,
+        },
+      ]);
+      expect(detectArgumentsUsage(ast)).toBe(true);
+    });
+
+    it("returns false when arguments is not referenced anywhere", () => {
+      const ast = createProgram([
+        {
+          type: "FunctionDeclaration",
+          id: id("foo"),
+          params: [id("a")],
+          body: {
+            type: "BlockStatement",
+            body: [
+              {
+                type: "ExpressionStatement",
+                expression: id("a"),
+                start: 20,
+                end: 21,
+              },
+            ],
+            start: 15,
+            end: 25,
+          },
+          start: 0,
+          end: 25,
+        },
+      ]);
+      expect(detectArgumentsUsage(ast)).toBe(false);
+    });
+  });
+
+  describe("deoptimizeScope", () => {
+    it("marks all bindings in scope and parent scopes for eval", () => {
+      const parentScope = new Scope(null, false);
+      parentScope.addBinding("x", "const", {
+        type: "Identifier",
+        start: 0,
+        end: 1,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+      parentScope.addBinding("y", "const", {
+        type: "Identifier",
+        start: 2,
+        end: 3,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+
+      const childScope = new Scope(parentScope, false);
+      childScope.addBinding("z", "const", {
+        type: "Identifier",
+        start: 4,
+        end: 5,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+
+      expect(parentScope.bindings.get("x")!.isIncluded).toBe(false);
+      expect(parentScope.bindings.get("y")!.isIncluded).toBe(false);
+      expect(childScope.bindings.get("z")!.isIncluded).toBe(false);
+
+      deoptimizeScope(childScope, "eval");
+
+      expect(parentScope.bindings.get("x")!.isIncluded).toBe(true);
+      expect(parentScope.bindings.get("y")!.isIncluded).toBe(true);
+      expect(childScope.bindings.get("z")!.isIncluded).toBe(true);
+    });
+
+    it("marks only current scope bindings for arguments", () => {
+      const parentScope = new Scope(null, false);
+      parentScope.addBinding("x", "const", {
+        type: "Identifier",
+        start: 0,
+        end: 1,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+
+      const childScope = new Scope(parentScope, false);
+      childScope.addBinding("a", "param", {
+        type: "Identifier",
+        start: 2,
+        end: 3,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+      childScope.addBinding("b", "param", {
+        type: "Identifier",
+        start: 4,
+        end: 5,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+
+      deoptimizeScope(childScope, "arguments");
+
+      expect(parentScope.bindings.get("x")!.isIncluded).toBe(false);
+      expect(childScope.bindings.get("a")!.isIncluded).toBe(true);
+      expect(childScope.bindings.get("b")!.isIncluded).toBe(true);
+    });
+
+    it("handles scope with no bindings without error", () => {
+      const scope = new Scope(null, false);
+      expect(() => deoptimizeScope(scope, "eval")).not.toThrow();
+      expect(() => deoptimizeScope(scope, "arguments")).not.toThrow();
+    });
+
+    it("handles deeply nested scope chain for eval", () => {
+      const root = new Scope(null, false);
+      root.addBinding("r", "const", {
+        type: "Identifier",
+        start: 0,
+        end: 1,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+
+      const mid = new Scope(root, false);
+      mid.addBinding("m", "const", {
+        type: "Identifier",
+        start: 2,
+        end: 3,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+
+      const leaf = new Scope(mid, false);
+      leaf.addBinding("l", "const", {
+        type: "Identifier",
+        start: 4,
+        end: 5,
+      } as unknown as import("../../../src/ast/types.js").BaseNode);
+
+      deoptimizeScope(leaf, "eval");
+
+      expect(root.bindings.get("r")!.isIncluded).toBe(true);
+      expect(mid.bindings.get("m")!.isIncluded).toBe(true);
+      expect(leaf.bindings.get("l")!.isIncluded).toBe(true);
+    });
+  });
+});
+
+// ============================================================
+// Issue #50: Tree-shaking presets and options
+// ============================================================
+
+describe("options", () => {
+  describe("getPreset", () => {
+    it("returns smallest preset values", () => {
+      const preset = getPreset("smallest");
+      expect(preset.annotations).toBe(true);
+      expect(preset.correctVarValueBeforeDeclaration).toBe(true);
+      expect(preset.manualPureFunctions).toEqual([]);
+      expect(preset.moduleSideEffects).toBe(false);
+      expect(preset.propertyReadSideEffects).toBe(false);
+      expect(preset.tryCatchDeoptimization).toBe(false);
+      expect(preset.unknownGlobalSideEffects).toBe(false);
+    });
+
+    it("returns safest preset values", () => {
+      const preset = getPreset("safest");
+      expect(preset.annotations).toBe(true);
+      expect(preset.correctVarValueBeforeDeclaration).toBe(true);
+      expect(preset.moduleSideEffects).toBe(true);
+      expect(preset.propertyReadSideEffects).toBe(true);
+      expect(preset.tryCatchDeoptimization).toBe(true);
+      expect(preset.unknownGlobalSideEffects).toBe(true);
+    });
+
+    it("returns recommended preset values", () => {
+      const preset = getPreset("recommended");
+      expect(preset.annotations).toBe(true);
+      expect(preset.correctVarValueBeforeDeclaration).toBe(false);
+      expect(preset.moduleSideEffects).toBe(true);
+      expect(preset.propertyReadSideEffects).toBe(true);
+      expect(preset.tryCatchDeoptimization).toBe(true);
+      expect(preset.unknownGlobalSideEffects).toBe(false);
+    });
+  });
+
+  describe("normalizeTreeshakeOptions", () => {
+    it("returns false when input is false", () => {
+      expect(normalizeTreeshakeOptions(false)).toBe(false);
+    });
+
+    it("uses recommended preset when input is true", () => {
+      const result = normalizeTreeshakeOptions(true);
+      expect(result).not.toBe(false);
+      if (result === false) return;
+      expect(result.annotations).toBe(true);
+      expect(result.correctVarValueBeforeDeclaration).toBe(false);
+      expect(result.tryCatchDeoptimization).toBe(true);
+      expect(result.unknownGlobalSideEffects).toBe(false);
+    });
+
+    it("uses recommended preset when input is undefined", () => {
+      const result = normalizeTreeshakeOptions(undefined);
+      expect(result).not.toBe(false);
+      if (result === false) return;
+      expect(result.correctVarValueBeforeDeclaration).toBe(false);
+      expect(result.unknownGlobalSideEffects).toBe(false);
+    });
+
+    it("normalizes smallest preset string", () => {
+      const result = normalizeTreeshakeOptions("smallest");
+      expect(result).not.toBe(false);
+      if (result === false) return;
+      expect(result.correctVarValueBeforeDeclaration).toBe(true);
+      expect(result.propertyReadSideEffects).toBe(false);
+      expect(result.tryCatchDeoptimization).toBe(false);
+      expect(result.unknownGlobalSideEffects).toBe(false);
+      expect(result.moduleSideEffects("any", false)).toBe(false);
+    });
+
+    it("normalizes safest preset string", () => {
+      const result = normalizeTreeshakeOptions("safest");
+      expect(result).not.toBe(false);
+      if (result === false) return;
+      expect(result.propertyReadSideEffects).toBe(true);
+      expect(result.tryCatchDeoptimization).toBe(true);
+      expect(result.unknownGlobalSideEffects).toBe(true);
+      expect(result.moduleSideEffects("any", false)).toBe(true);
+    });
+
+    it("merges partial options over recommended preset", () => {
+      const result = normalizeTreeshakeOptions({
+        propertyReadSideEffects: "always",
+        manualPureFunctions: ["myPure"],
+      });
+      expect(result).not.toBe(false);
+      if (result === false) return;
+      expect(result.propertyReadSideEffects).toBe("always");
+      expect(result.manualPureFunctions).toEqual(["myPure"]);
+      // Should inherit remaining from recommended
+      expect(result.annotations).toBe(true);
+      expect(result.correctVarValueBeforeDeclaration).toBe(false);
+      expect(result.tryCatchDeoptimization).toBe(true);
+    });
+
+    it("merges partial options over specified preset", () => {
+      const result = normalizeTreeshakeOptions({
+        preset: "smallest",
+        unknownGlobalSideEffects: true,
+      });
+      expect(result).not.toBe(false);
+      if (result === false) return;
+      expect(result.unknownGlobalSideEffects).toBe(true);
+      // Other values from smallest
+      expect(result.correctVarValueBeforeDeclaration).toBe(true);
+      expect(result.propertyReadSideEffects).toBe(false);
+      expect(result.tryCatchDeoptimization).toBe(false);
+    });
+
+    it("normalizes moduleSideEffects boolean correctly", () => {
+      const result = normalizeTreeshakeOptions({ moduleSideEffects: false });
+      expect(result).not.toBe(false);
+      if (result === false) return;
+      expect(result.moduleSideEffects("any-module", false)).toBe(false);
+    });
+  });
+
+  describe("normalizeModuleSideEffects", () => {
+    it("returns always-true for undefined", () => {
+      const fn = normalizeModuleSideEffects(undefined);
+      expect(fn("any", false)).toBe(true);
+      expect(fn("any", true)).toBe(true);
+    });
+
+    it("returns always-true for true", () => {
+      const fn = normalizeModuleSideEffects(true);
+      expect(fn("any", true)).toBe(true);
+    });
+
+    it("returns always-false for false", () => {
+      const fn = normalizeModuleSideEffects(false);
+      expect(fn("any", false)).toBe(false);
+    });
+
+    it("returns !external for no-external", () => {
+      const fn = normalizeModuleSideEffects("no-external");
+      expect(fn("mod", false)).toBe(true);
+      expect(fn("mod", true)).toBe(false);
+    });
+
+    it("returns set-based lookup for array", () => {
+      const fn = normalizeModuleSideEffects(["a", "b"]);
+      expect(fn("a", false)).toBe(true);
+      expect(fn("b", false)).toBe(true);
+      expect(fn("c", false)).toBe(false);
+    });
+
+    it("passes through a function directly", () => {
+      const custom = (id: string) => id.startsWith("keep");
+      const fn = normalizeModuleSideEffects(custom);
+      expect(fn("keep-me", false)).toBe(true);
+      expect(fn("remove-me", false)).toBe(false);
+    });
+  });
+});
+
+// ============================================================
+// Issue #53: experimentalLogSideEffects
+// ============================================================
+
+describe("log-side-effects", () => {
+  describe("FIRST_SIDE_EFFECT", () => {
+    it("has the correct error code value", () => {
+      expect(FIRST_SIDE_EFFECT).toBe("FIRST_SIDE_EFFECT");
+    });
+  });
+
+  describe("positionFromOffset", () => {
+    it("computes line 1 column 0 for offset 0", () => {
+      const result = positionFromOffset("hello\nworld", 0);
+      expect(result.line).toBe(1);
+      expect(result.column).toBe(0);
+    });
+
+    it("computes correct position mid-first-line", () => {
+      const result = positionFromOffset("hello\nworld", 3);
+      expect(result.line).toBe(1);
+      expect(result.column).toBe(3);
+    });
+
+    it("computes correct position on second line", () => {
+      const result = positionFromOffset("hello\nworld", 7);
+      expect(result.line).toBe(2);
+      expect(result.column).toBe(1);
+    });
+
+    it("computes correct position on third line", () => {
+      const result = positionFromOffset("a\nb\nc", 4);
+      expect(result.line).toBe(3);
+      expect(result.column).toBe(0);
+    });
+  });
+
+  describe("generateCodeFrame", () => {
+    it("generates a frame with caret at correct position", () => {
+      const source = "const x = 1;\nconsole.log(x);\nconst y = 2;";
+      const frame = generateCodeFrame(source, 2, 0);
+      expect(frame).toContain("> 2 |");
+      expect(frame).toContain("console.log(x);");
+      expect(frame).toContain("^");
+    });
+
+    it("shows context lines around the target", () => {
+      const source = "line1\nline2\nline3\nline4\nline5";
+      const frame = generateCodeFrame(source, 3, 0);
+      expect(frame).toContain("line1");
+      expect(frame).toContain("line2");
+      expect(frame).toContain("line3");
+      expect(frame).toContain("line4");
+    });
+
+    it("handles first line correctly", () => {
+      const source = "first\nsecond\nthird";
+      const frame = generateCodeFrame(source, 1, 2);
+      expect(frame).toContain("> 1 |");
+      expect(frame).toContain("first");
+      expect(frame).toContain("^");
+    });
+  });
+
+  describe("logFirstSideEffect", () => {
+    it("returns null when sideEffectNodes is empty", () => {
+      const result = logFirstSideEffect("module.js", [], "const x = 1;");
+      expect(result).toBeNull();
+    });
+
+    it("returns a log entry with correct structure for first node", () => {
+      const source = "const x = 1;\nconsole.log(x);";
+      const nodes = [
+        { type: "ExpressionStatement", start: 13, end: 28 },
+      ] as unknown as ReadonlyArray<
+        import("../../../src/ast/types.js").BaseNode
+      >;
+
+      const result = logFirstSideEffect("test.js", nodes, source);
+
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe(FIRST_SIDE_EFFECT);
+      expect(result!.id).toBe("test.js");
+      expect(result!.pos).toBe(13);
+      expect(result!.loc.file).toBe("test.js");
+      expect(result!.loc.line).toBe(2);
+      expect(result!.loc.column).toBe(0);
+      expect(result!.frame).toContain("console.log(x);");
+      expect(result!.message).toContain("test.js");
+      expect(result!.message).toContain("line 2");
+    });
+
+    it("only logs the first side effect even with multiple nodes", () => {
+      const source = "a();\nb();\nc();";
+      const nodes = [
+        { type: "ExpressionStatement", start: 0, end: 3 },
+        { type: "ExpressionStatement", start: 5, end: 8 },
+        { type: "ExpressionStatement", start: 10, end: 13 },
+      ] as unknown as ReadonlyArray<
+        import("../../../src/ast/types.js").BaseNode
+      >;
+
+      const result = logFirstSideEffect("multi.js", nodes, source);
+
+      expect(result).not.toBeNull();
+      expect(result!.pos).toBe(0);
+      expect(result!.loc.line).toBe(1);
+    });
+
+    it("includes module ID in the message", () => {
+      const source = "sideEffect();";
+      const nodes = [
+        { type: "ExpressionStatement", start: 0, end: 13 },
+      ] as unknown as ReadonlyArray<
+        import("../../../src/ast/types.js").BaseNode
+      >;
+
+      const result = logFirstSideEffect("/path/to/module.js", nodes, source);
+      expect(result!.message).toContain("/path/to/module.js");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Issue #46**: Implements eval/arguments deoptimization detection with iterative AST traversal. When `eval()` is detected, all bindings in the scope chain are preserved. When `arguments` is used in non-arrow functions, all scope bindings are preserved.
- **Issue #50**: Adds tree-shaking presets (`smallest`, `safest`, `recommended`) and `normalizeTreeshakeOptions()` which accepts boolean, preset string, or partial options object.
- **Issue #53**: Implements `experimentalLogSideEffects` support with `logFirstSideEffect()` that produces structured log entries with code frames using the `FIRST_SIDE_EFFECT` error code.

Closes #46
Closes #50
Closes #53

## Test plan

- [x] 44 unit tests covering all three modules with 100% coverage on new code
- [x] All existing 3315 tests continue to pass
- [x] TypeScript strict mode passes with no errors
- [x] Formatted with prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)