### PR TITLE
feat: watch hooks, TransformPluginContext, and EmittedFile handling

### DIFF
--- a/src/plugins/emitted-files.ts
+++ b/src/plugins/emitted-files.ts
@@ -1,0 +1,309 @@
+/**
+ * @module plugins/emitted-files
+ * @description Full lifecycle management for emitted files in steamroller.
+ * Handles assets, chunks, and prebuilt chunks with reference IDs,
+ * source management, and name finalization via configurable patterns.
+ */
+
+import {
+  ASSET_NOT_FOUND,
+  ASSET_SOURCE_ALREADY_SET,
+  ASSET_SOURCE_MISSING,
+  ASSET_NOT_FINALISED,
+} from "../utils/error-codes.js";
+
+/** Options for emitting an asset. */
+export interface EmitAssetOptions {
+  readonly name: string;
+  readonly source?: string | Uint8Array;
+  readonly fileName?: string;
+  readonly needsCodeReference?: boolean;
+}
+
+/** Options for emitting a chunk. */
+export interface EmitChunkOptions {
+  readonly id: string;
+  readonly name?: string;
+  readonly fileName?: string;
+  readonly implicitlyLoadedAfterOneOf?: ReadonlyArray<string>;
+}
+
+/** Options for emitting a prebuilt chunk. */
+export interface EmitPrebuiltChunkOptions {
+  readonly fileName: string;
+  readonly code: string;
+  readonly map?: string | null;
+  readonly exports?: ReadonlyArray<string>;
+}
+
+/** The type discriminator for emitted files. */
+export type EmittedFileType = "asset" | "chunk" | "prebuilt-chunk";
+
+/** Internal record for a managed emitted file. */
+export interface ManagedEmittedFile {
+  readonly referenceId: string;
+  readonly type: EmittedFileType;
+  readonly name?: string;
+  readonly fileName?: string;
+  readonly id?: string;
+  readonly code?: string;
+  readonly map?: string | null;
+  readonly exports?: ReadonlyArray<string>;
+  readonly needsCodeReference?: boolean;
+  readonly implicitlyLoadedAfterOneOf?: ReadonlyArray<string>;
+  source?: string | Uint8Array;
+  finalizedFileName?: string;
+  sourceFinalized: boolean;
+}
+
+/** Error with a structured code for programmatic handling. */
+export class EmittedFileError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "EmittedFileError";
+  }
+}
+
+/**
+ * Compute a simple hash from a string or Uint8Array source.
+ * Returns an 8-character hex string.
+ */
+export const computeHash = (source: string | Uint8Array): string => {
+  let hash = 0x811c9dc5; // FNV-1a offset basis
+  const data =
+    typeof source === "string" ? new TextEncoder().encode(source) : source;
+
+  for (let i = 0; i < data.length; i++) {
+    hash ^= data[i];
+    hash = Math.imul(hash, 0x01000193); // FNV-1a prime
+    hash = hash >>> 0; // Keep as unsigned 32-bit
+  }
+
+  return hash.toString(16).padStart(8, "0");
+};
+
+/**
+ * Apply a file name pattern, substituting placeholders.
+ * Supported placeholders: [name], [hash], [ext], [extname].
+ */
+export const applyPattern = (
+  pattern: string,
+  name: string,
+  hash: string,
+): string => {
+  const dotIdx = name.lastIndexOf(".");
+  const baseName = dotIdx >= 0 ? name.slice(0, dotIdx) : name;
+  const ext = dotIdx >= 0 ? name.slice(dotIdx + 1) : "";
+  const extname = dotIdx >= 0 ? name.slice(dotIdx) : "";
+
+  let result = pattern;
+  result = result.replace(/\[name\]/g, baseName);
+  result = result.replace(/\[hash\]/g, hash);
+  result = result.replace(/\[ext\]/g, ext);
+  result = result.replace(/\[extname\]/g, extname);
+  return result;
+};
+
+/**
+ * EmittedFileManager manages the full lifecycle of emitted files.
+ * Provides emission, source setting, finalization, and retrieval.
+ */
+export class EmittedFileManager {
+  private readonly _files: Map<string, ManagedEmittedFile> = new Map();
+  private _nextId: number = 1;
+  private _finalized: boolean = false;
+
+  /** Whether file names have been finalized. */
+  isFinalized(): boolean {
+    return this._finalized;
+  }
+
+  /** Get the count of emitted files. */
+  size(): number {
+    return this._files.size;
+  }
+
+  /**
+   * Emit an asset file. Returns a unique reference ID.
+   *
+   * @param options - Asset emission options
+   * @returns A unique reference ID
+   */
+  emitAsset(options: EmitAssetOptions): string {
+    const referenceId = this._generateId();
+    const entry: ManagedEmittedFile = {
+      referenceId,
+      type: "asset",
+      name: options.name,
+      fileName: options.fileName,
+      source: options.source,
+      needsCodeReference: options.needsCodeReference,
+      sourceFinalized: options.source !== undefined,
+    };
+    this._files.set(referenceId, entry);
+    return referenceId;
+  }
+
+  /**
+   * Emit a chunk file. Returns a unique reference ID.
+   *
+   * @param options - Chunk emission options
+   * @returns A unique reference ID
+   */
+  emitChunk(options: EmitChunkOptions): string {
+    const referenceId = this._generateId();
+    const entry: ManagedEmittedFile = {
+      referenceId,
+      type: "chunk",
+      id: options.id,
+      name: options.name,
+      fileName: options.fileName,
+      implicitlyLoadedAfterOneOf: options.implicitlyLoadedAfterOneOf,
+      sourceFinalized: false,
+    };
+    this._files.set(referenceId, entry);
+    return referenceId;
+  }
+
+  /**
+   * Emit a prebuilt chunk. Returns a unique reference ID.
+   *
+   * @param options - Prebuilt chunk emission options
+   * @returns A unique reference ID
+   */
+  emitPrebuiltChunk(options: EmitPrebuiltChunkOptions): string {
+    const referenceId = this._generateId();
+    const entry: ManagedEmittedFile = {
+      referenceId,
+      type: "prebuilt-chunk",
+      fileName: options.fileName,
+      code: options.code,
+      map: options.map,
+      exports: options.exports,
+      sourceFinalized: true,
+    };
+    this._files.set(referenceId, entry);
+    return referenceId;
+  }
+
+  /**
+   * Set or update the source of an emitted asset.
+   *
+   * @param refId - The reference ID of the asset
+   * @param source - The source content
+   * @throws EmittedFileError with ASSET_NOT_FOUND if refId is invalid
+   * @throws EmittedFileError with ASSET_SOURCE_ALREADY_SET if source is finalized
+   */
+  setAssetSource(refId: string, source: string | Uint8Array): void {
+    const entry = this._files.get(refId);
+    if (!entry) {
+      throw new EmittedFileError(
+        ASSET_NOT_FOUND,
+        `File reference "${refId}" not found`,
+      );
+    }
+    if (entry.type !== "asset") {
+      throw new EmittedFileError(
+        ASSET_NOT_FOUND,
+        `File reference "${refId}" is not an asset`,
+      );
+    }
+    if (entry.sourceFinalized) {
+      throw new EmittedFileError(
+        ASSET_SOURCE_ALREADY_SET,
+        `Source for "${refId}" has already been set and finalized`,
+      );
+    }
+    entry.source = source;
+    entry.sourceFinalized = true;
+  }
+
+  /**
+   * Get the final file name for an emitted file by reference ID.
+   *
+   * @param refId - The reference ID
+   * @returns The finalized file name
+   * @throws EmittedFileError with ASSET_NOT_FOUND if refId is invalid
+   * @throws EmittedFileError with ASSET_NOT_FINALISED if names not yet finalized
+   */
+  getFileName(refId: string): string {
+    const entry = this._files.get(refId);
+    if (!entry) {
+      throw new EmittedFileError(
+        ASSET_NOT_FOUND,
+        `File reference "${refId}" not found`,
+      );
+    }
+    // Explicit fileName always takes priority
+    if (entry.fileName) {
+      return entry.fileName;
+    }
+    if (!this._finalized) {
+      throw new EmittedFileError(
+        ASSET_NOT_FINALISED,
+        `File names have not been finalized for "${refId}"`,
+      );
+    }
+    if (entry.finalizedFileName) {
+      return entry.finalizedFileName;
+    }
+    return `assets/${refId}`;
+  }
+
+  /**
+   * Finalize all file names using the given pattern.
+   * Pattern supports [name], [hash], [ext], [extname] placeholders.
+   *
+   * @param pattern - The naming pattern (e.g., "[name]-[hash].js")
+   * @throws EmittedFileError with ASSET_SOURCE_MISSING if an asset has no source
+   */
+  finalizeFileNames(pattern: string): void {
+    const entries = [...this._files.values()];
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      // Skip entries with explicit fileName
+      if (entry.fileName) {
+        continue;
+      }
+
+      if (entry.type === "asset") {
+        if (entry.source === undefined) {
+          throw new EmittedFileError(
+            ASSET_SOURCE_MISSING,
+            `Asset "${entry.referenceId}" has no source set`,
+          );
+        }
+        const hash = computeHash(entry.source);
+        const name = entry.name ?? entry.referenceId;
+        entry.finalizedFileName = applyPattern(pattern, name, hash);
+      } else if (entry.type === "chunk") {
+        const name = entry.name ?? entry.id ?? entry.referenceId;
+        const hash = computeHash(name);
+        entry.finalizedFileName = applyPattern(pattern, name, hash);
+      } else if (entry.type === "prebuilt-chunk") {
+        // Prebuilt chunks must have explicit fileName; skip pattern
+        entry.finalizedFileName = entry.fileName;
+      }
+    }
+    this._finalized = true;
+  }
+
+  /**
+   * Get all emitted files for the bundle output.
+   *
+   * @returns All managed emitted files
+   */
+  getEmittedFiles(): ReadonlyArray<ManagedEmittedFile> {
+    return [...this._files.values()];
+  }
+
+  /** Generate a unique reference ID. */
+  private _generateId(): string {
+    const id = `emitted_${this._nextId}`;
+    this._nextId += 1;
+    return id;
+  }
+}

