### PR TITLE
feat: module concatenation, output validation, and addon hooks

### DIFF
--- a/src/codegen/addons.ts
+++ b/src/codegen/addons.ts
@@ -1,0 +1,124 @@
+/**
+ * @module codegen/addons
+ * @description Banner/footer/intro/outro addon hooks for output generation.
+ * Processes addon values that can be strings or functions (sync or async),
+ * and applies them to generated code in the correct positions.
+ */
+
+/**
+ * An addon value: a string literal, a sync function returning a string,
+ * or an async function returning a string.
+ */
+export type AddonValue =
+  | string
+  | (() => string)
+  | (() => Promise<string>)
+  | null
+  | undefined;
+
+/**
+ * Collection of all addon hooks for output generation.
+ */
+export interface Addons {
+  readonly banner?: AddonValue;
+  readonly footer?: AddonValue;
+  readonly intro?: AddonValue;
+  readonly outro?: AddonValue;
+}
+
+/**
+ * Resolved addon strings ready for application.
+ */
+export interface ResolvedAddons {
+  readonly banner: string;
+  readonly footer: string;
+  readonly intro: string;
+  readonly outro: string;
+}
+
+/**
+ * Resolve a single addon value to a string.
+ * Handles null/undefined (returns empty string), string literals,
+ * and sync/async function values.
+ *
+ * @param value - The addon value to resolve
+ * @returns The resolved string value
+ */
+export const resolveAddon = async (value: AddonValue): Promise<string> => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  const result = value();
+  if (typeof result === "string") {
+    return result;
+  }
+  return await result;
+};
+
+/**
+ * Resolve all addon values in an Addons object to strings.
+ *
+ * @param addons - The addons object with potentially unresolved values
+ * @returns A fully resolved addons object with string values
+ */
+export const resolveAllAddons = async (
+  addons: Addons,
+): Promise<ResolvedAddons> => {
+  const [banner, footer, intro, outro] = await Promise.all([
+    resolveAddon(addons.banner),
+    resolveAddon(addons.footer),
+    resolveAddon(addons.intro),
+    resolveAddon(addons.outro),
+  ]);
+  return { banner, footer, intro, outro };
+};
+
+/**
+ * Apply resolved addons to generated code.
+ *
+ * Placement order:
+ * 1. Banner goes before everything
+ * 2. Intro goes at the start of the wrapper function body (after banner)
+ * 3. The main code
+ * 4. Outro goes at the end of the wrapper function body (before footer)
+ * 5. Footer goes after everything
+ *
+ * @param code - The generated code to wrap with addons
+ * @param addons - The resolved addon strings
+ * @returns The code with all addons applied
+ */
+export const applyAddons = (code: string, addons: ResolvedAddons): string => {
+  const parts: Array<string> = [];
+
+  if (addons.banner.length > 0) {
+    parts.push(addons.banner);
+    parts.push("\n");
+  }
+
+  if (addons.intro.length > 0) {
+    parts.push(addons.intro);
+    parts.push("\n");
+  }
+
+  parts.push(code);
+
+  if (addons.outro.length > 0) {
+    if (code.length > 0 && !code.endsWith("\n")) {
+      parts.push("\n");
+    }
+    parts.push(addons.outro);
+  }
+
+  if (addons.footer.length > 0) {
+    const current = parts.join("");
+    if (current.length > 0 && !current.endsWith("\n")) {
+      parts.push("\n");
+    }
+    parts.push(addons.footer);
+  }
+
+  return parts.join("");
+};

