### PR TITLE
feat: implement MagicString-based rendering approach

### DIFF
--- a/src/codegen/module-render.ts
+++ b/src/codegen/module-render.ts
@@ -1,0 +1,358 @@
+/**
+ * @module codegen/module-render
+ * @description Renders a single Module's output by making targeted edits to the
+ * original source via MagicString, preserving formatting and enabling accurate
+ * source maps.
+ */
+
+import { MagicString } from "../sourcemap/magic-string.js";
+import type * as AST from "../ast/types.js";
+
+/**
+ * Options controlling how a module is rendered.
+ */
+export interface ModuleRenderOptions {
+  readonly compact?: boolean;
+  readonly format: "es" | "cjs" | "iife" | "umd" | "amd" | "system";
+  readonly exportMode: "named" | "default" | "none" | "auto";
+  readonly interop: string;
+}
+
+/**
+ * Result of rendering a module.
+ */
+export interface RenderResult {
+  readonly code: string;
+  readonly magicString: MagicString;
+}
+
+/**
+ * Describes how to rewrite an import declaration.
+ */
+export interface ImportRewrite {
+  readonly start: number;
+  readonly end: number;
+  readonly replacement: string;
+}
+
+/**
+ * Describes how to rewrite an export declaration.
+ */
+export interface ExportRewrite {
+  readonly start: number;
+  readonly end: number;
+  readonly replacement: string;
+}
+
+/**
+ * Binding descriptor for CJS import conversion.
+ */
+export interface BindingDescriptor {
+  readonly local: string;
+  readonly imported: string;
+}
+
+/**
+ * Render a module by editing its source with MagicString.
+ *
+ * Performs the following transformations in order:
+ * 1. Remove excluded (tree-shaken) statements
+ * 2. Rewrite imports based on format
+ * 3. Rewrite exports based on format
+ * 4. Apply variable deconflictions
+ *
+ * @param source - The original module source code
+ * @param ast - The parsed AST Program node
+ * @param includedStatements - Set of start positions of statements to include
+ * @param importRewrites - Import declaration rewrites to apply
+ * @param exportRewrites - Export declaration rewrites to apply
+ * @param deconflictions - Map of original name to deconflicted name
+ * @param options - Rendering options (format, compact, etc.)
+ * @returns The rendered code and MagicString instance
+ */
+export const renderModule = (
+  source: string,
+  ast: AST.Program,
+  includedStatements: ReadonlySet<number>,
+  importRewrites: ReadonlyArray<ImportRewrite>,
+  exportRewrites: ReadonlyArray<ExportRewrite>,
+  deconflictions: ReadonlyMap<string, string>,
+  options: ModuleRenderOptions,
+): RenderResult => {
+  const ms = new MagicString(source);
+
+  // 1. Remove excluded (tree-shaken) statements
+  const body = ast.body;
+  for (let i = 0; i < body.length; i++) {
+    const stmt = body[i];
+    if (!includedStatements.has(stmt.start)) {
+      ms.remove(stmt.start, stmt.end);
+    }
+  }
+
+  // 2. Rewrite imports based on format
+  for (let i = 0; i < importRewrites.length; i++) {
+    const rewrite = importRewrites[i];
+    ms.overwrite(rewrite.start, rewrite.end, rewrite.replacement);
+  }
+
+  // 3. Rewrite exports based on format
+  for (let i = 0; i < exportRewrites.length; i++) {
+    const rewrite = exportRewrites[i];
+    ms.overwrite(rewrite.start, rewrite.end, rewrite.replacement);
+  }
+
+  // 4. Apply variable deconflictions
+  applyDeconflictions(ms, source, deconflictions);
+
+  // 5. Apply compact mode if requested
+  const code =
+    options.compact === true ? compactOutput(ms.toString()) : ms.toString();
+
+  if (options.compact === true) {
+    // Re-create MagicString with compacted code for consistency
+    const compactMs = new MagicString(code);
+    return { code, magicString: compactMs };
+  }
+
+  return { code, magicString: ms };
+};
+
+/**
+ * Apply variable deconflictions by finding identifier occurrences in source.
+ * Uses word-boundary matching to avoid partial replacements.
+ *
+ * @param ms - The MagicString instance to modify
+ * @param source - The original source code
+ * @param deconflictions - Map of original name to deconflicted name
+ */
+const applyDeconflictions = (
+  ms: MagicString,
+  source: string,
+  deconflictions: ReadonlyMap<string, string>,
+): void => {
+  if (deconflictions.size === 0) {
+    return;
+  }
+
+  // Build a list of all replacements to apply, sorted by position descending
+  // so later replacements don't shift earlier positions
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
+
+  for (const [original, deconflicted] of deconflictions) {
+    const pattern = new RegExp(`\\b${escapeRegExp(original)}\\b`, "g");
+    let match: RegExpExecArray | null = pattern.exec(source);
+    while (match !== null) {
+      replacements.push({
+        start: match.index,
+        end: match.index + original.length,
+        text: deconflicted,
+      });
+      match = pattern.exec(source);
+    }
+  }
+
+  // Sort descending by start position so we apply from end to beginning
+  replacements.sort((a, b) => b.start - a.start);
+
+  for (let i = 0; i < replacements.length; i++) {
+    const r = replacements[i];
+    ms.overwrite(r.start, r.end, r.text);
+  }
+};
+
+/**
+ * Escape special regex characters in a string.
+ *
+ * @param str - The string to escape
+ * @returns The escaped string safe for use in RegExp
+ */
+const escapeRegExp = (str: string): string => {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+};
+
+/**
+ * Compact output by removing unnecessary whitespace.
+ * Collapses multiple newlines to single newline, trims lines.
+ *
+ * @param code - The code to compact
+ * @returns The compacted code
+ */
+const compactOutput = (code: string): string => {
+  // Remove empty lines and collapse whitespace
+  const lines = code.split("\n");
+  const result: Array<string> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.length > 0) {
+      result.push(trimmed);
+    }
+  }
+  return result.join("\n");
+};
+
+/**
+ * Generate an import rewrite for ES format.
+ * Imports stay as-is structurally, only the source path is updated.
+ *
+ * @param importDecl - The import declaration AST node
+ * @param resolvedPath - The resolved import path
+ * @returns An ImportRewrite describing the source path replacement
+ */
+export const generateEsImportRewrite = (
+  importDecl: AST.ImportDeclaration,
+  resolvedPath: string,
+): ImportRewrite => {
+  const source = importDecl.source;
+  return {
+    start: source.start,
+    end: source.end,
+    replacement: `'${resolvedPath}'`,
+  };
+};
+
+/**
+ * Generate an import rewrite for CJS format.
+ * Converts ES import statement to a require() call with destructuring.
+ *
+ * @param importDecl - The import declaration AST node
+ * @param resolvedPath - The resolved import path
+ * @param bindings - The binding descriptors (local/imported names)
+ * @returns An ImportRewrite converting the import to require()
+ */
+export const generateCjsImportRewrite = (
+  importDecl: AST.ImportDeclaration,
+  resolvedPath: string,
+  bindings: ReadonlyArray<BindingDescriptor>,
+): ImportRewrite => {
+  const destructured = bindings
+    .map((b) =>
+      b.imported === b.local ? b.local : `${b.imported}: ${b.local}`,
+    )
+    .join(", ");
+  const requireCall = `const { ${destructured} } = require('${resolvedPath}');`;
+  return {
+    start: importDecl.start,
+    end: importDecl.end,
+    replacement: requireCall,
+  };
+};
+
+/**
+ * Generate an export rewrite for ES format (named exports).
+ * Preserves the export statement but may adjust exported names.
+ *
+ * @param exportDecl - The export declaration AST node
+ * @param exportedNames - Array of names to export
+ * @returns An ExportRewrite for the declaration
+ */
+export const generateEsExportRewrite = (
+  exportDecl: AST.ExportNamedDeclaration,
+  exportedNames: ReadonlyArray<{
+    readonly local: string;
+    readonly exported: string;
+  }>,
+): ExportRewrite => {
+  const specifiers = exportedNames
+    .map((n) =>
+      n.local === n.exported ? n.local : `${n.local} as ${n.exported}`,
+    )
+    .join(", ");
+  return {
+    start: exportDecl.start,
+    end: exportDecl.end,
+    replacement: `export { ${specifiers} };`,
+  };
+};
+
+/**
+ * Generate an export rewrite for CJS format.
+ * Converts ES export to module.exports/exports assignment.
+ *
+ * @param exportDecl - The export declaration AST node
+ * @param exportedNames - Array of names to export
+ * @returns An ExportRewrite converting the export to CJS assignment
+ */
+export const generateCjsExportRewrite = (
+  exportDecl: AST.ExportNamedDeclaration,
+  exportedNames: ReadonlyArray<{
+    readonly local: string;
+    readonly exported: string;
+  }>,
+): ExportRewrite => {
+  const assignments = exportedNames
+    .map((n) => `exports.${n.exported} = ${n.local};`)
+    .join("\n");
+  return {
+    start: exportDecl.start,
+    end: exportDecl.end,
+    replacement: assignments,
+  };
+};
+
+/**
+ * Generate a default export rewrite for CJS format.
+ *
+ * @param exportDecl - The export default declaration AST node
+ * @param localName - The local variable name for the default export
+ * @returns An ExportRewrite converting to module.exports assignment
+ */
+export const generateCjsDefaultExportRewrite = (
+  exportDecl: AST.ExportDefaultDeclaration,
+  localName: string,
+): ExportRewrite => {
+  return {
+    start: exportDecl.start,
+    end: exportDecl.end,
+    replacement: `module.exports = ${localName};`,
+  };
+};
+
+/**
+ * Generate a namespace import rewrite for CJS format.
+ * Converts `import * as ns from '...'` to `const ns = require('...')`.
+ *
+ * @param importDecl - The import declaration AST node
+ * @param resolvedPath - The resolved import path
+ * @param localName - The local namespace binding name
+ * @returns An ImportRewrite for the namespace import
+ */
+export const generateCjsNamespaceImportRewrite = (
+  importDecl: AST.ImportDeclaration,
+  resolvedPath: string,
+  localName: string,
+): ImportRewrite => {
+  return {
+    start: importDecl.start,
+    end: importDecl.end,
+    replacement: `const ${localName} = require('${resolvedPath}');`,
+  };
+};
+
+/**
+ * Generate a default import rewrite for CJS format.
+ * Converts `import foo from '...'` to
+ * `const foo = require('...').default || require('...')`.
+ *
+ * @param importDecl - The import declaration AST node
+ * @param resolvedPath - The resolved import path
+ * @param localName - The local binding name
+ * @param interop - The interop mode string
+ * @returns An ImportRewrite for the default import
+ */
+export const generateCjsDefaultImportRewrite = (
+  importDecl: AST.ImportDeclaration,
+  resolvedPath: string,
+  localName: string,
+  interop: string,
+): ImportRewrite => {
+  const replacement =
+    interop === "default"
+      ? `const ${localName} = require('${resolvedPath}').default;`
+      : `const ${localName} = require('${resolvedPath}');`;
+  return {
+    start: importDecl.start,
+    end: importDecl.end,
+    replacement,
+  };
+};