--- a/src/plugins/transform-context.ts
+++ b/src/plugins/transform-context.ts
@@ -1,0 +1,157 @@
+/**
+ * @module plugins/transform-context
+ * @description TransformPluginContext implementation for steamroller.
+ * Extends PluginContext with getCombinedSourcemap() which returns the
+ * composed source map of all previous transforms in the chain.
+ */
+
+import type { ExistingDecodedSourceMap, SourceMapSegment } from "../types.js";
+import type { DecodedSourceMap } from "../sourcemap/compose.js";
+import { composeSourceMaps } from "../sourcemap/compose.js";
+import { PluginContextImpl } from "./plugin-context.js";
+import type { PluginContextConfig } from "./plugin-context.js";
+
+/** Configuration for creating a TransformPluginContextImpl. */
+export interface TransformContextConfig extends PluginContextConfig {
+  readonly filename: string;
+  readonly originalCode: string;
+  readonly originalSourcemap?: ExistingDecodedSourceMap | null;
+}
+
+/**
+ * Convert an ExistingDecodedSourceMap (with SourceMapSegment tuples) to
+ * a DecodedSourceMap (with plain number arrays) for composition.
+ */
+export const toDecodedSourceMap = (
+  map: ExistingDecodedSourceMap,
+): DecodedSourceMap => {
+  const mappings: Array<Array<Array<number>>> = [];
+  for (let lineIdx = 0; lineIdx < map.mappings.length; lineIdx++) {
+    const line = map.mappings[lineIdx];
+    const decodedLine: Array<Array<number>> = [];
+    for (let segIdx = 0; segIdx < line.length; segIdx++) {
+      const segment = line[segIdx];
+      decodedLine.push([...(segment as ReadonlyArray<number>)]);
+    }
+    mappings.push(decodedLine);
+  }
+  return {
+    version: 3,
+    sources: [...map.sources],
+    sourcesContent: map.sourcesContent ? [...map.sourcesContent] : undefined,
+    names: [...map.names],
+    mappings,
+  };
+};
+
+/**
+ * Convert a DecodedSourceMap back to ExistingDecodedSourceMap format.
+ */
+export const toExistingDecodedSourceMap = (
+  map: DecodedSourceMap,
+): ExistingDecodedSourceMap => {
+  const mappings: Array<Array<SourceMapSegment>> = [];
+  for (let lineIdx = 0; lineIdx < map.mappings.length; lineIdx++) {
+    const line = map.mappings[lineIdx];
+    const segmentLine: Array<SourceMapSegment> = [];
+    for (let segIdx = 0; segIdx < line.length; segIdx++) {
+      const seg = line[segIdx];
+      segmentLine.push(seg as unknown as SourceMapSegment);
+    }
+    mappings.push(segmentLine);
+  }
+  return {
+    version: 3,
+    sources: [...map.sources],
+    sourcesContent: map.sourcesContent ? [...map.sourcesContent] : undefined,
+    names: [...map.names],
+    mappings,
+  };
+};
+
+/**
+ * Create an identity source map for a given source file.
+ * Maps each line/column 1:1 back to itself.
+ */
+export const createIdentitySourceMap = (
+  filename: string,
+  code: string,
+): ExistingDecodedSourceMap => {
+  const lines = code.split("\n");
+  const mappings: Array<Array<SourceMapSegment>> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const segment: SourceMapSegment = [0, 0, i, 0];
+    mappings.push([segment]);
+  }
+  return {
+    version: 3,
+    sources: [filename],
+    sourcesContent: [code],
+    names: [],
+    mappings,
+  };
+};
+
+/**
+ * TransformPluginContext extends PluginContext with source map composition.
+ * Maintains a stack of source maps from sequential transform calls and
+ * provides getCombinedSourcemap() to get the composed result.
+ */
+export class TransformPluginContextImpl extends PluginContextImpl {
+  private readonly _sourceMaps: Array<ExistingDecodedSourceMap> = [];
+  private readonly _filename: string;
+  private readonly _originalCode: string;
+  private readonly _originalSourcemap: ExistingDecodedSourceMap | null;
+
+  constructor(config: TransformContextConfig) {
+    super(config);
+    this._filename = config.filename;
+    this._originalCode = config.originalCode;
+    this._originalSourcemap = config.originalSourcemap ?? null;
+  }
+
+  /**
+   * Add a source map from a completed transform to the stack.
+   *
+   * @param map - The source map produced by a transform
+   */
+  addSourceMap(map: ExistingDecodedSourceMap): void {
+    this._sourceMaps.push(map);
+  }
+
+  /** Get the number of source maps in the stack. */
+  getSourceMapCount(): number {
+    return this._sourceMaps.length;
+  }
+
+  /**
+   * Get the combined source map of all previous transforms.
+   * If no transforms have produced source maps, returns an identity map.
+   * Composes all maps in order, optionally starting from the original sourcemap.
+   */
+  getCombinedSourcemap(): ExistingDecodedSourceMap {
+    if (this._sourceMaps.length === 0) {
+      if (this._originalSourcemap !== null) {
+        return this._originalSourcemap;
+      }
+      return createIdentitySourceMap(this._filename, this._originalCode);
+    }
+
+    let composed: DecodedSourceMap;
+
+    if (this._originalSourcemap !== null) {
+      composed = toDecodedSourceMap(this._originalSourcemap);
+    } else {
+      composed = toDecodedSourceMap(
+        createIdentitySourceMap(this._filename, this._originalCode),
+      );
+    }
+
+    for (let i = 0; i < this._sourceMaps.length; i++) {
+      const nextMap = toDecodedSourceMap(this._sourceMaps[i]);
+      composed = composeSourceMaps(composed, nextMap);
+    }
+
+    return toExistingDecodedSourceMap(composed);
+  }
+}