--- a/src/codegen/concatenate.ts
+++ b/src/codegen/concatenate.ts
@@ -1,0 +1,187 @@
+/**
+ * @module codegen/concatenate
+ * @description Module concatenation for chunk generation. Takes an ordered array
+ * of rendered module code strings and concatenates them into a single chunk,
+ * handling separators, namespace wrappers, and source position tracking.
+ */
+
+/**
+ * Represents a rendered module ready for concatenation.
+ */
+export interface RenderedModule {
+  readonly id: string;
+  readonly code: string;
+  readonly magicString?: { toString(): string } | undefined;
+}
+
+/**
+ * Options for module concatenation.
+ */
+export interface ConcatenateOptions {
+  readonly separator?: string;
+  readonly namespace?: ReadonlyMap<string, string>;
+  readonly banner?: string;
+  readonly footer?: string;
+}
+
+/**
+ * Tracks the source position of a module within the concatenated output.
+ */
+export interface SourcePosition {
+  readonly moduleId: string;
+  readonly startLine: number;
+  readonly startColumn: number;
+  readonly endLine: number;
+  readonly endColumn: number;
+  readonly startOffset: number;
+  readonly endOffset: number;
+}
+
+/**
+ * Result of module concatenation.
+ */
+export interface ConcatenateResult {
+  readonly code: string;
+  readonly map?: ReadonlyArray<SourcePosition>;
+}
+
+/**
+ * Count the number of newline characters in a string.
+ *
+ * @param str - The string to count newlines in
+ * @returns The number of newlines found
+ */
+const countNewlines = (str: string): number => {
+  let count = 0;
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === "\n") {
+      count++;
+    }
+  }
+  return count;
+};
+
+/**
+ * Get the column offset after the last newline in a string.
+ * If no newline exists, returns the full string length added to the given base column.
+ *
+ * @param str - The string to examine
+ * @param baseColumn - The starting column if no newline is found
+ * @returns The column position after the last newline
+ */
+const getLastLineColumn = (str: string, baseColumn: number): number => {
+  const lastNewline = str.lastIndexOf("\n");
+  if (lastNewline === -1) {
+    return baseColumn + str.length;
+  }
+  return str.length - lastNewline - 1;
+};
+
+/**
+ * Wrap module code in a namespace IIFE.
+ *
+ * @param code - The module code to wrap
+ * @param namespaceName - The namespace variable name
+ * @returns The wrapped code
+ */
+const wrapNamespace = (code: string, namespaceName: string): string => {
+  return `var ${namespaceName} = (function() {\n${code}\n})();`;
+};
+
+/**
+ * Concatenate an ordered array of rendered modules into a single chunk.
+ * Handles separators between modules, applies namespace wrappers where needed,
+ * and tracks source positions for source map offset calculation.
+ *
+ * @param modules - Ordered array of rendered modules
+ * @param options - Concatenation options (separator, namespace map, banner, footer)
+ * @returns The concatenated code and source position map
+ */
+export const concatenateModules = (
+  modules: ReadonlyArray<RenderedModule>,
+  options?: ConcatenateOptions,
+): ConcatenateResult => {
+  const separator = options?.separator ?? "\n\n";
+  const namespaceMap = options?.namespace;
+  const banner = options?.banner ?? "";
+  const footer = options?.footer ?? "";
+
+  if (modules.length === 0) {
+    const code = banner + footer;
+    return { code, map: [] };
+  }
+
+  const parts: Array<string> = [];
+  const positions: Array<SourcePosition> = [];
+
+  let currentLine = 0;
+  let currentColumn = 0;
+  let currentOffset = 0;
+
+  // Add banner if present
+  if (banner.length > 0) {
+    parts.push(banner);
+    currentLine += countNewlines(banner);
+    currentColumn = getLastLineColumn(banner, currentColumn);
+    currentOffset += banner.length;
+  }
+
+  for (let i = 0; i < modules.length; i++) {
+    const mod = modules[i];
+
+    // Add separator between modules (not before first if no banner)
+    if (i > 0 || banner.length > 0) {
+      parts.push(separator);
+      currentLine += countNewlines(separator);
+      currentColumn = getLastLineColumn(separator, currentColumn);
+      currentOffset += separator.length;
+    }
+
+    // Resolve module code - prefer magicString.toString() if available
+    const rawCode =
+      mod.magicString !== undefined && mod.magicString !== null
+        ? mod.magicString.toString()
+        : mod.code;
+
+    // Apply namespace wrapper if needed
+    const moduleCode =
+      namespaceMap !== undefined && namespaceMap.has(mod.id)
+        ? wrapNamespace(rawCode, namespaceMap.get(mod.id)!)
+        : rawCode;
+
+    // Track start position
+    const startLine = currentLine;
+    const startColumn = currentColumn;
+    const startOffset = currentOffset;
+
+    // Add module code
+    parts.push(moduleCode);
+
+    // Calculate end position
+    currentLine += countNewlines(moduleCode);
+    currentColumn = getLastLineColumn(moduleCode, currentColumn);
+    currentOffset += moduleCode.length;
+
+    positions.push({
+      moduleId: mod.id,
+      startLine,
+      startColumn,
+      endLine: currentLine,
+      endColumn: currentColumn,
+      startOffset,
+      endOffset: currentOffset,
+    });
+  }
+
+  // Add footer if present
+  if (footer.length > 0) {
+    parts.push(separator);
+    currentOffset += separator.length;
+    currentLine += countNewlines(separator);
+    currentColumn = getLastLineColumn(separator, currentColumn);
+    parts.push(footer);
+  }
+
+  const code = parts.join("");
+  return { code, map: positions };
+};

