### PR TITLE
feat: implement interop modes

### DIFF
--- a/src/codegen/interop.ts
+++ b/src/codegen/interop.ts
@@ -1,0 +1,178 @@
+/**
+ * @module codegen/interop
+ * @description Interop mode helpers for external CJS module imports.
+ * Determines how default/namespace imports from external CommonJS modules
+ * are handled during code generation.
+ *
+ * Modes:
+ * - 'auto': detect based on __esModule flag at runtime
+ * - 'esModule': assume all externals are ES modules (access .default directly)
+ * - 'default': wrap in default-getting helper, namespace is the module itself
+ * - 'defaultOnly': external is the default export itself (no namespace access)
+ */
+
+/**
+ * The supported interop types for external module handling.
+ * Boolean values are normalized: true → 'auto', false → 'esModule'.
+ */
+export type InteropType =
+  | "auto"
+  | "esModule"
+  | "default"
+  | "defaultOnly"
+  | boolean;
+
+/**
+ * A function that resolves the interop type for a given module ID.
+ */
+export type InteropResolver = (id: string | null) => InteropType;
+
+/**
+ * Generates the interop helper function code that provides runtime
+ * __esModule detection for 'auto' mode imports.
+ *
+ * @param interop - The interop mode to generate helpers for
+ * @param constBindings - Whether to use const (true) or var (false) bindings
+ * @returns The helper function source code, or empty string if not needed
+ */
+export const generateInteropHelper = (
+  interop: InteropType,
+  constBindings: boolean,
+): string => {
+  const normalized = normalizeSingleInterop(interop);
+
+  if (normalized === "esModule" || normalized === "defaultOnly") {
+    return "";
+  }
+
+  const binding = constBindings ? "const" : "var";
+
+  if (normalized === "auto") {
+    return [
+      `function _interopDefault(e) {`,
+      `  return e && e.__esModule && Object.prototype.hasOwnProperty.call(e, 'default')`,
+      `    ? e['default']`,
+      `    : e;`,
+      `}`,
+      `function _interopNamespace(e) {`,
+      `  if (e && e.__esModule) return e;`,
+      `  ${binding} n = Object.create(null);`,
+      `  if (e) {`,
+      `    for (${binding} k in e) {`,
+      `      if (k !== 'default') {`,
+      `        ${binding} d = Object.getOwnPropertyDescriptor(e, k);`,
+      `        Object.defineProperty(n, k, d.get ? d : {`,
+      `          enumerable: true,`,
+      `          get: function () { return e[k]; }`,
+      `        });`,
+      `      }`,
+      `    }`,
+      `  }`,
+      `  n['default'] = e;`,
+      `  return Object.freeze(n);`,
+      `}`,
+    ].join("\n");
+  }
+
+  // 'default' mode
+  return [
+    `function _interopDefault(e) {`,
+    `  return e && e.__esModule && Object.prototype.hasOwnProperty.call(e, 'default')`,
+    `    ? e['default']`,
+    `    : e;`,
+    `}`,
+  ].join("\n");
+};
+
+/**
+ * Generates namespace access code for an external module.
+ * This determines how `import * as ns from 'ext'` is compiled.
+ *
+ * @param localName - The local variable name holding the required module
+ * @param interop - The interop mode
+ * @returns Expression code for namespace access
+ */
+export const generateNamespaceAccess = (
+  localName: string,
+  interop: InteropType,
+): string => {
+  const normalized = normalizeSingleInterop(interop);
+
+  switch (normalized) {
+    case "esModule":
+      return localName;
+    case "default":
+      return localName;
+    case "defaultOnly":
+      return `{ 'default': ${localName} }`;
+    case "auto":
+      return `_interopNamespace(${localName})`;
+  }
+};
+
+/**
+ * Generates default import access code for an external module.
+ * This determines how `import def from 'ext'` is compiled.
+ *
+ * @param localName - The local variable name holding the required module
+ * @param interop - The interop mode
+ * @returns Expression code for default access
+ */
+export const generateDefaultAccess = (
+  localName: string,
+  interop: InteropType,
+): string => {
+  const normalized = normalizeSingleInterop(interop);
+
+  switch (normalized) {
+    case "esModule":
+      return `${localName}['default']`;
+    case "default":
+      return `_interopDefault(${localName})`;
+    case "defaultOnly":
+      return localName;
+    case "auto":
+      return `_interopDefault(${localName})`;
+  }
+};
+
+/**
+ * Normalizes an interop option into a resolver function.
+ * Handles boolean values (true → 'auto', false → 'esModule'),
+ * string literals, and function-form options.
+ *
+ * @param interop - The interop option (string, boolean, or resolver function)
+ * @returns A resolver function that returns the interop type for a given module ID
+ */
+export const normalizeInterop = (
+  interop: InteropType | ((id: string | null) => InteropType),
+): InteropResolver => {
+  if (typeof interop === "function") {
+    return (id: string | null): InteropType => {
+      const result = interop(id);
+      return normalizeSingleInterop(result);
+    };
+  }
+
+  const normalized = normalizeSingleInterop(interop);
+  return (_id: string | null): InteropType => normalized;
+};
+
+/**
+ * Normalizes a single interop value, converting booleans to their
+ * string equivalents.
+ *
+ * @param interop - The raw interop value
+ * @returns The normalized string interop type
+ */
+const normalizeSingleInterop = (
+  interop: InteropType,
+): "auto" | "esModule" | "default" | "defaultOnly" => {
+  if (interop === true) {
+    return "auto";
+  }
+  if (interop === false) {
+    return "esModule";
+  }
+  return interop;
+};

