### PR TITLE
feat: implement import/export rewriting

### DIFF
--- a/src/codegen/import-export.ts
+++ b/src/codegen/import-export.ts
@@ -1,0 +1,410 @@
+/**
+ * @module codegen/import-export
+ * @description Format-specific import/export rewriting utilities.
+ * Generates appropriate import/export code for ES, CJS, IIFE, UMD, AMD,
+ * and SystemJS module formats with support for live bindings, namespace
+ * objects, and interop markers.
+ */
+
+/**
+ * Describes a single import binding with its source, imported/local names,
+ * and binding type.
+ */
+export interface ImportBinding {
+  readonly source: string;
+  readonly imported: string;
+  readonly local: string;
+  readonly type: "default" | "named" | "namespace";
+}
+
+/**
+ * Describes a single export binding with its local and exported names.
+ */
+export interface ExportBinding {
+  readonly local: string;
+  readonly exported: string;
+  readonly type: "default" | "named";
+}
+
+/**
+ * Options controlling how imports/exports are rewritten for a target format.
+ */
+export interface RewriteOptions {
+  readonly format: "es" | "cjs" | "iife" | "umd" | "amd" | "system";
+  readonly esModule?: boolean | "if-default-prop";
+  readonly externalLiveBindings?: boolean;
+  readonly freeze?: boolean;
+  readonly interop: "auto" | "esModule" | "default" | "defaultOnly";
+  readonly constBindings: boolean;
+}
+
+/**
+ * Groups import bindings by source module.
+ */
+const groupBySource = (
+  bindings: ReadonlyArray<ImportBinding>,
+): Map<string, ReadonlyArray<ImportBinding>> => {
+  const groups = new Map<string, Array<ImportBinding>>();
+  for (let i = 0; i < bindings.length; i++) {
+    const binding = bindings[i];
+    const existing = groups.get(binding.source);
+    if (existing) {
+      existing.push(binding);
+    } else {
+      groups.set(binding.source, [binding]);
+    }
+  }
+  return groups;
+};
+
+/**
+ * Generates ES module import statements.
+ * Example: import { foo, bar as baz } from 'source';
+ */
+const generateEsImport = (bindings: ReadonlyArray<ImportBinding>): string => {
+  if (bindings.length === 0) return "";
+  const groups = groupBySource(bindings);
+  const lines: Array<string> = [];
+
+  for (const [source, group] of groups) {
+    const defaultBindings: Array<ImportBinding> = [];
+    const namedBindings: Array<ImportBinding> = [];
+    const namespaceBindings: Array<ImportBinding> = [];
+
+    for (let i = 0; i < group.length; i++) {
+      const b = group[i];
+      if (b.type === "default") {
+        defaultBindings.push(b);
+      } else if (b.type === "namespace") {
+        namespaceBindings.push(b);
+      } else {
+        namedBindings.push(b);
+      }
+    }
+
+    for (let i = 0; i < namespaceBindings.length; i++) {
+      lines.push(`import * as ${namespaceBindings[i].local} from '${source}';`);
+    }
+
+    if (defaultBindings.length > 0 || namedBindings.length > 0) {
+      const parts: Array<string> = [];
+      if (defaultBindings.length > 0) {
+        parts.push(defaultBindings[0].local);
+      }
+      if (namedBindings.length > 0) {
+        const specifiers = namedBindings.map((b) =>
+          b.imported === b.local ? b.imported : `${b.imported} as ${b.local}`,
+        );
+        parts.push(`{ ${specifiers.join(", ")} }`);
+      }
+      lines.push(`import ${parts.join(", ")} from '${source}';`);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Generates CJS require() statements.
+ * Example: const { foo } = require('source');
+ */
+const generateCjsImport = (
+  bindings: ReadonlyArray<ImportBinding>,
+  options: RewriteOptions,
+): string => {
+  if (bindings.length === 0) return "";
+  const groups = groupBySource(bindings);
+  const lines: Array<string> = [];
+  const varKw = options.constBindings ? "const" : "var";
+
+  for (const [source, group] of groups) {
+    const defaultBindings: Array<ImportBinding> = [];
+    const namedBindings: Array<ImportBinding> = [];
+    const namespaceBindings: Array<ImportBinding> = [];
+
+    for (let i = 0; i < group.length; i++) {
+      const b = group[i];
+      if (b.type === "default") {
+        defaultBindings.push(b);
+      } else if (b.type === "namespace") {
+        namespaceBindings.push(b);
+      } else {
+        namedBindings.push(b);
+      }
+    }
+
+    for (let i = 0; i < namespaceBindings.length; i++) {
+      lines.push(
+        `${varKw} ${namespaceBindings[i].local} = require('${source}');`,
+      );
+    }
+
+    if (defaultBindings.length > 0) {
+      const requireExpr = `require('${source}')`;
+      if (options.interop === "defaultOnly") {
+        lines.push(`${varKw} ${defaultBindings[0].local} = ${requireExpr};`);
+      } else {
+        lines.push(
+          `${varKw} ${defaultBindings[0].local} = ${requireExpr}.default;`,
+        );
+      }
+    }
+
+    if (namedBindings.length > 0) {
+      const destructured = namedBindings.map((b) =>
+        b.imported === b.local ? b.imported : `${b.imported}: ${b.local}`,
+      );
+      lines.push(
+        `${varKw} { ${destructured.join(", ")} } = require('${source}');`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Converts a module source path to a valid global variable name.
+ * Example: '@scope/my-lib' -> '_scope_myLib'
+ */
+const sourceToGlobalName = (source: string): string => {
+  const cleaned = source
+    .replace(/^@/, "")
+    .replace(/[^a-zA-Z0-9]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+  return cleaned || "_module";
+};
+
+/**
+ * Generates IIFE/UMD import code that reads from global variables.
+ * Example: const foo = globalThis.source.default;
+ */
+const generateIifeImport = (
+  bindings: ReadonlyArray<ImportBinding>,
+  options: RewriteOptions,
+): string => {
+  if (bindings.length === 0) return "";
+  const groups = groupBySource(bindings);
+  const lines: Array<string> = [];
+  const varKw = options.constBindings ? "const" : "var";
+
+  for (const [source, group] of groups) {
+    const globalName = sourceToGlobalName(source);
+
+    for (let i = 0; i < group.length; i++) {
+      const b = group[i];
+      if (b.type === "namespace") {
+        lines.push(`${varKw} ${b.local} = globalThis.${globalName};`);
+      } else if (b.type === "default") {
+        lines.push(`${varKw} ${b.local} = globalThis.${globalName}.default;`);
+      } else {
+        lines.push(
+          `${varKw} ${b.local} = globalThis.${globalName}.${b.imported};`,
+        );
+      }
+    }
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Generates ES module export statements.
+ * Example: export { foo, bar as baz };
+ */
+const generateEsExport = (bindings: ReadonlyArray<ExportBinding>): string => {
+  if (bindings.length === 0) return "";
+
+  const defaultBindings: Array<ExportBinding> = [];
+  const namedBindings: Array<ExportBinding> = [];
+
+  for (let i = 0; i < bindings.length; i++) {
+    const b = bindings[i];
+    if (b.type === "default") {
+      defaultBindings.push(b);
+    } else {
+      namedBindings.push(b);
+    }
+  }
+
+  const lines: Array<string> = [];
+
+  for (let i = 0; i < defaultBindings.length; i++) {
+    lines.push(`export default ${defaultBindings[i].local};`);
+  }
+
+  if (namedBindings.length > 0) {
+    const specifiers = namedBindings.map((b) =>
+      b.local === b.exported ? b.local : `${b.local} as ${b.exported}`,
+    );
+    lines.push(`export { ${specifiers.join(", ")} };`);
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Generates CJS export code.
+ * With live bindings: Object.defineProperty(exports, 'x', { get: () => x })
+ * Without live bindings: exports.x = x;
+ */
+const generateCjsExport = (
+  bindings: ReadonlyArray<ExportBinding>,
+  options: RewriteOptions,
+): string => {
+  if (bindings.length === 0) return "";
+  const useLiveBindings = options.externalLiveBindings !== false;
+  const lines: Array<string> = [];
+
+  for (let i = 0; i < bindings.length; i++) {
+    const b = bindings[i];
+    const exportName = b.type === "default" ? "default" : b.exported;
+
+    if (useLiveBindings) {
+      lines.push(
+        `Object.defineProperty(exports, '${exportName}', { enumerable: true, get: function() { return ${b.local}; } });`,
+      );
+    } else {
+      lines.push(`exports.${exportName} = ${b.local};`);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Generates IIFE/UMD export code that assigns to a return object or globals.
+ */
+const generateIifeExport = (
+  bindings: ReadonlyArray<ExportBinding>,
+  options: RewriteOptions,
+): string => {
+  if (bindings.length === 0) return "";
+  const useLiveBindings = options.externalLiveBindings !== false;
+  const lines: Array<string> = [];
+
+  for (let i = 0; i < bindings.length; i++) {
+    const b = bindings[i];
+    const exportName = b.type === "default" ? "default" : b.exported;
+
+    if (useLiveBindings) {
+      lines.push(
+        `Object.defineProperty(exports, '${exportName}', { enumerable: true, get: function() { return ${b.local}; } });`,
+      );
+    } else {
+      lines.push(`exports.${exportName} = ${b.local};`);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Generates SystemJS register export calls.
+ * Example: exports('name', value)
+ */
+const generateSystemExport = (
+  bindings: ReadonlyArray<ExportBinding>,
+): string => {
+  if (bindings.length === 0) return "";
+  const lines: Array<string> = [];
+
+  for (let i = 0; i < bindings.length; i++) {
+    const b = bindings[i];
+    const exportName = b.type === "default" ? "default" : b.exported;
+    lines.push(`exports('${exportName}', ${b.local});`);
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Generate import code for a given format.
+ * Dispatches to format-specific import generators.
+ */
+export const generateImportCode = (
+  bindings: ReadonlyArray<ImportBinding>,
+  options: RewriteOptions,
+): string => {
+  switch (options.format) {
+    case "es":
+      return generateEsImport(bindings);
+    case "cjs":
+      return generateCjsImport(bindings, options);
+    case "iife":
+    case "umd":
+      return generateIifeImport(bindings, options);
+    case "amd":
+      return "";
+    case "system":
+      return "";
+  }
+};
+
+/**
+ * Generate export code for a given format.
+ * Dispatches to format-specific export generators.
+ */
+export const generateExportCode = (
+  bindings: ReadonlyArray<ExportBinding>,
+  options: RewriteOptions,
+): string => {
+  switch (options.format) {
+    case "es":
+      return generateEsExport(bindings);
+    case "cjs":
+      return generateCjsExport(bindings, options);
+    case "iife":
+    case "umd":
+      return generateIifeExport(bindings, options);
+    case "amd":
+      return generateCjsExport(bindings, options);
+    case "system":
+      return generateSystemExport(bindings);
+  }
+};
+
+/**
+ * Generate __esModule marker for CJS output.
+ * Marks the module as having ES module semantics for interop.
+ */
+export const generateEsModuleMarker = (options: RewriteOptions): string => {
+  if (!options.esModule) return "";
+  return `Object.defineProperty(exports, '__esModule', { value: true });`;
+};
+
+/**
+ * Generate a namespace object containing all export bindings.
+ * Optionally frozen via Object.freeze for immutability.
+ */
+export const generateNamespaceObject = (
+  bindings: ReadonlyArray<ExportBinding>,
+  name: string,
+  options: RewriteOptions,
+): string => {
+  if (bindings.length === 0) {
+    const varKw = options.constBindings ? "const" : "var";
+    const emptyObj = options.freeze !== false ? "Object.freeze({})" : "{}";
+    return `${varKw} ${name} = ${emptyObj};`;
+  }
+
+  const varKw = options.constBindings ? "const" : "var";
+  const props: Array<string> = [];
+
+  for (let i = 0; i < bindings.length; i++) {
+    const b = bindings[i];
+    const exportName = b.type === "default" ? "default" : b.exported;
+    if (exportName === b.local) {
+      props.push(`  ${exportName}`);
+    } else {
+      props.push(`  ${exportName}: ${b.local}`);
+    }
+  }
+
+  const objLiteral = `{\n${props.join(",\n")}\n}`;
+  const wrapped =
+    options.freeze !== false ? `Object.freeze(${objLiteral})` : objLiteral;
+
+  return `${varKw} ${name} = ${wrapped};`;
+};

--- a/tests/unit/codegen/import-export.test.ts
+++ b/tests/unit/codegen/import-export.test.ts
@@ -1,0 +1,613 @@
+/**
+ * @module tests/unit/codegen/import-export
+ * @description Unit tests for format-specific import/export rewriting utilities.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  generateEsModuleMarker,
+  generateExportCode,
+  generateImportCode,
+  generateNamespaceObject,
+} from "../../../src/codegen/import-export.js";
+import type {
+  ExportBinding,
+  ImportBinding,
+  RewriteOptions,
+} from "../../../src/codegen/import-export.js";
+
+const baseOptions: RewriteOptions = {
+  format: "es",
+  esModule: false,
+  externalLiveBindings: true,
+  freeze: true,
+  interop: "auto",
+  constBindings: true,
+};
+
+describe("codegen/import-export", () => {
+  describe("generateImportCode", () => {
+    describe("ES format", () => {
+      const options: RewriteOptions = { ...baseOptions, format: "es" };
+
+      it("generates default import", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          {
+            source: "lodash",
+            imported: "default",
+            local: "_",
+            type: "default",
+          },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("import _ from 'lodash';");
+      });
+
+      it("generates named imports", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "utils", imported: "foo", local: "foo", type: "named" },
+          { source: "utils", imported: "bar", local: "baz", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("import { foo, bar as baz } from 'utils';");
+      });
+
+      it("generates namespace import", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "React", imported: "*", local: "React", type: "namespace" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("import * as React from 'React';");
+      });
+
+      it("generates combined default and named imports", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "mod", imported: "default", local: "def", type: "default" },
+          { source: "mod", imported: "named1", local: "named1", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("import def, { named1 } from 'mod';");
+      });
+
+      it("handles multiple sources", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "a", imported: "x", local: "x", type: "named" },
+          { source: "b", imported: "y", local: "y", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toContain("import { x } from 'a';");
+        expect(result).toContain("import { y } from 'b';");
+      });
+
+      it("returns empty string for empty bindings", () => {
+        const result = generateImportCode([], options);
+        expect(result).toBe("");
+      });
+    });
+
+    describe("CJS format", () => {
+      const options: RewriteOptions = { ...baseOptions, format: "cjs" };
+
+      it("generates require for named imports", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "utils", imported: "foo", local: "foo", type: "named" },
+          { source: "utils", imported: "bar", local: "baz", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const { foo, bar: baz } = require('utils');");
+      });
+
+      it("generates require for default import with .default access", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          {
+            source: "lodash",
+            imported: "default",
+            local: "_",
+            type: "default",
+          },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const _ = require('lodash').default;");
+      });
+
+      it("generates require for default import with defaultOnly interop", () => {
+        const opts: RewriteOptions = { ...options, interop: "defaultOnly" };
+        const bindings: ReadonlyArray<ImportBinding> = [
+          {
+            source: "lodash",
+            imported: "default",
+            local: "_",
+            type: "default",
+          },
+        ];
+        const result = generateImportCode(bindings, opts);
+        expect(result).toBe("const _ = require('lodash');");
+      });
+
+      it("generates require for namespace import", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "fs", imported: "*", local: "fs", type: "namespace" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const fs = require('fs');");
+      });
+
+      it("uses var when constBindings is false", () => {
+        const opts: RewriteOptions = { ...options, constBindings: false };
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "x", imported: "a", local: "a", type: "named" },
+        ];
+        const result = generateImportCode(bindings, opts);
+        expect(result).toBe("var { a } = require('x');");
+      });
+
+      it("returns empty string for empty bindings", () => {
+        const result = generateImportCode([], options);
+        expect(result).toBe("");
+      });
+
+      it("handles multiple sources with different binding types", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          {
+            source: "a",
+            imported: "default",
+            local: "aDefault",
+            type: "default",
+          },
+          { source: "a", imported: "foo", local: "foo", type: "named" },
+          { source: "b", imported: "*", local: "bAll", type: "namespace" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toContain("const aDefault = require('a').default;");
+        expect(result).toContain("const { foo } = require('a');");
+        expect(result).toContain("const bAll = require('b');");
+      });
+    });
+
+    describe("IIFE/UMD format", () => {
+      const options: RewriteOptions = { ...baseOptions, format: "iife" };
+
+      it("generates global access for named imports", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "myLib", imported: "foo", local: "foo", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const foo = globalThis.myLib.foo;");
+      });
+
+      it("generates global access for default imports", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          {
+            source: "myLib",
+            imported: "default",
+            local: "lib",
+            type: "default",
+          },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const lib = globalThis.myLib.default;");
+      });
+
+      it("generates global access for namespace imports", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "myLib", imported: "*", local: "lib", type: "namespace" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const lib = globalThis.myLib;");
+      });
+
+      it("sanitizes source names for global access", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          {
+            source: "@scope/my-lib",
+            imported: "foo",
+            local: "foo",
+            type: "named",
+          },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const foo = globalThis.scope_my_lib.foo;");
+      });
+
+      it("uses var when constBindings is false", () => {
+        const opts: RewriteOptions = { ...options, constBindings: false };
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "lib", imported: "x", local: "x", type: "named" },
+        ];
+        const result = generateImportCode(bindings, opts);
+        expect(result).toBe("var x = globalThis.lib.x;");
+      });
+
+      it("falls back to _module for sources that sanitize to empty string", () => {
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "---", imported: "x", local: "x", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("const x = globalThis._module.x;");
+      });
+
+      it("UMD format uses same logic as IIFE", () => {
+        const umdOpts: RewriteOptions = { ...baseOptions, format: "umd" };
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "lib", imported: "x", local: "x", type: "named" },
+        ];
+        const result = generateImportCode(bindings, umdOpts);
+        expect(result).toBe("const x = globalThis.lib.x;");
+      });
+
+      it("returns empty string for empty bindings", () => {
+        const result = generateImportCode([], options);
+        expect(result).toBe("");
+      });
+    });
+
+    describe("AMD format", () => {
+      it("returns empty string (AMD uses define() deps array)", () => {
+        const options: RewriteOptions = { ...baseOptions, format: "amd" };
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "lib", imported: "x", local: "x", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("");
+      });
+    });
+
+    describe("SystemJS format", () => {
+      it("returns empty string (SystemJS uses setters)", () => {
+        const options: RewriteOptions = { ...baseOptions, format: "system" };
+        const bindings: ReadonlyArray<ImportBinding> = [
+          { source: "lib", imported: "x", local: "x", type: "named" },
+        ];
+        const result = generateImportCode(bindings, options);
+        expect(result).toBe("");
+      });
+    });
+  });
+
+  describe("generateExportCode", () => {
+    describe("ES format", () => {
+      const options: RewriteOptions = { ...baseOptions, format: "es" };
+
+      it("generates named exports", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+          { local: "bar", exported: "baz", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("export { foo, bar as baz };");
+      });
+
+      it("generates default export", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "myVal", exported: "default", type: "default" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("export default myVal;");
+      });
+
+      it("generates combined default and named exports", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "main", exported: "default", type: "default" },
+          { local: "helper", exported: "helper", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toContain("export default main;");
+        expect(result).toContain("export { helper };");
+      });
+
+      it("returns empty string for empty bindings", () => {
+        const result = generateExportCode([], options);
+        expect(result).toBe("");
+      });
+    });
+
+    describe("CJS format with live bindings", () => {
+      const options: RewriteOptions = {
+        ...baseOptions,
+        format: "cjs",
+        externalLiveBindings: true,
+      };
+
+      it("generates Object.defineProperty for named exports", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe(
+          "Object.defineProperty(exports, 'foo', { enumerable: true, get: function() { return foo; } });",
+        );
+      });
+
+      it("generates Object.defineProperty for default export", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "myDefault", exported: "default", type: "default" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe(
+          "Object.defineProperty(exports, 'default', { enumerable: true, get: function() { return myDefault; } });",
+        );
+      });
+
+      it("generates multiple defineProperty calls", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "a", exported: "a", type: "named" },
+          { local: "b", exported: "b", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        const lines = result.split("\n");
+        expect(lines).toHaveLength(2);
+        expect(lines[0]).toContain("'a'");
+        expect(lines[1]).toContain("'b'");
+      });
+    });
+
+    describe("CJS format without live bindings", () => {
+      const options: RewriteOptions = {
+        ...baseOptions,
+        format: "cjs",
+        externalLiveBindings: false,
+      };
+
+      it("generates simple assignment for named exports", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports.foo = foo;");
+      });
+
+      it("generates simple assignment for default export", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "myDefault", exported: "default", type: "default" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports.default = myDefault;");
+      });
+
+      it("generates multiple assignments", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "x", exported: "x", type: "named" },
+          { local: "y", exported: "y", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports.x = x;\nexports.y = y;");
+      });
+
+      it("returns empty string for empty bindings", () => {
+        const result = generateExportCode([], options);
+        expect(result).toBe("");
+      });
+    });
+
+    describe("IIFE/UMD format", () => {
+      it("generates live binding exports for IIFE", () => {
+        const options: RewriteOptions = {
+          ...baseOptions,
+          format: "iife",
+          externalLiveBindings: true,
+        };
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toContain("Object.defineProperty(exports, 'foo'");
+      });
+
+      it("generates simple assignment exports for IIFE without live bindings", () => {
+        const options: RewriteOptions = {
+          ...baseOptions,
+          format: "iife",
+          externalLiveBindings: false,
+        };
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports.foo = foo;");
+      });
+
+      it("UMD format uses same logic as IIFE", () => {
+        const options: RewriteOptions = {
+          ...baseOptions,
+          format: "umd",
+          externalLiveBindings: false,
+        };
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "bar", exported: "bar", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports.bar = bar;");
+      });
+
+      it("generates export for default type in IIFE", () => {
+        const options: RewriteOptions = {
+          ...baseOptions,
+          format: "iife",
+          externalLiveBindings: false,
+        };
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "main", exported: "default", type: "default" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports.default = main;");
+      });
+
+      it("returns empty string for empty bindings", () => {
+        const options: RewriteOptions = { ...baseOptions, format: "iife" };
+        const result = generateExportCode([], options);
+        expect(result).toBe("");
+      });
+    });
+
+    describe("AMD format", () => {
+      it("uses CJS-style exports (same as CJS format)", () => {
+        const options: RewriteOptions = {
+          ...baseOptions,
+          format: "amd",
+          externalLiveBindings: true,
+        };
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toContain("Object.defineProperty(exports, 'foo'");
+      });
+
+      it("uses simple assignment without live bindings", () => {
+        const options: RewriteOptions = {
+          ...baseOptions,
+          format: "amd",
+          externalLiveBindings: false,
+        };
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports.foo = foo;");
+      });
+    });
+
+    describe("SystemJS format", () => {
+      const options: RewriteOptions = { ...baseOptions, format: "system" };
+
+      it("generates exports() calls for named exports", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "foo", exported: "foo", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports('foo', foo);");
+      });
+
+      it("generates exports() call for default export", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "myVal", exported: "default", type: "default" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports('default', myVal);");
+      });
+
+      it("generates multiple exports() calls", () => {
+        const bindings: ReadonlyArray<ExportBinding> = [
+          { local: "a", exported: "a", type: "named" },
+          { local: "b", exported: "b", type: "named" },
+        ];
+        const result = generateExportCode(bindings, options);
+        expect(result).toBe("exports('a', a);\nexports('b', b);");
+      });
+
+      it("returns empty string for empty bindings", () => {
+        const result = generateExportCode([], options);
+        expect(result).toBe("");
+      });
+    });
+  });
+
+  describe("generateEsModuleMarker", () => {
+    it("generates marker when esModule is true", () => {
+      const options: RewriteOptions = { ...baseOptions, esModule: true };
+      const result = generateEsModuleMarker(options);
+      expect(result).toBe(
+        "Object.defineProperty(exports, '__esModule', { value: true });",
+      );
+    });
+
+    it("generates marker when esModule is 'if-default-prop'", () => {
+      const options: RewriteOptions = {
+        ...baseOptions,
+        esModule: "if-default-prop",
+      };
+      const result = generateEsModuleMarker(options);
+      expect(result).toBe(
+        "Object.defineProperty(exports, '__esModule', { value: true });",
+      );
+    });
+
+    it("returns empty string when esModule is false", () => {
+      const options: RewriteOptions = { ...baseOptions, esModule: false };
+      const result = generateEsModuleMarker(options);
+      expect(result).toBe("");
+    });
+
+    it("returns empty string when esModule is undefined", () => {
+      const options: RewriteOptions = {
+        format: "cjs",
+        interop: "auto",
+        constBindings: true,
+      };
+      const result = generateEsModuleMarker(options);
+      expect(result).toBe("");
+    });
+  });
+
+  describe("generateNamespaceObject", () => {
+    it("generates frozen namespace object with bindings", () => {
+      const bindings: ReadonlyArray<ExportBinding> = [
+        { local: "foo", exported: "foo", type: "named" },
+        { local: "bar", exported: "baz", type: "named" },
+      ];
+      const options: RewriteOptions = { ...baseOptions, freeze: true };
+      const result = generateNamespaceObject(bindings, "ns", options);
+      expect(result).toContain("const ns = Object.freeze(");
+      expect(result).toContain("foo");
+      expect(result).toContain("baz: bar");
+    });
+
+    it("generates unfrozen namespace object when freeze is false", () => {
+      const bindings: ReadonlyArray<ExportBinding> = [
+        { local: "foo", exported: "foo", type: "named" },
+      ];
+      const options: RewriteOptions = { ...baseOptions, freeze: false };
+      const result = generateNamespaceObject(bindings, "ns", options);
+      expect(result).not.toContain("Object.freeze");
+      expect(result).toContain("const ns = {");
+    });
+
+    it("uses var when constBindings is false", () => {
+      const bindings: ReadonlyArray<ExportBinding> = [
+        { local: "x", exported: "x", type: "named" },
+      ];
+      const options: RewriteOptions = { ...baseOptions, constBindings: false };
+      const result = generateNamespaceObject(bindings, "myNs", options);
+      expect(result).toContain("var myNs = ");
+    });
+
+    it("handles empty bindings with freeze", () => {
+      const options: RewriteOptions = { ...baseOptions, freeze: true };
+      const result = generateNamespaceObject([], "empty", options);
+      expect(result).toBe("const empty = Object.freeze({});");
+    });
+
+    it("handles empty bindings without freeze", () => {
+      const options: RewriteOptions = { ...baseOptions, freeze: false };
+      const result = generateNamespaceObject([], "empty", options);
+      expect(result).toBe("const empty = {};");
+    });
+
+    it("handles default export binding in namespace", () => {
+      const bindings: ReadonlyArray<ExportBinding> = [
+        { local: "myDefault", exported: "default", type: "default" },
+        { local: "named1", exported: "named1", type: "named" },
+      ];
+      const options: RewriteOptions = { ...baseOptions, freeze: true };
+      const result = generateNamespaceObject(bindings, "ns", options);
+      expect(result).toContain("default: myDefault");
+      expect(result).toContain("named1");
+    });
+
+    it("generates frozen empty object when freeze undefined (defaults true)", () => {
+      const options: RewriteOptions = {
+        format: "cjs",
+        interop: "auto",
+        constBindings: true,
+      };
+      const result = generateNamespaceObject([], "ns", options);
+      expect(result).toBe("const ns = Object.freeze({});");
+    });
+
+    it("uses var for empty bindings when constBindings is false", () => {
+      const options: RewriteOptions = { ...baseOptions, constBindings: false };
+      const result = generateNamespaceObject([], "ns", options);
+      expect(result).toBe("var ns = Object.freeze({});");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/codegen/import-export.ts` with format-specific import/export code generation for ES, CJS, IIFE, UMD, AMD, and SystemJS formats
- Support live bindings (Object.defineProperty), namespace object generation (with freeze), __esModule marker, and configurable const/var bindings
- Add comprehensive unit tests (57 tests) with 100% coverage across all metrics

## Test plan
- [x] All 57 unit tests pass covering ES/CJS/IIFE/UMD/AMD/SystemJS import and export generation
- [x] 100% statement, branch, function, and line coverage
- [x] TypeScript strict mode typecheck passes
- [x] Prettier formatting verified

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)