--- a/src/codegen/validate.ts
+++ b/src/codegen/validate.ts
@@ -1,0 +1,71 @@
+/**
+ * @module codegen/validate
+ * @description Output validation for generated code. When validate option is enabled,
+ * parses the generated output back through our parser to verify correctness.
+ */
+
+import { parse } from "../parser/parser.js";
+
+/**
+ * Result of output validation.
+ */
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Error code for validation failures.
+ */
+export const VALIDATION_ERROR = "VALIDATION_ERROR" as const;
+
+/**
+ * Structured validation error with code and details.
+ */
+export interface ValidationError {
+  readonly code: typeof VALIDATION_ERROR;
+  readonly message: string;
+  readonly fileName: string;
+}
+
+/**
+ * Validate generated output by parsing it back through our parser.
+ * If parsing fails, returns an error with the parse failure details.
+ *
+ * @param code - The generated code to validate
+ * @param fileName - The output file name (for error reporting)
+ * @returns A validation result indicating success or failure with details
+ */
+export const validateOutput = (
+  code: string,
+  fileName: string,
+): ValidationResult => {
+  try {
+    parse(code, { sourceType: "module" });
+    return { valid: true };
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error
+        ? `${VALIDATION_ERROR} in ${fileName}: ${err.message}`
+        : `${VALIDATION_ERROR} in ${fileName}: Unknown parse error`;
+    return { valid: false, error: message };
+  }
+};
+
+/**
+ * Create a structured validation error object.
+ *
+ * @param message - The error message from the parser
+ * @param fileName - The file name that failed validation
+ * @returns A structured ValidationError object
+ */
+export const createValidationError = (
+  message: string,
+  fileName: string,
+): ValidationError => {
+  return {
+    code: VALIDATION_ERROR,
+    message: `${VALIDATION_ERROR} in ${fileName}: ${message}`,
+    fileName,
+  };
+};