--- a/src/plugins/watch-hooks.ts
+++ b/src/plugins/watch-hooks.ts
@@ -1,0 +1,160 @@
+/**
+ * @module plugins/watch-hooks
+ * @description Watch and cross-cutting hooks for steamroller.
+ * Provides watchChange and closeWatcher hook execution via PluginDriver.
+ * Both hooks execute sequentially across all registered plugins.
+ */
+
+import type { Plugin, ChangeEvent } from "../types.js";
+import { PluginDriver } from "./driver.js";
+
+/** Event payload for the watchChange hook. */
+export interface WatchChangeEvent {
+  readonly event: ChangeEvent;
+}
+
+/** Hook definitions for watch-related hooks. */
+export const WATCH_HOOKS = {
+  watchChange: {
+    name: "watchChange",
+    strategy: "sequential" as const,
+    async: true,
+  },
+  closeWatcher: {
+    name: "closeWatcher",
+    strategy: "sequential" as const,
+    async: true,
+  },
+} as const;
+
+/** Result of a watch hook execution containing per-plugin results. */
+export interface WatchHookResult {
+  readonly hookName: string;
+  readonly pluginCount: number;
+  readonly executedCount: number;
+}
+
+/**
+ * WatchHookExecutor orchestrates execution of watch-related hooks.
+ * Wraps PluginDriver to provide typed access to watchChange and closeWatcher.
+ */
+export class WatchHookExecutor {
+  private readonly _driver: PluginDriver;
+  private _closed: boolean = false;
+
+  constructor(driver: PluginDriver) {
+    this._driver = driver;
+  }
+
+  /** Whether the watcher has been closed. */
+  isClosed(): boolean {
+    return this._closed;
+  }
+
+  /** Get the underlying plugin driver (for testing). */
+  getDriver(): PluginDriver {
+    return this._driver;
+  }
+
+  /**
+   * Fire the watchChange hook across all plugins.
+   * Called when a watched file is created, updated, or deleted.
+   *
+   * @param id - The file path that changed
+   * @param change - The change event descriptor
+   * @returns Result with execution metadata
+   * @throws Error if the watcher has been closed
+   */
+  async watchChange(
+    id: string,
+    change: WatchChangeEvent,
+  ): Promise<WatchHookResult> {
+    if (this._closed) {
+      throw new Error("Cannot fire watchChange: watcher is already closed");
+    }
+
+    const plugins = this._driver.getPlugins();
+    let executedCount = 0;
+
+    for (const plugin of plugins) {
+      const hook = (plugin as unknown as Record<string, unknown>)[
+        "watchChange"
+      ];
+      if (hook !== undefined && hook !== null) {
+        const handler = extractHandler(hook);
+        if (typeof handler === "function") {
+          await (handler as WatchChangeHandler).call(undefined, id, change);
+          executedCount += 1;
+        }
+      }
+    }
+
+    return {
+      hookName: "watchChange",
+      pluginCount: plugins.length,
+      executedCount,
+    };
+  }
+
+  /**
+   * Fire the closeWatcher hook across all plugins.
+   * Called when the watcher is shutting down. Marks this executor as closed.
+   *
+   * @returns Result with execution metadata
+   * @throws Error if already closed
+   */
+  async closeWatcher(): Promise<WatchHookResult> {
+    if (this._closed) {
+      throw new Error("Cannot fire closeWatcher: watcher is already closed");
+    }
+
+    const plugins = this._driver.getPlugins();
+    let executedCount = 0;
+
+    for (const plugin of plugins) {
+      const hook = (plugin as unknown as Record<string, unknown>)[
+        "closeWatcher"
+      ];
+      if (hook !== undefined && hook !== null) {
+        const handler = extractHandler(hook);
+        if (typeof handler === "function") {
+          await (handler as CloseWatcherHandler).call(undefined);
+          executedCount += 1;
+        }
+      }
+    }
+
+    this._closed = true;
+
+    return {
+      hookName: "closeWatcher",
+      pluginCount: plugins.length,
+      executedCount,
+    };
+  }
+}
+
+/** Handler type for watchChange hook. */
+type WatchChangeHandler = (
+  id: string,
+  change: WatchChangeEvent,
+) => unknown | Promise<unknown>;
+
+/** Handler type for closeWatcher hook. */
+type CloseWatcherHandler = () => unknown | Promise<unknown>;
+
+/**
+ * Extract the handler function from an ObjectHook value.
+ * ObjectHook can be a plain function or { handler, order }.
+ */
+const extractHandler = (hook: unknown): unknown => {
+  if (
+    hook !== null &&
+    hook !== undefined &&
+    typeof hook === "object" &&
+    "handler" in (hook as Record<string, unknown>)
+  ) {
+    return (hook as { readonly handler: unknown }).handler;
+  }
+  return hook;
+};