--- a/tests/unit/codegen/interop.test.ts
+++ b/tests/unit/codegen/interop.test.ts
@@ -1,0 +1,237 @@
+/**
+ * @module tests/unit/codegen/interop
+ * @description Unit tests for interop mode helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateInteropHelper,
+  generateNamespaceAccess,
+  generateDefaultAccess,
+  normalizeInterop,
+} from "../../../src/codegen/interop.js";
+import type { InteropType } from "../../../src/codegen/interop.js";
+
+describe("codegen/interop", () => {
+  describe("generateInteropHelper", () => {
+    it("returns empty string for esModule mode", () => {
+      const result = generateInteropHelper("esModule", true);
+      expect(result).toBe("");
+    });
+
+    it("returns empty string for defaultOnly mode", () => {
+      const result = generateInteropHelper("defaultOnly", false);
+      expect(result).toBe("");
+    });
+
+    it("returns empty string for boolean false (esModule)", () => {
+      const result = generateInteropHelper(false, true);
+      expect(result).toBe("");
+    });
+
+    it("generates _interopDefault and _interopNamespace for auto mode", () => {
+      const result = generateInteropHelper("auto", true);
+      expect(result).toContain("function _interopDefault(e)");
+      expect(result).toContain("function _interopNamespace(e)");
+      expect(result).toContain("e.__esModule");
+      expect(result).toContain("Object.freeze(n)");
+    });
+
+    it("generates _interopDefault and _interopNamespace for boolean true (auto)", () => {
+      const result = generateInteropHelper(true, true);
+      expect(result).toContain("function _interopDefault(e)");
+      expect(result).toContain("function _interopNamespace(e)");
+    });
+
+    it("uses const bindings when constBindings is true in auto mode", () => {
+      const result = generateInteropHelper("auto", true);
+      expect(result).toContain("const n = Object.create(null)");
+      expect(result).toContain("const k in e");
+      expect(result).toContain("const d = Object.getOwnPropertyDescriptor");
+    });
+
+    it("uses var bindings when constBindings is false in auto mode", () => {
+      const result = generateInteropHelper("auto", false);
+      expect(result).toContain("var n = Object.create(null)");
+      expect(result).toContain("var k in e");
+      expect(result).toContain("var d = Object.getOwnPropertyDescriptor");
+    });
+
+    it("generates only _interopDefault for default mode", () => {
+      const result = generateInteropHelper("default", true);
+      expect(result).toContain("function _interopDefault(e)");
+      expect(result).not.toContain("function _interopNamespace(e)");
+    });
+
+    it("includes hasOwnProperty check in auto mode helper", () => {
+      const result = generateInteropHelper("auto", true);
+      expect(result).toContain(
+        "Object.prototype.hasOwnProperty.call(e, 'default')",
+      );
+    });
+
+    it("includes hasOwnProperty check in default mode helper", () => {
+      const result = generateInteropHelper("default", false);
+      expect(result).toContain(
+        "Object.prototype.hasOwnProperty.call(e, 'default')",
+      );
+    });
+  });
+
+  describe("generateNamespaceAccess", () => {
+    it("returns localName directly for esModule mode", () => {
+      const result = generateNamespaceAccess("myModule", "esModule");
+      expect(result).toBe("myModule");
+    });
+
+    it("returns localName directly for default mode", () => {
+      const result = generateNamespaceAccess("myModule", "default");
+      expect(result).toBe("myModule");
+    });
+
+    it("wraps in object literal for defaultOnly mode", () => {
+      const result = generateNamespaceAccess("myModule", "defaultOnly");
+      expect(result).toBe("{ 'default': myModule }");
+    });
+
+    it("wraps in _interopNamespace for auto mode", () => {
+      const result = generateNamespaceAccess("myModule", "auto");
+      expect(result).toBe("_interopNamespace(myModule)");
+    });
+
+    it("handles boolean true as auto mode", () => {
+      const result = generateNamespaceAccess("ext", true);
+      expect(result).toBe("_interopNamespace(ext)");
+    });
+
+    it("handles boolean false as esModule mode", () => {
+      const result = generateNamespaceAccess("ext", false);
+      expect(result).toBe("ext");
+    });
+
+    it("handles various local name formats", () => {
+      expect(generateNamespaceAccess("_react", "auto")).toBe(
+        "_interopNamespace(_react)",
+      );
+      expect(generateNamespaceAccess("$lodash", "defaultOnly")).toBe(
+        "{ 'default': $lodash }",
+      );
+      expect(generateNamespaceAccess("require$$1", "esModule")).toBe(
+        "require$$1",
+      );
+    });
+  });
+
+  describe("generateDefaultAccess", () => {
+    it("accesses ['default'] property for esModule mode", () => {
+      const result = generateDefaultAccess("myModule", "esModule");
+      expect(result).toBe("myModule['default']");
+    });
+
+    it("wraps in _interopDefault for default mode", () => {
+      const result = generateDefaultAccess("myModule", "default");
+      expect(result).toBe("_interopDefault(myModule)");
+    });
+
+    it("returns localName directly for defaultOnly mode", () => {
+      const result = generateDefaultAccess("myModule", "defaultOnly");
+      expect(result).toBe("myModule");
+    });
+
+    it("wraps in _interopDefault for auto mode", () => {
+      const result = generateDefaultAccess("myModule", "auto");
+      expect(result).toBe("_interopDefault(myModule)");
+    });
+
+    it("handles boolean true as auto mode", () => {
+      const result = generateDefaultAccess("ext", true);
+      expect(result).toBe("_interopDefault(ext)");
+    });
+
+    it("handles boolean false as esModule mode", () => {
+      const result = generateDefaultAccess("ext", false);
+      expect(result).toBe("ext['default']");
+    });
+
+    it("handles various local name formats", () => {
+      expect(generateDefaultAccess("_react", "auto")).toBe(
+        "_interopDefault(_react)",
+      );
+      expect(generateDefaultAccess("$lodash", "defaultOnly")).toBe("$lodash");
+      expect(generateDefaultAccess("require$$1", "esModule")).toBe(
+        "require$$1['default']",
+      );
+    });
+  });
+
+  describe("normalizeInterop", () => {
+    it("returns a function when given a string interop type", () => {
+      const resolver = normalizeInterop("auto");
+      expect(typeof resolver).toBe("function");
+    });
+
+    it("resolver returns auto for string auto", () => {
+      const resolver = normalizeInterop("auto");
+      expect(resolver("some-module")).toBe("auto");
+      expect(resolver(null)).toBe("auto");
+    });
+
+    it("resolver returns esModule for string esModule", () => {
+      const resolver = normalizeInterop("esModule");
+      expect(resolver("mod")).toBe("esModule");
+    });
+
+    it("resolver returns default for string default", () => {
+      const resolver = normalizeInterop("default");
+      expect(resolver("mod")).toBe("default");
+    });
+
+    it("resolver returns defaultOnly for string defaultOnly", () => {
+      const resolver = normalizeInterop("defaultOnly");
+      expect(resolver("mod")).toBe("defaultOnly");
+    });
+
+    it("normalizes boolean true to auto", () => {
+      const resolver = normalizeInterop(true);
+      expect(resolver("mod")).toBe("auto");
+      expect(resolver(null)).toBe("auto");
+    });
+
+    it("normalizes boolean false to esModule", () => {
+      const resolver = normalizeInterop(false);
+      expect(resolver("mod")).toBe("esModule");
+      expect(resolver(null)).toBe("esModule");
+    });
+
+    it("wraps a function and normalizes its return values", () => {
+      const customFn = (id: string | null): InteropType => {
+        if (id === "react") return "esModule";
+        if (id === "lodash") return "defaultOnly";
+        if (id === null) return true;
+        return "auto";
+      };
+      const resolver = normalizeInterop(customFn);
+      expect(resolver("react")).toBe("esModule");
+      expect(resolver("lodash")).toBe("defaultOnly");
+      expect(resolver(null)).toBe("auto");
+      expect(resolver("other")).toBe("auto");
+    });
+
+    it("normalizes boolean returns from custom function", () => {
+      const customFn = (id: string | null): InteropType => {
+        if (id === "legacy") return true;
+        return false;
+      };
+      const resolver = normalizeInterop(customFn);
+      expect(resolver("legacy")).toBe("auto");
+      expect(resolver("modern")).toBe("esModule");
+    });
+
+    it("returns consistent results for repeated calls", () => {
+      const resolver = normalizeInterop("default");
+      expect(resolver("a")).toBe("default");
+      expect(resolver("b")).toBe("default");
+      expect(resolver(null)).toBe("default");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/codegen/interop.ts` implementing external module interop helpers for `auto`, `esModule`, `default`, and `defaultOnly` modes
- Provides runtime `__esModule` detection helpers, namespace access generation, default import access generation, and interop option normalization
- 100% test coverage with 34 unit tests covering all modes, boolean normalization, and custom resolver functions

## Test plan

- [x] All 34 unit tests pass (`npx vitest run tests/unit/codegen/interop.test.ts`)
- [x] TypeScript strict mode passes with no errors
- [x] 100% line/branch/function/statement coverage on `src/codegen/interop.ts`
- [ ] CI pipeline passes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)