--- a/tests/unit/codegen/codegen-final.test.ts
+++ b/tests/unit/codegen/codegen-final.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect } from "vitest";
+import {
+  concatenateModules,
+  type RenderedModule,
+  type ConcatenateOptions,
+} from "../../../src/codegen/concatenate.js";
+import {
+  validateOutput,
+  createValidationError,
+  VALIDATION_ERROR,
+} from "../../../src/codegen/validate.js";
+import {
+  resolveAddon,
+  resolveAllAddons,
+  applyAddons,
+  type ResolvedAddons,
+} from "../../../src/codegen/addons.js";
+
+describe("concatenateModules", () => {
+  it("concatenates multiple modules with default separator", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "const a = 1;" },
+      { id: "mod2", code: "const b = 2;" },
+      { id: "mod3", code: "const c = 3;" },
+    ];
+    const result = concatenateModules(modules);
+    expect(result.code).toBe("const a = 1;\n\nconst b = 2;\n\nconst c = 3;");
+  });
+
+  it("concatenates with a custom separator", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "const a = 1;" },
+      { id: "mod2", code: "const b = 2;" },
+    ];
+    const result = concatenateModules(modules, { separator: "\n" });
+    expect(result.code).toBe("const a = 1;\nconst b = 2;");
+  });
+
+  it("handles empty module array", () => {
+    const result = concatenateModules([]);
+    expect(result.code).toBe("");
+    expect(result.map).toEqual([]);
+  });
+
+  it("handles a single module", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "only", code: "export const x = 42;" },
+    ];
+    const result = concatenateModules(modules);
+    expect(result.code).toBe("export const x = 42;");
+    expect(result.map).toHaveLength(1);
+    expect(result.map![0].moduleId).toBe("only");
+  });
+
+  it("tracks source positions for source map offsets", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "line1\nline2" },
+      { id: "mod2", code: "line3\nline4" },
+    ];
+    const result = concatenateModules(modules, { separator: "\n" });
+    const positions = result.map!;
+
+    expect(positions[0].moduleId).toBe("mod1");
+    expect(positions[0].startLine).toBe(0);
+    expect(positions[0].startColumn).toBe(0);
+    expect(positions[0].startOffset).toBe(0);
+    expect(positions[0].endLine).toBe(1);
+    expect(positions[0].endOffset).toBe(11);
+
+    expect(positions[1].moduleId).toBe("mod2");
+    expect(positions[1].startLine).toBe(2);
+    expect(positions[1].startOffset).toBe(12);
+    expect(positions[1].endLine).toBe(3);
+    expect(positions[1].endOffset).toBe(23);
+  });
+
+  it("applies namespace wrappers for modules that need them", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "const x = 1;" },
+      { id: "mod2", code: "const y = 2;" },
+    ];
+    const namespaceMap = new Map([["mod1", "ns_mod1"]]);
+    const result = concatenateModules(modules, { namespace: namespaceMap });
+    expect(result.code).toContain("var ns_mod1 = (function() {");
+    expect(result.code).toContain("const x = 1;");
+    expect(result.code).toContain("})();");
+    expect(result.code).toContain("const y = 2;");
+  });
+
+  it("does not wrap modules without namespace mapping", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "const x = 1;" },
+    ];
+    const namespaceMap = new Map([["other", "ns_other"]]);
+    const result = concatenateModules(modules, { namespace: namespaceMap });
+    expect(result.code).toBe("const x = 1;");
+  });
+
+  it("uses magicString.toString() when available", () => {
+    const mockMagicString = { toString: () => "magic output;" };
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "original;", magicString: mockMagicString },
+    ];
+    const result = concatenateModules(modules);
+    expect(result.code).toBe("magic output;");
+  });
+
+  it("includes banner and footer in output", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "const a = 1;" },
+    ];
+    const options: ConcatenateOptions = {
+      banner: "/* banner */",
+      footer: "/* footer */",
+    };
+    const result = concatenateModules(modules, options);
+    expect(result.code.startsWith("/* banner */")).toBe(true);
+    expect(result.code).toContain("const a = 1;");
+    expect(result.code.endsWith("/* footer */")).toBe(true);
+  });
+
+  it("handles empty modules with banner and footer", () => {
+    const result = concatenateModules([], {
+      banner: "/* start */",
+      footer: "/* end */",
+    });
+    expect(result.code).toBe("/* start *//* end */");
+  });
+
+  it("tracks positions correctly with banner", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "code" },
+    ];
+    const result = concatenateModules(modules, { banner: "BAN\n" });
+    const pos = result.map![0];
+    // "BAN\n" = 1 newline, separator "\n\n" = 2 newlines, total = 3
+    expect(pos.startLine).toBe(3);
+    expect(pos.startOffset).toBe(6);
+  });
+
+  it("handles multiline module code in position tracking", () => {
+    const modules: ReadonlyArray<RenderedModule> = [
+      { id: "mod1", code: "a\nb\nc" },
+    ];
+    const result = concatenateModules(modules);
+    const pos = result.map![0];
+    expect(pos.startLine).toBe(0);
+    expect(pos.endLine).toBe(2);
+  });
+});
+
+describe("validateOutput", () => {
+  it("returns valid: true for valid JavaScript", () => {
+    const result = validateOutput("const x = 42;", "output.js");
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns valid: true for valid module code", () => {
+    const result = validateOutput(
+      'import { foo } from "./bar.js";\nexport const baz = foo();',
+      "bundle.mjs",
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns valid: false with error for invalid code", () => {
+    const result = validateOutput("const = ;", "broken.js");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain(VALIDATION_ERROR);
+    expect(result.error).toContain("broken.js");
+  });
+
+  it("returns valid: false for unterminated strings", () => {
+    const result = validateOutput('const x = "unterminated', "bad.js");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(VALIDATION_ERROR);
+    expect(result.error).toContain("bad.js");
+  });
+
+  it("returns valid: true for empty string (valid empty module)", () => {
+    const result = validateOutput("", "empty.js");
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns valid: false for unexpected tokens", () => {
+    const result = validateOutput("function {}", "invalid.js");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("invalid.js");
+  });
+
+  it("includes the file name in error messages", () => {
+    const result = validateOutput("@@@", "myfile.js");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("myfile.js");
+  });
+});
+
+describe("createValidationError", () => {
+  it("creates a structured validation error", () => {
+    const err = createValidationError("Unexpected token", "output.js");
+    expect(err.code).toBe(VALIDATION_ERROR);
+    expect(err.fileName).toBe("output.js");
+    expect(err.message).toContain("Unexpected token");
+    expect(err.message).toContain("output.js");
+    expect(err.message).toContain(VALIDATION_ERROR);
+  });
+});
+
+describe("resolveAddon", () => {
+  it("resolves null to empty string", async () => {
+    const result = await resolveAddon(null);
+    expect(result).toBe("");
+  });
+
+  it("resolves undefined to empty string", async () => {
+    const result = await resolveAddon(undefined);
+    expect(result).toBe("");
+  });
+
+  it("resolves a string value directly", async () => {
+    const result = await resolveAddon("/* banner */");
+    expect(result).toBe("/* banner */");
+  });
+
+  it("resolves a sync function", async () => {
+    const result = await resolveAddon(() => "/* generated */");
+    expect(result).toBe("/* generated */");
+  });
+
+  it("resolves an async function", async () => {
+    const result = await resolveAddon(async () => "/* async banner */");
+    expect(result).toBe("/* async banner */");
+  });
+
+  it("resolves empty string", async () => {
+    const result = await resolveAddon("");
+    expect(result).toBe("");
+  });
+});
+
+describe("resolveAllAddons", () => {
+  it("resolves all addon values", async () => {
+    const result = await resolveAllAddons({
+      banner: "/* banner */",
+      footer: "/* footer */",
+      intro: "// intro",
+      outro: "// outro",
+    });
+    expect(result.banner).toBe("/* banner */");
+    expect(result.footer).toBe("/* footer */");
+    expect(result.intro).toBe("// intro");
+    expect(result.outro).toBe("// outro");
+  });
+
+  it("resolves mixed value types", async () => {
+    const result = await resolveAllAddons({
+      banner: () => "fn banner",
+      footer: async () => "async footer",
+      intro: "string intro",
+      outro: null,
+    });
+    expect(result.banner).toBe("fn banner");
+    expect(result.footer).toBe("async footer");
+    expect(result.intro).toBe("string intro");
+    expect(result.outro).toBe("");
+  });
+
+  it("handles all undefined/null values", async () => {
+    const result = await resolveAllAddons({});
+    expect(result.banner).toBe("");
+    expect(result.footer).toBe("");
+    expect(result.intro).toBe("");
+    expect(result.outro).toBe("");
+  });
+});
+
+describe("applyAddons", () => {
+  it("applies banner before everything", () => {
+    const addons: ResolvedAddons = {
+      banner: "/* banner */",
+      footer: "",
+      intro: "",
+      outro: "",
+    };
+    const result = applyAddons("const x = 1;", addons);
+    expect(result).toBe("/* banner */\nconst x = 1;");
+  });
+
+  it("applies footer after everything", () => {
+    const addons: ResolvedAddons = {
+      banner: "",
+      footer: "/* footer */",
+      intro: "",
+      outro: "",
+    };
+    const result = applyAddons("const x = 1;", addons);
+    expect(result).toBe("const x = 1;\n/* footer */");
+  });
+
+  it("applies intro at the start of wrapper body", () => {
+    const addons: ResolvedAddons = {
+      banner: "",
+      footer: "",
+      intro: '"use strict";',
+      outro: "",
+    };
+    const result = applyAddons("const x = 1;", addons);
+    expect(result).toBe('"use strict";\nconst x = 1;');
+  });
+
+  it("applies outro at the end of wrapper body", () => {
+    const addons: ResolvedAddons = {
+      banner: "",
+      footer: "",
+      intro: "",
+      outro: "// end",
+    };
+    const result = applyAddons("const x = 1;", addons);
+    expect(result).toBe("const x = 1;\n// end");
+  });
+
+  it("applies all addons in correct order", () => {
+    const addons: ResolvedAddons = {
+      banner: "/* banner */",
+      footer: "/* footer */",
+      intro: "// intro",
+      outro: "// outro",
+    };
+    const result = applyAddons("CODE", addons);
+    expect(result).toBe("/* banner */\n// intro\nCODE\n// outro\n/* footer */");
+  });
+
+  it("handles empty code with all addons", () => {
+    const addons: ResolvedAddons = {
+      banner: "B",
+      footer: "F",
+      intro: "I",
+      outro: "",
+    };
+    const result = applyAddons("", addons);
+    // banner + \n + intro + \n + code("") -> ends with \n -> footer appended
+    expect(result).toBe("B\nI\nF");
+  });
+
+  it("handles empty code with banner and footer only", () => {
+    const addons: ResolvedAddons = {
+      banner: "B",
+      footer: "F",
+      intro: "",
+      outro: "",
+    };
+    const result = applyAddons("", addons);
+    // banner + \n + code("") -> current is "B\n" ends with \n -> footer appended
+    expect(result).toBe("B\nF");
+  });
+
+  it("handles all empty addons", () => {
+    const addons: ResolvedAddons = {
+      banner: "",
+      footer: "",
+      intro: "",
+      outro: "",
+    };
+    const result = applyAddons("const x = 1;", addons);
+    expect(result).toBe("const x = 1;");
+  });
+
+  it("handles code ending with newline", () => {
+    const addons: ResolvedAddons = {
+      banner: "",
+      footer: "",
+      intro: "",
+      outro: "// end",
+    };
+    const result = applyAddons("const x = 1;\n", addons);
+    expect(result).toBe("const x = 1;\n// end");
+  });
+
+  it("does not add extra newlines when banner ends with newline", () => {
+    const addons: ResolvedAddons = {
+      banner: "/* banner */\n",
+      footer: "",
+      intro: "",
+      outro: "",
+    };
+    const result = applyAddons("code", addons);
+    expect(result).toBe("/* banner */\n\ncode");
+  });
+});


### PR DESCRIPTION
## Summary

- **Module concatenation** (`src/codegen/concatenate.ts`): Takes ordered rendered modules and concatenates into a single chunk with configurable separators, namespace IIFE wrappers, and source position tracking for source map offsets
- **Output validation** (`src/codegen/validate.ts`): Parses generated output back through our parser when `validate: true`, emitting `VALIDATION_ERROR` with parse error details on failure
- **Addon hooks** (`src/codegen/addons.ts`): Processes banner/footer/intro/outro from output options (string or sync/async function), applying them in correct positions around generated code

## Test plan

- [x] 39 unit tests covering all three features in `tests/unit/codegen/codegen-final.test.ts`
- [x] Concatenation: multiple modules joined, custom separators, source map offset tracking, namespace wrappers
- [x] Validation: valid code passes, invalid code returns structured error with file name
- [x] Addons: string values, function values, async function values, null/undefined handling, placement order
- [x] TypeScript strict mode passes with no errors
- [x] All 3742 existing tests continue to pass

Closes #54
Closes #58
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)