--- a/tests/unit/codegen/module-render.test.ts
+++ b/tests/unit/codegen/module-render.test.ts
@@ -1,0 +1,734 @@
+/**
+ * @module tests/unit/codegen/module-render
+ * @description Unit tests for MagicString-based module rendering.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  renderModule,
+  generateEsImportRewrite,
+  generateCjsImportRewrite,
+  generateEsExportRewrite,
+  generateCjsExportRewrite,
+  generateCjsDefaultExportRewrite,
+  generateCjsNamespaceImportRewrite,
+  generateCjsDefaultImportRewrite,
+} from "../../../src/codegen/module-render.js";
+import type {
+  ModuleRenderOptions,
+  ImportRewrite,
+  ExportRewrite,
+} from "../../../src/codegen/module-render.js";
+import type * as AST from "../../../src/ast/types.js";
+
+const makeOptions = (
+  overrides?: Partial<ModuleRenderOptions>,
+): ModuleRenderOptions => ({
+  format: "es",
+  exportMode: "named",
+  interop: "default",
+  ...overrides,
+});
+
+const makeProgram = (
+  source: string,
+  body: ReadonlyArray<{ start: number; end: number; type: string }>,
+): AST.Program => ({
+  type: "Program",
+  sourceType: "module",
+  start: 0,
+  end: source.length,
+  body: body as unknown as ReadonlyArray<AST.Statement | AST.ModuleDeclaration>,
+});
+
+describe("renderModule", () => {
+  describe("tree-shaking (removing excluded statements)", () => {
+    it("should remove statements not in includedStatements set", () => {
+      // "const a = 1;\nconst b = 2;\nconst c = 3;\n" = 40 chars
+      const source = "const a = 1;\nconst b = 2;\nconst c = 3;\n";
+      // positions: 0-13, 13-26, 26-39 (each "const x = N;\n" is 13 chars)
+      const stmts = [
+        { start: 0, end: 13, type: "VariableDeclaration" },
+        { start: 13, end: 26, type: "VariableDeclaration" },
+        { start: 26, end: 39, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      // Only include first and third statements
+      const included = new Set([0, 26]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe("const a = 1;\nconst c = 3;\n");
+    });
+
+    it("should keep all statements when all are included", () => {
+      const source = "const x = 1;\nconst y = 2;\n";
+      const stmts = [
+        { start: 0, end: 13, type: "VariableDeclaration" },
+        { start: 13, end: 27, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 13]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe(source);
+    });
+
+    it("should remove all statements when none are included", () => {
+      // "const a = 1;\nconst b = 2;\n" = 26 chars
+      const source = "const a = 1;\nconst b = 2;\n";
+      const stmts = [
+        { start: 0, end: 13, type: "VariableDeclaration" },
+        { start: 13, end: 26, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set<number>();
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe("");
+    });
+  });
+
+  describe("preserving non-modified source regions", () => {
+    it("should preserve whitespace and formatting in untouched regions", () => {
+      const source = "const   a   =   1;\nconst b = 2;\n";
+      const stmts = [
+        { start: 0, end: 19, type: "VariableDeclaration" },
+        { start: 19, end: 32, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 19]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe(source);
+    });
+
+    it("should preserve comments in included regions", () => {
+      const source = "/* comment */\nconst a = 1;\n";
+      const stmts = [
+        { start: 0, end: 14, type: "ExpressionStatement" },
+        { start: 14, end: 27, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 14]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe(source);
+    });
+  });
+
+  describe("import path rewriting (ES format)", () => {
+    it("should rewrite import source path", () => {
+      const source = "import { foo } from './foo';\n";
+      const stmts = [{ start: 0, end: 28, type: "ImportDeclaration" }];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0]);
+
+      const importRewrites: ReadonlyArray<ImportRewrite> = [
+        { start: 20, end: 27, replacement: "'./foo.js'" },
+      ];
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        importRewrites,
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe("import { foo } from './foo.js';\n");
+    });
+
+    it("should handle multiple import rewrites", () => {
+      // "import { a } from './a';\n" = 25 chars, source literal './a' at 18-23
+      // "import { b } from './b';\n" = 25 chars, source literal './b' at 43-48
+      const source = "import { a } from './a';\nimport { b } from './b';\n";
+      const stmts = [
+        { start: 0, end: 25, type: "ImportDeclaration" },
+        { start: 25, end: 50, type: "ImportDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 25]);
+
+      const importRewrites: ReadonlyArray<ImportRewrite> = [
+        { start: 18, end: 23, replacement: "'./a.js'" },
+        { start: 43, end: 48, replacement: "'./b.js'" },
+      ];
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        importRewrites,
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe(
+        "import { a } from './a.js';\nimport { b } from './b.js';\n",
+      );
+    });
+  });
+
+  describe("import to require conversion (CJS format)", () => {
+    it("should convert import statement to require()", () => {
+      const source = "import { foo, bar } from './utils';\n";
+      const stmts = [{ start: 0, end: 35, type: "ImportDeclaration" }];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0]);
+
+      const importRewrites: ReadonlyArray<ImportRewrite> = [
+        {
+          start: 0,
+          end: 35,
+          replacement: "const { foo, bar } = require('./utils');",
+        },
+      ];
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        importRewrites,
+        [],
+        new Map(),
+        makeOptions({ format: "cjs" }),
+      );
+
+      expect(result.code).toBe("const { foo, bar } = require('./utils');\n");
+    });
+
+    it("should handle renamed bindings in CJS conversion", () => {
+      const source = "import { foo as f } from './mod';\n";
+      const stmts = [{ start: 0, end: 33, type: "ImportDeclaration" }];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0]);
+
+      const importRewrites: ReadonlyArray<ImportRewrite> = [
+        {
+          start: 0,
+          end: 33,
+          replacement: "const { foo: f } = require('./mod');",
+        },
+      ];
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        importRewrites,
+        [],
+        new Map(),
+        makeOptions({ format: "cjs" }),
+      );
+
+      expect(result.code).toBe("const { foo: f } = require('./mod');\n");
+    });
+  });
+
+  describe("export rewriting", () => {
+    it("should rewrite named export declaration", () => {
+      const source = "export { foo, bar };\n";
+      const stmts = [{ start: 0, end: 20, type: "ExportNamedDeclaration" }];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0]);
+
+      const exportRewrites: ReadonlyArray<ExportRewrite> = [
+        {
+          start: 0,
+          end: 20,
+          replacement: "exports.foo = foo;\nexports.bar = bar;",
+        },
+      ];
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        exportRewrites,
+        new Map(),
+        makeOptions({ format: "cjs" }),
+      );
+
+      expect(result.code).toBe("exports.foo = foo;\nexports.bar = bar;\n");
+    });
+
+    it("should rewrite default export to module.exports", () => {
+      const source = "export default myFunc;\n";
+      const stmts = [{ start: 0, end: 22, type: "ExportDefaultDeclaration" }];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0]);
+
+      const exportRewrites: ReadonlyArray<ExportRewrite> = [
+        { start: 0, end: 22, replacement: "module.exports = myFunc;" },
+      ];
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        exportRewrites,
+        new Map(),
+        makeOptions({ format: "cjs" }),
+      );
+
+      expect(result.code).toBe("module.exports = myFunc;\n");
+    });
+  });
+
+  describe("variable deconfliction", () => {
+    it("should rename deconflicted variables", () => {
+      const source = "const foo = 1;\nconsole.log(foo);\n";
+      const stmts = [
+        { start: 0, end: 15, type: "VariableDeclaration" },
+        { start: 15, end: 32, type: "ExpressionStatement" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 15]);
+      const deconflictions = new Map([["foo", "foo_1"]]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        deconflictions,
+        makeOptions(),
+      );
+
+      expect(result.code).toContain("foo_1");
+      expect(result.code).not.toMatch(/\bfoo\b(?!_1)/);
+    });
+
+    it("should not rename partial matches", () => {
+      const source = "const foobar = 1;\nconst foo = 2;\n";
+      const stmts = [
+        { start: 0, end: 18, type: "VariableDeclaration" },
+        { start: 18, end: 33, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 18]);
+      const deconflictions = new Map([["foo", "foo$1"]]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        deconflictions,
+        makeOptions(),
+      );
+
+      expect(result.code).toContain("foobar");
+      expect(result.code).toContain("foo$1");
+    });
+
+    it("should handle empty deconflictions map", () => {
+      const source = "const a = 1;\n";
+      const stmts = [{ start: 0, end: 13, type: "VariableDeclaration" }];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe(source);
+    });
+  });
+
+  describe("source map generation", () => {
+    it("should produce a MagicString that can generate source maps", () => {
+      const source = "const a = 1;\nconst b = 2;\n";
+      const stmts = [
+        { start: 0, end: 13, type: "VariableDeclaration" },
+        { start: 13, end: 27, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 13]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      const map = result.magicString.generateMap({ source: "test.js" });
+      expect(map.version).toBe(3);
+      expect(map.sources).toEqual(["test.js"]);
+      expect(typeof map.mappings).toBe("string");
+    });
+
+    it("should produce valid mappings after edits", () => {
+      const source = "import { x } from './x';\nconst a = x;\n";
+      const stmts = [
+        { start: 0, end: 25, type: "ImportDeclaration" },
+        { start: 25, end: 39, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 25]);
+      const importRewrites: ReadonlyArray<ImportRewrite> = [
+        { start: 17, end: 22, replacement: "'./x.js'" },
+      ];
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        importRewrites,
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      const map = result.magicString.generateDecodedMap({
+        source: "test.js",
+        includeContent: true,
+      });
+      expect(map.version).toBe(3);
+      expect(map.sourcesContent).toEqual([source]);
+      expect(map.mappings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("empty module", () => {
+    it("should render empty string for empty source", () => {
+      const source = "";
+      const ast = makeProgram(source, []);
+      const included = new Set<number>();
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe("");
+    });
+
+    it("should render empty when all statements are excluded", () => {
+      const source = "const unused = true;\n";
+      const stmts = [{ start: 0, end: 21, type: "VariableDeclaration" }];
+      const ast = makeProgram(source, stmts);
+      const included = new Set<number>();
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions(),
+      );
+
+      expect(result.code).toBe("");
+    });
+  });
+
+  describe("compact mode", () => {
+    it("should remove empty lines in compact mode", () => {
+      const source = "const a = 1;\n\n\nconst b = 2;\n";
+      const stmts = [
+        { start: 0, end: 13, type: "VariableDeclaration" },
+        { start: 13, end: 28, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      // Only include first statement; second gets removed, leaving empty lines
+      const included = new Set([0]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions({ compact: true }),
+      );
+
+      // Compact mode should have no empty lines
+      const lines = result.code.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].length > 0) {
+          expect(lines[i].trim().length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("should trim leading whitespace from lines in compact mode", () => {
+      const source = "  const a = 1;\n  const b = 2;\n";
+      const stmts = [
+        { start: 0, end: 15, type: "VariableDeclaration" },
+        { start: 15, end: 30, type: "VariableDeclaration" },
+      ];
+      const ast = makeProgram(source, stmts);
+      const included = new Set([0, 15]);
+
+      const result = renderModule(
+        source,
+        ast,
+        included,
+        [],
+        [],
+        new Map(),
+        makeOptions({ compact: true }),
+      );
+
+      expect(result.code).toBe("const a = 1;\nconst b = 2;");
+    });
+  });
+});
+
+describe("generateEsImportRewrite", () => {
+  it("should create a rewrite for the source literal", () => {
+    const importDecl: AST.ImportDeclaration = {
+      type: "ImportDeclaration",
+      start: 0,
+      end: 28,
+      specifiers: [],
+      source: { type: "Literal", value: "./foo", start: 20, end: 27 },
+    };
+
+    const rewrite = generateEsImportRewrite(importDecl, "./foo.js");
+    expect(rewrite.start).toBe(20);
+    expect(rewrite.end).toBe(27);
+    expect(rewrite.replacement).toBe("'./foo.js'");
+  });
+});
+
+describe("generateCjsImportRewrite", () => {
+  it("should convert to require() with same-name bindings", () => {
+    const importDecl: AST.ImportDeclaration = {
+      type: "ImportDeclaration",
+      start: 0,
+      end: 30,
+      specifiers: [],
+      source: { type: "Literal", value: "./mod", start: 22, end: 29 },
+    };
+
+    const rewrite = generateCjsImportRewrite(importDecl, "./mod.js", [
+      { local: "foo", imported: "foo" },
+      { local: "bar", imported: "bar" },
+    ]);
+
+    expect(rewrite.start).toBe(0);
+    expect(rewrite.end).toBe(30);
+    expect(rewrite.replacement).toBe(
+      "const { foo, bar } = require('./mod.js');",
+    );
+  });
+
+  it("should handle renamed bindings", () => {
+    const importDecl: AST.ImportDeclaration = {
+      type: "ImportDeclaration",
+      start: 0,
+      end: 35,
+      specifiers: [],
+      source: { type: "Literal", value: "./mod", start: 25, end: 32 },
+    };
+
+    const rewrite = generateCjsImportRewrite(importDecl, "./mod.js", [
+      { local: "myFoo", imported: "foo" },
+    ]);
+
+    expect(rewrite.replacement).toBe(
+      "const { foo: myFoo } = require('./mod.js');",
+    );
+  });
+});
+
+describe("generateEsExportRewrite", () => {
+  it("should generate export statement with same-name exports", () => {
+    const exportDecl: AST.ExportNamedDeclaration = {
+      type: "ExportNamedDeclaration",
+      start: 0,
+      end: 20,
+      declaration: null,
+      specifiers: [],
+      source: null,
+    };
+
+    const rewrite = generateEsExportRewrite(exportDecl, [
+      { local: "foo", exported: "foo" },
+      { local: "bar", exported: "bar" },
+    ]);
+
+    expect(rewrite.replacement).toBe("export { foo, bar };");
+  });
+
+  it("should generate export statement with renamed exports", () => {
+    const exportDecl: AST.ExportNamedDeclaration = {
+      type: "ExportNamedDeclaration",
+      start: 0,
+      end: 25,
+      declaration: null,
+      specifiers: [],
+      source: null,
+    };
+
+    const rewrite = generateEsExportRewrite(exportDecl, [
+      { local: "foo", exported: "publicFoo" },
+    ]);
+
+    expect(rewrite.replacement).toBe("export { foo as publicFoo };");
+  });
+});
+
+describe("generateCjsExportRewrite", () => {
+  it("should generate exports assignments", () => {
+    const exportDecl: AST.ExportNamedDeclaration = {
+      type: "ExportNamedDeclaration",
+      start: 0,
+      end: 20,
+      declaration: null,
+      specifiers: [],
+      source: null,
+    };
+
+    const rewrite = generateCjsExportRewrite(exportDecl, [
+      { local: "foo", exported: "foo" },
+      { local: "bar", exported: "baz" },
+    ]);
+
+    expect(rewrite.replacement).toBe("exports.foo = foo;\nexports.baz = bar;");
+  });
+});
+
+describe("generateCjsDefaultExportRewrite", () => {
+  it("should generate module.exports assignment", () => {
+    const exportDecl: AST.ExportDefaultDeclaration = {
+      type: "ExportDefaultDeclaration",
+      start: 0,
+      end: 22,
+      declaration: { type: "Identifier", name: "myFunc", start: 15, end: 21 },
+    };
+
+    const rewrite = generateCjsDefaultExportRewrite(exportDecl, "myFunc");
+    expect(rewrite.replacement).toBe("module.exports = myFunc;");
+  });
+});
+
+describe("generateCjsNamespaceImportRewrite", () => {
+  it("should generate const = require() for namespace import", () => {
+    const importDecl: AST.ImportDeclaration = {
+      type: "ImportDeclaration",
+      start: 0,
+      end: 28,
+      specifiers: [],
+      source: { type: "Literal", value: "./mod", start: 20, end: 27 },
+    };
+
+    const rewrite = generateCjsNamespaceImportRewrite(
+      importDecl,
+      "./mod.js",
+      "ns",
+    );
+    expect(rewrite.replacement).toBe("const ns = require('./mod.js');");
+  });
+});
+
+describe("generateCjsDefaultImportRewrite", () => {
+  it("should generate require().default with default interop", () => {
+    const importDecl: AST.ImportDeclaration = {
+      type: "ImportDeclaration",
+      start: 0,
+      end: 25,
+      specifiers: [],
+      source: { type: "Literal", value: "./mod", start: 17, end: 24 },
+    };
+
+    const rewrite = generateCjsDefaultImportRewrite(
+      importDecl,
+      "./mod.js",
+      "foo",
+      "default",
+    );
+    expect(rewrite.replacement).toBe(
+      "const foo = require('./mod.js').default;",
+    );
+  });
+
+  it("should generate plain require() with non-default interop", () => {
+    const importDecl: AST.ImportDeclaration = {
+      type: "ImportDeclaration",
+      start: 0,
+      end: 25,
+      specifiers: [],
+      source: { type: "Literal", value: "./mod", start: 17, end: 24 },
+    };
+
+    const rewrite = generateCjsDefaultImportRewrite(
+      importDecl,
+      "./mod.js",
+      "foo",
+      "compat",
+    );
+    expect(rewrite.replacement).toBe("const foo = require('./mod.js');");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `src/codegen/module-render.ts` with MagicString-based module rendering that performs targeted source edits for tree-shaking, import/export rewriting, and variable deconfliction
- Supports ES and CJS format output with compact mode option
- Preserves original source formatting and enables accurate source map generation
- 100% test coverage with 30 unit tests covering all code paths

## Test plan

- [x] All 30 unit tests pass (`npx vitest run tests/unit/codegen/module-render.test.ts`)
- [x] 100% statement, branch, function, and line coverage on `src/codegen/module-render.ts`
- [x] TypeScript strict mode type checking passes (`npx tsc --noEmit`)
- [x] Prettier formatting applied

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)