--- a/tests/unit/plugins/emitted-files.test.ts
+++ b/tests/unit/plugins/emitted-files.test.ts
@@ -1,0 +1,427 @@
+/**
+ * @module tests/unit/plugins/emitted-files
+ * @description Unit tests for EmittedFileManager lifecycle management.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  EmittedFileManager,
+  EmittedFileError,
+  computeHash,
+  applyPattern,
+} from "../../../src/plugins/emitted-files.js";
+import {
+  ASSET_NOT_FOUND,
+  ASSET_SOURCE_ALREADY_SET,
+  ASSET_SOURCE_MISSING,
+  ASSET_NOT_FINALISED,
+} from "../../../src/utils/error-codes.js";
+
+describe("emitted-files", () => {
+  describe("computeHash", () => {
+    it("should compute a hash from a string", () => {
+      const hash = computeHash("hello world");
+      expect(hash).toHaveLength(8);
+      expect(/^[0-9a-f]{8}$/.test(hash)).toBe(true);
+    });
+
+    it("should compute a hash from a Uint8Array", () => {
+      const data = new Uint8Array([72, 101, 108, 108, 111]);
+      const hash = computeHash(data);
+      expect(hash).toHaveLength(8);
+      expect(/^[0-9a-f]{8}$/.test(hash)).toBe(true);
+    });
+
+    it("should produce different hashes for different inputs", () => {
+      const h1 = computeHash("abc");
+      const h2 = computeHash("def");
+      expect(h1).not.toBe(h2);
+    });
+
+    it("should produce same hash for same input", () => {
+      const h1 = computeHash("same");
+      const h2 = computeHash("same");
+      expect(h1).toBe(h2);
+    });
+
+    it("should handle empty string", () => {
+      const hash = computeHash("");
+      expect(hash).toHaveLength(8);
+    });
+
+    it("should handle empty Uint8Array", () => {
+      const hash = computeHash(new Uint8Array(0));
+      expect(hash).toHaveLength(8);
+    });
+  });
+
+  describe("applyPattern", () => {
+    it("should replace [name] placeholder", () => {
+      expect(applyPattern("[name].js", "bundle.js", "abc12345")).toBe(
+        "bundle.js",
+      );
+    });
+
+    it("should replace [hash] placeholder", () => {
+      expect(applyPattern("[name]-[hash].js", "bundle.js", "abc12345")).toBe(
+        "bundle-abc12345.js",
+      );
+    });
+
+    it("should replace [ext] placeholder", () => {
+      expect(applyPattern("[name].[ext]", "style.css", "abc")).toBe(
+        "style.css",
+      );
+    });
+
+    it("should replace [extname] placeholder", () => {
+      expect(applyPattern("[name][extname]", "style.css", "abc")).toBe(
+        "style.css",
+      );
+    });
+
+    it("should handle file without extension", () => {
+      expect(applyPattern("[name]-[hash].[ext]", "README", "abc")).toBe(
+        "README-abc.",
+      );
+    });
+
+    it("should handle multiple placeholder occurrences", () => {
+      expect(applyPattern("[name]-[name]-[hash]", "x.js", "h")).toBe("x-x-h");
+    });
+  });
+
+  describe("EmittedFileManager", () => {
+    describe("emitAsset", () => {
+      it("should emit an asset and return a reference ID", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({ name: "style.css", source: "body {}" });
+        expect(refId).toBeTruthy();
+        expect(mgr.size()).toBe(1);
+      });
+
+      it("should emit asset without initial source", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({ name: "lazy.css" });
+        expect(refId).toBeTruthy();
+        expect(mgr.size()).toBe(1);
+      });
+
+      it("should emit asset with explicit fileName", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({
+          name: "icon.png",
+          fileName: "assets/icon.png",
+          source: "data",
+        });
+        mgr.finalizeFileNames("[name]-[hash]");
+        expect(mgr.getFileName(refId)).toBe("assets/icon.png");
+      });
+
+      it("should emit asset with needsCodeReference", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({
+          name: "data.json",
+          source: "{}",
+          needsCodeReference: true,
+        });
+        const files = mgr.getEmittedFiles();
+        const file = files.find((f) => f.referenceId === refId);
+        expect(file?.needsCodeReference).toBe(true);
+      });
+
+      it("should generate unique reference IDs", () => {
+        const mgr = new EmittedFileManager();
+        const id1 = mgr.emitAsset({ name: "a.css", source: "a" });
+        const id2 = mgr.emitAsset({ name: "b.css", source: "b" });
+        expect(id1).not.toBe(id2);
+      });
+    });
+
+    describe("emitChunk", () => {
+      it("should emit a chunk and return a reference ID", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitChunk({ id: "./src/worker.ts" });
+        expect(refId).toBeTruthy();
+        expect(mgr.size()).toBe(1);
+      });
+
+      it("should emit chunk with name and fileName", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitChunk({
+          id: "./src/lazy.ts",
+          name: "lazy",
+          fileName: "chunks/lazy.js",
+        });
+        mgr.finalizeFileNames("[name]-[hash].js");
+        expect(mgr.getFileName(refId)).toBe("chunks/lazy.js");
+      });
+
+      it("should emit chunk with implicitlyLoadedAfterOneOf", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitChunk({
+          id: "./src/polyfill.ts",
+          implicitlyLoadedAfterOneOf: ["./src/main.ts"],
+        });
+        const files = mgr.getEmittedFiles();
+        const file = files.find((f) => f.referenceId === refId);
+        expect(file?.implicitlyLoadedAfterOneOf).toEqual(["./src/main.ts"]);
+      });
+    });
+
+    describe("emitPrebuiltChunk", () => {
+      it("should emit a prebuilt chunk and return a reference ID", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitPrebuiltChunk({
+          fileName: "vendor.js",
+          code: "var x = 1;",
+        });
+        expect(refId).toBeTruthy();
+        expect(mgr.size()).toBe(1);
+      });
+
+      it("should store map and exports", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitPrebuiltChunk({
+          fileName: "lib.js",
+          code: "export const a = 1;",
+          map: "sourcemap-data",
+          exports: ["a"],
+        });
+        const files = mgr.getEmittedFiles();
+        const file = files.find((f) => f.referenceId === refId);
+        expect(file?.map).toBe("sourcemap-data");
+        expect(file?.exports).toEqual(["a"]);
+      });
+
+      it("should handle null map", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitPrebuiltChunk({
+          fileName: "lib.js",
+          code: "code",
+          map: null,
+        });
+        const files = mgr.getEmittedFiles();
+        const file = files.find((f) => f.referenceId === refId);
+        expect(file?.map).toBeNull();
+      });
+    });
+
+    describe("setAssetSource", () => {
+      it("should set source for a deferred asset", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({ name: "lazy.css" });
+        mgr.setAssetSource(refId, "body { color: red; }");
+        mgr.finalizeFileNames("[name]-[hash].css");
+        // Should not throw on getFileName
+        expect(mgr.getFileName(refId)).toBeTruthy();
+      });
+
+      it("should throw ASSET_NOT_FOUND for invalid refId", () => {
+        const mgr = new EmittedFileManager();
+        try {
+          mgr.setAssetSource("nonexistent", "data");
+          expect.fail("Should have thrown");
+        } catch (err) {
+          expect(err).toBeInstanceOf(EmittedFileError);
+          expect((err as EmittedFileError).code).toBe(ASSET_NOT_FOUND);
+        }
+      });
+
+      it("should throw ASSET_NOT_FOUND for non-asset refId", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitChunk({ id: "./chunk.ts" });
+        try {
+          mgr.setAssetSource(refId, "data");
+          expect.fail("Should have thrown");
+        } catch (err) {
+          expect(err).toBeInstanceOf(EmittedFileError);
+          expect((err as EmittedFileError).code).toBe(ASSET_NOT_FOUND);
+        }
+      });
+
+      it("should throw ASSET_SOURCE_ALREADY_SET if already finalized", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({ name: "x.css", source: "initial" });
+        try {
+          mgr.setAssetSource(refId, "updated");
+          expect.fail("Should have thrown");
+        } catch (err) {
+          expect(err).toBeInstanceOf(EmittedFileError);
+          expect((err as EmittedFileError).code).toBe(ASSET_SOURCE_ALREADY_SET);
+        }
+      });
+
+      it("should accept Uint8Array source", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({ name: "binary.dat" });
+        const data = new Uint8Array([1, 2, 3]);
+        mgr.setAssetSource(refId, data);
+        mgr.finalizeFileNames("[name]-[hash]");
+        expect(mgr.getFileName(refId)).toBeTruthy();
+      });
+    });
+
+    describe("getFileName", () => {
+      it("should return explicit fileName immediately", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({
+          name: "img.png",
+          fileName: "static/img.png",
+          source: "data",
+        });
+        // Even without finalization, explicit fileName works
+        expect(mgr.getFileName(refId)).toBe("static/img.png");
+      });
+
+      it("should throw ASSET_NOT_FOUND for unknown refId", () => {
+        const mgr = new EmittedFileManager();
+        try {
+          mgr.getFileName("unknown");
+          expect.fail("Should have thrown");
+        } catch (err) {
+          expect(err).toBeInstanceOf(EmittedFileError);
+          expect((err as EmittedFileError).code).toBe(ASSET_NOT_FOUND);
+        }
+      });
+
+      it("should throw ASSET_NOT_FINALISED before finalization", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({ name: "lazy.css", source: "x" });
+        try {
+          mgr.getFileName(refId);
+          expect.fail("Should have thrown");
+        } catch (err) {
+          expect(err).toBeInstanceOf(EmittedFileError);
+          expect((err as EmittedFileError).code).toBe(ASSET_NOT_FINALISED);
+        }
+      });
+
+      it("should return finalized name after finalization", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({ name: "style.css", source: "body{}" });
+        mgr.finalizeFileNames("[name]-[hash].css");
+        const fileName = mgr.getFileName(refId);
+        expect(fileName).toMatch(/^style-[0-9a-f]{8}\.css$/);
+      });
+    });
+
+    describe("finalizeFileNames", () => {
+      it("should assign names to all files without explicit fileName", () => {
+        const mgr = new EmittedFileManager();
+        const a1 = mgr.emitAsset({ name: "a.css", source: "a" });
+        const a2 = mgr.emitAsset({ name: "b.js", source: "b" });
+        const c1 = mgr.emitChunk({ id: "./c.ts", name: "c" });
+        mgr.finalizeFileNames("[name]-[hash].js");
+
+        expect(mgr.isFinalized()).toBe(true);
+        expect(mgr.getFileName(a1)).toMatch(/^a-[0-9a-f]{8}\.js$/);
+        expect(mgr.getFileName(a2)).toMatch(/^b-[0-9a-f]{8}\.js$/);
+        expect(mgr.getFileName(c1)).toMatch(/^c-[0-9a-f]{8}\.js$/);
+      });
+
+      it("should throw ASSET_SOURCE_MISSING for asset without source", () => {
+        const mgr = new EmittedFileManager();
+        mgr.emitAsset({ name: "missing.css" });
+        try {
+          mgr.finalizeFileNames("[name]-[hash]");
+          expect.fail("Should have thrown");
+        } catch (err) {
+          expect(err).toBeInstanceOf(EmittedFileError);
+          expect((err as EmittedFileError).code).toBe(ASSET_SOURCE_MISSING);
+        }
+      });
+
+      it("should skip entries with explicit fileName", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitAsset({
+          name: "x.css",
+          fileName: "fixed/x.css",
+          source: "data",
+        });
+        mgr.finalizeFileNames("[name]-[hash]");
+        expect(mgr.getFileName(refId)).toBe("fixed/x.css");
+      });
+
+      it("should use referenceId as fallback name for chunks without name", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitChunk({ id: "./unnamed.ts" });
+        mgr.finalizeFileNames("[name]-[hash].js");
+        // Uses the name or id field
+        const fileName = mgr.getFileName(refId);
+        expect(fileName).toContain("[hash]".length > 0 ? "-" : "");
+        expect(fileName).toBeTruthy();
+      });
+
+      it("should handle prebuilt chunks (skip pattern)", () => {
+        const mgr = new EmittedFileManager();
+        const refId = mgr.emitPrebuiltChunk({
+          fileName: "vendor.js",
+          code: "code",
+        });
+        mgr.finalizeFileNames("[name]-[hash].js");
+        expect(mgr.getFileName(refId)).toBe("vendor.js");
+      });
+    });
+
+    describe("getEmittedFiles", () => {
+      it("should return all emitted files", () => {
+        const mgr = new EmittedFileManager();
+        mgr.emitAsset({ name: "a.css", source: "a" });
+        mgr.emitChunk({ id: "./b.ts" });
+        mgr.emitPrebuiltChunk({ fileName: "c.js", code: "c" });
+
+        const files = mgr.getEmittedFiles();
+        expect(files.length).toBe(3);
+      });
+
+      it("should return empty array when nothing emitted", () => {
+        const mgr = new EmittedFileManager();
+        expect(mgr.getEmittedFiles()).toEqual([]);
+      });
+
+      it("should return a copy (not internal reference)", () => {
+        const mgr = new EmittedFileManager();
+        mgr.emitAsset({ name: "a.css", source: "a" });
+        const files1 = mgr.getEmittedFiles();
+        const files2 = mgr.getEmittedFiles();
+        expect(files1).not.toBe(files2);
+        expect(files1).toEqual(files2);
+      });
+    });
+
+    describe("EmittedFileError", () => {
+      it("should have correct code and message", () => {
+        const err = new EmittedFileError("TEST_CODE", "test message");
+        expect(err.code).toBe("TEST_CODE");
+        expect(err.message).toBe("test message");
+        expect(err.name).toBe("EmittedFileError");
+        expect(err).toBeInstanceOf(Error);
+      });
+    });
+
+    describe("isFinalized", () => {
+      it("should be false initially", () => {
+        const mgr = new EmittedFileManager();
+        expect(mgr.isFinalized()).toBe(false);
+      });
+
+      it("should be true after finalizeFileNames", () => {
+        const mgr = new EmittedFileManager();
+        mgr.finalizeFileNames("[name]");
+        expect(mgr.isFinalized()).toBe(true);
+      });
+    });
+
+    describe("size", () => {
+      it("should track emitted file count", () => {
+        const mgr = new EmittedFileManager();
+        expect(mgr.size()).toBe(0);
+        mgr.emitAsset({ name: "a", source: "a" });
+        expect(mgr.size()).toBe(1);
+        mgr.emitChunk({ id: "b" });
+        expect(mgr.size()).toBe(2);
+      });
+    });
+  });
+});

--- a/tests/unit/plugins/transform-context.test.ts
+++ b/tests/unit/plugins/transform-context.test.ts
@@ -1,0 +1,294 @@
+/**
+ * @module tests/unit/plugins/transform-context
+ * @description Unit tests for TransformPluginContext implementation.
+ */
+
+import { describe, it, expect } from "vitest";
+import type {
+  ExistingDecodedSourceMap,
+  SourceMapSegment,
+} from "../../../src/types.js";
+import {
+  TransformPluginContextImpl,
+  createIdentitySourceMap,
+  toDecodedSourceMap,
+  toExistingDecodedSourceMap,
+} from "../../../src/plugins/transform-context.js";
+import type { TransformContextConfig } from "../../../src/plugins/transform-context.js";
+import { InMemoryModuleGraph } from "../../../src/plugins/plugin-context.js";
+
+const makeConfig = (
+  overrides: Partial<TransformContextConfig> = {},
+): TransformContextConfig => {
+  return {
+    pluginName: "test-transform-plugin",
+    resolver: async () => null,
+    loader: async () => ({
+      id: "test",
+      code: "",
+      ast: null,
+      isEntry: false,
+      isExternal: false,
+      importedIds: [],
+      importedIdResolutions: [],
+      dynamicallyImportedIds: [],
+      dynamicallyImportedIdResolutions: [],
+      exportedBindings: null,
+      exports: null,
+      hasDefaultExport: null,
+      moduleSideEffects: true,
+      syntheticNamedExports: false,
+      meta: {},
+      implicitlyLoadedAfterOneOf: [],
+      implicitlyLoadedBefore: [],
+      importers: [],
+      dynamicImporters: [],
+      attributes: {},
+      isIncluded: null,
+    }),
+    parser: (code: string) => ({
+      type: "Program",
+      body: [],
+      sourceType: "module",
+      start: 0,
+      end: code.length,
+    }),
+    moduleGraph: new InMemoryModuleGraph(),
+    filename: "src/input.ts",
+    originalCode: "const x = 1;\nconst y = 2;\n",
+    ...overrides,
+  };
+};
+
+describe("transform-context", () => {
+  describe("createIdentitySourceMap", () => {
+    it("should create an identity map for single-line code", () => {
+      const map = createIdentitySourceMap("file.ts", "const x = 1;");
+      expect(map.version).toBe(3);
+      expect(map.sources).toEqual(["file.ts"]);
+      expect(map.sourcesContent).toEqual(["const x = 1;"]);
+      expect(map.names).toEqual([]);
+      expect(map.mappings.length).toBe(1);
+      expect(map.mappings[0][0]).toEqual([0, 0, 0, 0]);
+    });
+
+    it("should create identity map for multi-line code", () => {
+      const code = "line1\nline2\nline3";
+      const map = createIdentitySourceMap("test.js", code);
+      expect(map.mappings.length).toBe(3);
+      expect(map.mappings[0][0]).toEqual([0, 0, 0, 0]);
+      expect(map.mappings[1][0]).toEqual([0, 0, 1, 0]);
+      expect(map.mappings[2][0]).toEqual([0, 0, 2, 0]);
+    });
+
+    it("should handle empty code", () => {
+      const map = createIdentitySourceMap("empty.ts", "");
+      expect(map.mappings.length).toBe(1);
+    });
+  });
+
+  describe("toDecodedSourceMap", () => {
+    it("should convert ExistingDecodedSourceMap to DecodedSourceMap", () => {
+      const input: ExistingDecodedSourceMap = {
+        version: 3,
+        sources: ["a.ts"],
+        names: ["x"],
+        mappings: [[[0, 0, 0, 0, 0] as SourceMapSegment]],
+      };
+      const decoded = toDecodedSourceMap(input);
+      expect(decoded.version).toBe(3);
+      expect(decoded.sources).toEqual(["a.ts"]);
+      expect(decoded.names).toEqual(["x"]);
+      expect(decoded.mappings[0][0]).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it("should handle sourcesContent", () => {
+      const input: ExistingDecodedSourceMap = {
+        version: 3,
+        sources: ["a.ts"],
+        sourcesContent: ["code"],
+        names: [],
+        mappings: [],
+      };
+      const decoded = toDecodedSourceMap(input);
+      expect(decoded.sourcesContent).toEqual(["code"]);
+    });
+
+    it("should handle undefined sourcesContent", () => {
+      const input: ExistingDecodedSourceMap = {
+        version: 3,
+        sources: ["a.ts"],
+        names: [],
+        mappings: [],
+      };
+      const decoded = toDecodedSourceMap(input);
+      expect(decoded.sourcesContent).toBeUndefined();
+    });
+  });
+
+  describe("toExistingDecodedSourceMap", () => {
+    it("should convert DecodedSourceMap back to ExistingDecodedSourceMap", () => {
+      const input = {
+        version: 3 as const,
+        sources: ["b.ts"],
+        names: ["y"],
+        mappings: [[[0, 0, 0, 0]]],
+      };
+      const existing = toExistingDecodedSourceMap(input);
+      expect(existing.version).toBe(3);
+      expect(existing.sources).toEqual(["b.ts"]);
+      expect(existing.mappings[0][0]).toEqual([0, 0, 0, 0]);
+    });
+
+    it("should handle sourcesContent", () => {
+      const input = {
+        version: 3 as const,
+        sources: ["b.ts"],
+        sourcesContent: ["content"],
+        names: [],
+        mappings: [] as Array<Array<Array<number>>>,
+      };
+      const existing = toExistingDecodedSourceMap(input);
+      expect(existing.sourcesContent).toEqual(["content"]);
+    });
+
+    it("should handle undefined sourcesContent", () => {
+      const input = {
+        version: 3 as const,
+        sources: ["b.ts"],
+        names: [],
+        mappings: [] as Array<Array<Array<number>>>,
+      };
+      const existing = toExistingDecodedSourceMap(input);
+      expect(existing.sourcesContent).toBeUndefined();
+    });
+  });
+
+  describe("TransformPluginContextImpl", () => {
+    it("should construct with config", () => {
+      const ctx = new TransformPluginContextImpl(makeConfig());
+      expect(ctx.getPluginName()).toBe("test-transform-plugin");
+      expect(ctx.getSourceMapCount()).toBe(0);
+    });
+
+    describe("getCombinedSourcemap", () => {
+      it("should return identity map when no transforms applied", () => {
+        const ctx = new TransformPluginContextImpl(makeConfig());
+        const map = ctx.getCombinedSourcemap();
+        expect(map.version).toBe(3);
+        expect(map.sources).toEqual(["src/input.ts"]);
+        expect(map.sourcesContent).toEqual(["const x = 1;\nconst y = 2;\n"]);
+        expect(map.mappings.length).toBe(3); // 2 lines + trailing newline
+      });
+
+      it("should return original sourcemap when provided and no transforms", () => {
+        const originalMap: ExistingDecodedSourceMap = {
+          version: 3,
+          sources: ["original.ts"],
+          sourcesContent: ["original"],
+          names: [],
+          mappings: [[[0, 0, 0, 0] as SourceMapSegment]],
+        };
+        const ctx = new TransformPluginContextImpl(
+          makeConfig({ originalSourcemap: originalMap }),
+        );
+        const map = ctx.getCombinedSourcemap();
+        expect(map.sources).toEqual(["original.ts"]);
+      });
+
+      it("should compose a single transform map", () => {
+        const ctx = new TransformPluginContextImpl(makeConfig());
+        const transformMap: ExistingDecodedSourceMap = {
+          version: 3,
+          sources: ["src/input.ts"],
+          names: [],
+          mappings: [
+            [[0, 0, 0, 0] as SourceMapSegment],
+            [[0, 0, 1, 0] as SourceMapSegment],
+          ],
+        };
+        ctx.addSourceMap(transformMap);
+        expect(ctx.getSourceMapCount()).toBe(1);
+
+        const combined = ctx.getCombinedSourcemap();
+        expect(combined.version).toBe(3);
+        expect(combined.mappings.length).toBe(2);
+      });
+
+      it("should compose multiple transform maps", () => {
+        const ctx = new TransformPluginContextImpl(makeConfig());
+        const map1: ExistingDecodedSourceMap = {
+          version: 3,
+          sources: ["src/input.ts"],
+          names: [],
+          mappings: [
+            [[0, 0, 0, 0] as SourceMapSegment],
+            [[0, 0, 1, 0] as SourceMapSegment],
+            [[0, 0, 2, 0] as SourceMapSegment],
+          ],
+        };
+        const map2: ExistingDecodedSourceMap = {
+          version: 3,
+          sources: ["intermediate"],
+          names: [],
+          mappings: [
+            [[0, 0, 0, 0] as SourceMapSegment],
+            [[0, 0, 1, 0] as SourceMapSegment],
+            [[0, 0, 2, 0] as SourceMapSegment],
+          ],
+        };
+        ctx.addSourceMap(map1);
+        ctx.addSourceMap(map2);
+        expect(ctx.getSourceMapCount()).toBe(2);
+
+        const combined = ctx.getCombinedSourcemap();
+        expect(combined.version).toBe(3);
+        expect(combined.mappings.length).toBeGreaterThan(0);
+      });
+
+      it("should compose with originalSourcemap when transforms are added", () => {
+        const originalMap: ExistingDecodedSourceMap = {
+          version: 3,
+          sources: ["real-original.ts"],
+          sourcesContent: ["real code"],
+          names: [],
+          mappings: [[[0, 0, 0, 0] as SourceMapSegment]],
+        };
+        const ctx = new TransformPluginContextImpl(
+          makeConfig({ originalSourcemap: originalMap }),
+        );
+        const transformMap: ExistingDecodedSourceMap = {
+          version: 3,
+          sources: ["intermediate"],
+          names: [],
+          mappings: [[[0, 0, 0, 0] as SourceMapSegment]],
+        };
+        ctx.addSourceMap(transformMap);
+
+        const combined = ctx.getCombinedSourcemap();
+        expect(combined.version).toBe(3);
+        expect(combined.sources).toEqual(["real-original.ts"]);
+      });
+
+      it("should handle null originalSourcemap", () => {
+        const ctx = new TransformPluginContextImpl(
+          makeConfig({ originalSourcemap: null }),
+        );
+        const map = ctx.getCombinedSourcemap();
+        expect(map.sources).toEqual(["src/input.ts"]);
+      });
+    });
+
+    it("should inherit PluginContext methods", () => {
+      const ctx = new TransformPluginContextImpl(makeConfig());
+      ctx.addWatchFile("watched.ts");
+      expect(ctx.getWatchFiles()).toEqual(["watched.ts"]);
+    });
+
+    it("should support parse method from parent", () => {
+      const ctx = new TransformPluginContextImpl(makeConfig());
+      const ast = ctx.parse("const a = 1;");
+      expect(ast.type).toBe("Program");
+    });
+  });
+});

--- a/tests/unit/plugins/watch-hooks.test.ts
+++ b/tests/unit/plugins/watch-hooks.test.ts
@@ -1,0 +1,269 @@
+/**
+ * @module tests/unit/plugins/watch-hooks
+ * @description Unit tests for watch and cross-cutting hooks.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Plugin } from "../../../src/types.js";
+import { PluginDriver } from "../../../src/plugins/driver.js";
+import {
+  WatchHookExecutor,
+  WATCH_HOOKS,
+} from "../../../src/plugins/watch-hooks.js";
+import type { WatchChangeEvent } from "../../../src/plugins/watch-hooks.js";
+
+const makePlugin = (
+  name: string,
+  hooks: Record<string, unknown> = {},
+): Plugin => {
+  return { name, ...hooks } as unknown as Plugin;
+};
+
+const noopWarning = (): void => undefined;
+
+describe("watch-hooks", () => {
+  describe("WATCH_HOOKS", () => {
+    it("should define watchChange as sequential and async", () => {
+      expect(WATCH_HOOKS.watchChange.name).toBe("watchChange");
+      expect(WATCH_HOOKS.watchChange.strategy).toBe("sequential");
+      expect(WATCH_HOOKS.watchChange.async).toBe(true);
+    });
+
+    it("should define closeWatcher as sequential and async", () => {
+      expect(WATCH_HOOKS.closeWatcher.name).toBe("closeWatcher");
+      expect(WATCH_HOOKS.closeWatcher.strategy).toBe("sequential");
+      expect(WATCH_HOOKS.closeWatcher.async).toBe(true);
+    });
+  });
+
+  describe("WatchHookExecutor", () => {
+    it("should construct with a PluginDriver", () => {
+      const driver = new PluginDriver([], noopWarning);
+      const executor = new WatchHookExecutor(driver);
+      expect(executor.getDriver()).toBe(driver);
+      expect(executor.isClosed()).toBe(false);
+    });
+
+    describe("watchChange", () => {
+      it("should fire watchChange with correct id and event", async () => {
+        const handler = vi.fn();
+        const plugin = makePlugin("test-plugin", { watchChange: handler });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const change: WatchChangeEvent = { event: "update" };
+        const result = await executor.watchChange("/path/to/file.ts", change);
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith("/path/to/file.ts", change);
+        expect(result.hookName).toBe("watchChange");
+        expect(result.pluginCount).toBe(1);
+        expect(result.executedCount).toBe(1);
+      });
+
+      it("should fire watchChange with create event", async () => {
+        const handler = vi.fn();
+        const plugin = makePlugin("p1", { watchChange: handler });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        await executor.watchChange("new-file.js", { event: "create" });
+        expect(handler).toHaveBeenCalledWith("new-file.js", {
+          event: "create",
+        });
+      });
+
+      it("should fire watchChange with delete event", async () => {
+        const handler = vi.fn();
+        const plugin = makePlugin("p1", { watchChange: handler });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        await executor.watchChange("old-file.js", { event: "delete" });
+        expect(handler).toHaveBeenCalledWith("old-file.js", {
+          event: "delete",
+        });
+      });
+
+      it("should fire across multiple plugins sequentially", async () => {
+        const calls: Array<string> = [];
+        const handler1 = vi.fn(() => {
+          calls.push("p1");
+        });
+        const handler2 = vi.fn(() => {
+          calls.push("p2");
+        });
+        const p1 = makePlugin("p1", { watchChange: handler1 });
+        const p2 = makePlugin("p2", { watchChange: handler2 });
+        const driver = new PluginDriver([p1, p2], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.watchChange("file.ts", {
+          event: "update",
+        });
+        expect(calls).toEqual(["p1", "p2"]);
+        expect(result.executedCount).toBe(2);
+      });
+
+      it("should skip plugins without watchChange hook", async () => {
+        const handler = vi.fn();
+        const p1 = makePlugin("p1", {});
+        const p2 = makePlugin("p2", { watchChange: handler });
+        const driver = new PluginDriver([p1, p2], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.watchChange("file.ts", {
+          event: "create",
+        });
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(result.executedCount).toBe(1);
+        expect(result.pluginCount).toBe(2);
+      });
+
+      it("should handle ObjectHook format with handler property", async () => {
+        const handler = vi.fn();
+        const plugin = makePlugin("p1", {
+          watchChange: { handler, order: "pre" },
+        });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        await executor.watchChange("file.ts", { event: "update" });
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+
+      it("should throw if watcher is already closed", async () => {
+        const driver = new PluginDriver([], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+        await executor.closeWatcher();
+
+        await expect(
+          executor.watchChange("file.ts", { event: "update" }),
+        ).rejects.toThrow("Cannot fire watchChange: watcher is already closed");
+      });
+
+      it("should handle async hook handlers", async () => {
+        const handler = vi.fn(async () => {
+          await Promise.resolve();
+        });
+        const plugin = makePlugin("p1", { watchChange: handler });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.watchChange("file.ts", {
+          event: "update",
+        });
+        expect(result.executedCount).toBe(1);
+      });
+
+      it("should return zero executedCount when no hooks defined", async () => {
+        const driver = new PluginDriver(
+          [makePlugin("p1"), makePlugin("p2")],
+          noopWarning,
+        );
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.watchChange("file.ts", {
+          event: "create",
+        });
+        expect(result.executedCount).toBe(0);
+        expect(result.pluginCount).toBe(2);
+      });
+
+      it("should skip non-function hook values", async () => {
+        const plugin = makePlugin("p1", { watchChange: "not-a-function" });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.watchChange("file.ts", {
+          event: "update",
+        });
+        expect(result.executedCount).toBe(0);
+      });
+    });
+
+    describe("closeWatcher", () => {
+      it("should fire closeWatcher hook and mark as closed", async () => {
+        const handler = vi.fn();
+        const plugin = makePlugin("p1", { closeWatcher: handler });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        expect(executor.isClosed()).toBe(false);
+        const result = await executor.closeWatcher();
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(executor.isClosed()).toBe(true);
+        expect(result.hookName).toBe("closeWatcher");
+        expect(result.executedCount).toBe(1);
+      });
+
+      it("should fire across multiple plugins", async () => {
+        const calls: Array<string> = [];
+        const h1 = vi.fn(() => calls.push("p1"));
+        const h2 = vi.fn(() => calls.push("p2"));
+        const p1 = makePlugin("p1", { closeWatcher: h1 });
+        const p2 = makePlugin("p2", { closeWatcher: h2 });
+        const driver = new PluginDriver([p1, p2], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        await executor.closeWatcher();
+        expect(calls).toEqual(["p1", "p2"]);
+      });
+
+      it("should throw if already closed", async () => {
+        const driver = new PluginDriver([], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+        await executor.closeWatcher();
+
+        await expect(executor.closeWatcher()).rejects.toThrow(
+          "Cannot fire closeWatcher: watcher is already closed",
+        );
+      });
+
+      it("should handle ObjectHook format", async () => {
+        const handler = vi.fn();
+        const plugin = makePlugin("p1", {
+          closeWatcher: { handler, order: "post" },
+        });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        await executor.closeWatcher();
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+
+      it("should skip plugins without closeWatcher", async () => {
+        const p1 = makePlugin("p1", {});
+        const handler = vi.fn();
+        const p2 = makePlugin("p2", { closeWatcher: handler });
+        const driver = new PluginDriver([p1, p2], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.closeWatcher();
+        expect(result.executedCount).toBe(1);
+        expect(result.pluginCount).toBe(2);
+      });
+
+      it("should handle async handlers", async () => {
+        const handler = vi.fn(async () => {
+          await Promise.resolve();
+        });
+        const plugin = makePlugin("p1", { closeWatcher: handler });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.closeWatcher();
+        expect(result.executedCount).toBe(1);
+      });
+
+      it("should skip non-function hook values", async () => {
+        const plugin = makePlugin("p1", { closeWatcher: 42 });
+        const driver = new PluginDriver([plugin], noopWarning);
+        const executor = new WatchHookExecutor(driver);
+
+        const result = await executor.closeWatcher();
+        expect(result.executedCount).toBe(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Issue #66**: `WatchHookExecutor` class with `watchChange` and `closeWatcher` hooks executed sequentially via PluginDriver
- **Issue #71**: `TransformPluginContextImpl` extending `PluginContext` with `getCombinedSourcemap()` composing all prior transform source maps
- **Issue #72**: `EmittedFileManager` class managing full emit lifecycle: assets, chunks, prebuilt chunks with reference IDs, source setting, and name finalization via patterns

## Test plan
- [x] 20 tests for watch hooks (watchChange fires with correct event types, closeWatcher marks closed, ObjectHook support, error on double-close)
- [x] 18 tests for TransformPluginContext (identity map, composition of single/multiple maps, original sourcemap passthrough)
- [x] 44 tests for EmittedFileManager (emit asset/chunk/prebuilt, setAssetSource, getFileName, finalize, error codes)
- [x] All 4105 existing tests pass
- [x] TypeScript strict mode passes with zero errors
- [x] Coverage: watch-hooks 100%, transform-context 100%, emitted-files 98.24%

Closes #66
Closes #71
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)