### PR TITLE
feat: implement code splitting (Phase 7)

### DIFF
--- a/src/codegen/hash.ts
+++ b/src/codegen/hash.ts
@@ -1,0 +1,176 @@
+/**
+ * @module codegen/hash
+ * @description Content hashing using FNV-1a algorithm for deterministic chunk
+ * fingerprinting. Produces hex, base64, or base36 encoded output.
+ */
+
+import type { HashCharacters } from "../types.js";
+
+/**
+ * FNV-1a 32-bit parameters for generating multiple hash values.
+ * We run FNV-1a with different seeds to produce 128 bits total.
+ */
+const FNV32_OFFSET = 0x811c9dc5;
+const FNV32_PRIME = 0x01000193;
+
+/** Base64 URL-safe character set (no padding). */
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/** Hex character set. */
+const HEX_CHARS = "0123456789abcdef";
+
+/** Base36 character set. */
+const BASE36_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Compute FNV-1a 32-bit hash with a given seed.
+ * Processes each byte of the UTF-16 code units (both high and low bytes).
+ */
+const fnv1a32 = (input: string, seed: number): number => {
+  let hash = (FNV32_OFFSET ^ seed) >>> 0;
+
+  const length = input.length;
+  for (let i = 0; i < length; i++) {
+    const code = input.charCodeAt(i);
+    // Process high byte
+    hash = hash ^ ((code >>> 8) & 0xff);
+    hash = Math.imul(hash, FNV32_PRIME) >>> 0;
+    // Process low byte
+    hash = hash ^ (code & 0xff);
+    hash = Math.imul(hash, FNV32_PRIME) >>> 0;
+  }
+
+  return hash;
+};
+
+/**
+ * Compute 128-bit hash by running FNV-1a with 4 different seeds.
+ * Returns 16 bytes as a Uint8Array.
+ */
+const computeHash128 = (input: string): Uint8Array => {
+  const h0 = fnv1a32(input, 0);
+  const h1 = fnv1a32(input, 0x12345678);
+  const h2 = fnv1a32(input, 0x9abcdef0);
+  const h3 = fnv1a32(input, 0xfedcba98);
+
+  const result = new Uint8Array(16);
+  result[0] = (h0 >>> 24) & 0xff;
+  result[1] = (h0 >>> 16) & 0xff;
+  result[2] = (h0 >>> 8) & 0xff;
+  result[3] = h0 & 0xff;
+  result[4] = (h1 >>> 24) & 0xff;
+  result[5] = (h1 >>> 16) & 0xff;
+  result[6] = (h1 >>> 8) & 0xff;
+  result[7] = h1 & 0xff;
+  result[8] = (h2 >>> 24) & 0xff;
+  result[9] = (h2 >>> 16) & 0xff;
+  result[10] = (h2 >>> 8) & 0xff;
+  result[11] = h2 & 0xff;
+  result[12] = (h3 >>> 24) & 0xff;
+  result[13] = (h3 >>> 16) & 0xff;
+  result[14] = (h3 >>> 8) & 0xff;
+  result[15] = h3 & 0xff;
+
+  return result;
+};
+
+/**
+ * Encode raw bytes to hex string.
+ */
+const encodeHex = (bytes: Uint8Array, length: number): string => {
+  const chars: Array<string> = [];
+  const byteCount = Math.ceil(length / 2);
+  for (let i = 0; i < byteCount && i < bytes.length; i++) {
+    chars.push(HEX_CHARS[(bytes[i] >>> 4) & 0x0f]);
+    chars.push(HEX_CHARS[bytes[i] & 0x0f]);
+  }
+  return chars.slice(0, length).join("");
+};
+
+/**
+ * Encode raw bytes to base64url string (no padding).
+ */
+const encodeBase64 = (bytes: Uint8Array, length: number): string => {
+  const chars: Array<string> = [];
+  let bits = 0;
+  let buffer = 0;
+
+  for (let i = 0; i < bytes.length && chars.length < length; i++) {
+    buffer = (buffer << 8) | bytes[i];
+    bits += 8;
+    while (bits >= 6 && chars.length < length) {
+      bits -= 6;
+      chars.push(BASE64_CHARS[(buffer >>> bits) & 0x3f]);
+    }
+  }
+  if (bits > 0 && chars.length < length) {
+    chars.push(BASE64_CHARS[(buffer << (6 - bits)) & 0x3f]);
+  }
+  return chars.slice(0, length).join("");
+};
+
+/**
+ * Encode raw bytes to base36 string.
+ */
+const encodeBase36 = (bytes: Uint8Array, length: number): string => {
+  // Convert bytes to a big number represented as array of digits in base36
+  const digits: Array<number> = [0];
+
+  for (let i = 0; i < bytes.length; i++) {
+    let carry = bytes[i];
+    for (let j = 0; j < digits.length; j++) {
+      const value = digits[j] * 256 + carry;
+      digits[j] = value % 36;
+      carry = Math.floor(value / 36);
+    }
+    while (carry > 0) {
+      digits.push(carry % 36);
+      carry = Math.floor(carry / 36);
+    }
+  }
+
+  // digits are in reverse order (least significant first)
+  const chars: Array<string> = [];
+  for (let i = digits.length - 1; i >= 0 && chars.length < length; i--) {
+    chars.push(BASE36_CHARS[digits[i]]);
+  }
+
+  // Pad if needed
+  while (chars.length < length) {
+    chars.push("0");
+  }
+
+  return chars.slice(0, length).join("");
+};
+
+/**
+ * Compute a deterministic content hash of the given string.
+ *
+ * @param content - The string content to hash
+ * @param length - Desired output length in characters
+ * @param chars - Encoding format: 'hex', 'base64', or 'base36'
+ * @returns A deterministic hash string of the specified length and encoding
+ *
+ * @example
+ * ```typescript
+ * const hash = contentHash("hello world", 8, "hex");
+ * // Returns a deterministic 8-char hex string
+ * ```
+ */
+export const contentHash = (
+  content: string,
+  length: number,
+  chars: HashCharacters,
+): string => {
+  const bytes = computeHash128(content);
+
+  switch (chars) {
+    case "hex":
+      return encodeHex(bytes, length);
+    case "base64":
+      return encodeBase64(bytes, length);
+    case "base36":
+      return encodeBase36(bytes, length);
+  }
+};

--- a/src/splitting/chunk-assignment.ts
+++ b/src/splitting/chunk-assignment.ts
@@ -1,0 +1,241 @@
+/**
+ * @module splitting/chunk-assignment
+ * @description Assigns modules to chunks based on split points, entry points,
+ * and manual chunk configuration.
+ */
+
+import type { SplitPoint, SplittableModule } from "./split-points.js";
+
+/** A function-based manual chunks resolver. */
+export type ManualChunksFn = (moduleId: string) => string | null | undefined;
+
+/** Manual chunks configuration: either a record or a function. */
+export type ManualChunksConfig =
+  | Readonly<Record<string, ReadonlyArray<string>>>
+  | ManualChunksFn;
+
+/** Result of chunk assignment: map from chunk name to module IDs. */
+export type ChunkAssignment = Map<string, Array<string>>;
+
+/**
+ * Resolve manual chunk assignment for a module ID.
+ * Returns the chunk name if assigned, otherwise null.
+ */
+const resolveManualChunk = (
+  moduleId: string,
+  manualChunks: ManualChunksConfig | undefined,
+): string | null => {
+  if (!manualChunks) {
+    return null;
+  }
+
+  if (typeof manualChunks === "function") {
+    const result = manualChunks(moduleId);
+    return result ?? null;
+  }
+
+  // Record-based: check if moduleId appears in any chunk's module list
+  const chunkNames = Object.keys(manualChunks);
+  for (let i = 0; i < chunkNames.length; i++) {
+    const modules = manualChunks[chunkNames[i]];
+    if (modules.includes(moduleId)) {
+      return chunkNames[i];
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Build a reachability map from each chunk root (entry/split point) to all
+ * modules it statically reaches (excluding other chunk roots).
+ */
+const buildChunkReachability = (
+  modules: ReadonlyArray<SplittableModule>,
+  chunkRoots: ReadonlyArray<string>,
+): Map<string, Set<string>> => {
+  const moduleMap = new Map<string, SplittableModule>();
+  for (let i = 0; i < modules.length; i++) {
+    moduleMap.set(modules[i].id, modules[i]);
+  }
+
+  const rootSet = new Set(chunkRoots);
+  const reachability = new Map<string, Set<string>>();
+
+  for (let r = 0; r < chunkRoots.length; r++) {
+    const rootId = chunkRoots[r];
+    const reachable = new Set<string>([rootId]);
+    const queue: Array<string> = [rootId];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const mod = moduleMap.get(current);
+      if (!mod) {
+        continue;
+      }
+
+      for (let i = 0; i < mod.importedIds.length; i++) {
+        const dep = mod.importedIds[i];
+        // Don't cross into another chunk root (unless it's the same root)
+        if (reachable.has(dep)) {
+          continue;
+        }
+        if (rootSet.has(dep) && dep !== rootId) {
+          continue;
+        }
+        reachable.add(dep);
+        queue.push(dep);
+      }
+    }
+
+    reachability.set(rootId, reachable);
+  }
+
+  return reachability;
+};
+
+/**
+ * Derive a chunk name from a module ID.
+ */
+const deriveChunkName = (moduleId: string): string => {
+  const parts = moduleId.split("/");
+  const last = parts[parts.length - 1] || moduleId;
+  // Remove extension
+  const dotIndex = last.lastIndexOf(".");
+  return dotIndex > 0 ? last.slice(0, dotIndex) : last;
+};
+
+/**
+ * Assign modules to chunks based on entry points, split points, and manual
+ * chunk configuration.
+ *
+ * Algorithm:
+ * 1. Manual chunks take highest priority
+ * 2. Each entry point gets its own chunk
+ * 3. Each dynamic import split point gets its own chunk
+ * 4. Modules reachable from multiple chunks go into a shared chunk
+ * 5. Remaining modules go into the chunk that reaches them
+ *
+ * @param modules - All modules in the dependency graph
+ * @param entries - Entry point module IDs
+ * @param splitPoints - Detected split points
+ * @param manualChunks - Optional manual chunk configuration
+ * @returns Map from chunk name to array of module IDs in that chunk
+ *
+ * @example
+ * ```typescript
+ * const chunks = assignChunks(modules, ["./main.ts"], splitPoints);
+ * // Map { "main" => ["./main.ts", "./utils.ts"], "lazy" => ["./lazy.ts"] }
+ * ```
+ */
+export const assignChunks = (
+  modules: ReadonlyArray<SplittableModule>,
+  entries: ReadonlyArray<string>,
+  splitPoints: ReadonlyArray<SplitPoint>,
+  manualChunks?: ManualChunksConfig,
+): ChunkAssignment => {
+  const chunks: ChunkAssignment = new Map();
+  const assigned = new Map<string, string>(); // moduleId -> chunkName
+
+  // 1. Manual chunks (highest priority)
+  for (let i = 0; i < modules.length; i++) {
+    const chunkName = resolveManualChunk(modules[i].id, manualChunks);
+    if (chunkName !== null) {
+      assigned.set(modules[i].id, chunkName);
+      const existing = chunks.get(chunkName);
+      if (existing) {
+        existing.push(modules[i].id);
+      } else {
+        chunks.set(chunkName, [modules[i].id]);
+      }
+    }
+  }
+
+  // 2. Identify chunk roots (entries + dynamic import split points)
+  const chunkRoots: Array<string> = [];
+  const chunkRootNames = new Map<string, string>();
+
+  for (let i = 0; i < entries.length; i++) {
+    if (!assigned.has(entries[i])) {
+      const name = deriveChunkName(entries[i]);
+      chunkRoots.push(entries[i]);
+      chunkRootNames.set(entries[i], name);
+    }
+  }
+
+  for (let i = 0; i < splitPoints.length; i++) {
+    const sp = splitPoints[i];
+    if (sp.reason === "dynamic-import" && !assigned.has(sp.moduleId)) {
+      const name = deriveChunkName(sp.moduleId);
+      chunkRoots.push(sp.moduleId);
+      chunkRootNames.set(sp.moduleId, name);
+    }
+  }
+
+  // 3. Build reachability from each chunk root
+  const reachability = buildChunkReachability(modules, chunkRoots);
+
+  // 4. Assign chunk roots themselves
+  for (let i = 0; i < chunkRoots.length; i++) {
+    const rootId = chunkRoots[i];
+    const name = chunkRootNames.get(rootId)!;
+    assigned.set(rootId, name);
+    const existing = chunks.get(name);
+    if (existing) {
+      existing.push(rootId);
+    } else {
+      chunks.set(name, [rootId]);
+    }
+  }
+
+  // 5. Assign remaining modules
+  for (let i = 0; i < modules.length; i++) {
+    const moduleId = modules[i].id;
+    if (assigned.has(moduleId)) {
+      continue;
+    }
+
+    // Find which chunk roots can reach this module
+    const reachingChunks: Array<string> = [];
+    for (let r = 0; r < chunkRoots.length; r++) {
+      const reachable = reachability.get(chunkRoots[r]);
+      if (reachable && reachable.has(moduleId)) {
+        reachingChunks.push(chunkRootNames.get(chunkRoots[r])!);
+      }
+    }
+
+    if (reachingChunks.length === 0) {
+      // Unreachable module - put in first entry chunk
+      const fallbackName = chunkRootNames.get(entries[0]) || "chunk";
+      assigned.set(moduleId, fallbackName);
+      const existing = chunks.get(fallbackName);
+      if (existing) {
+        existing.push(moduleId);
+      } else {
+        chunks.set(fallbackName, [moduleId]);
+      }
+    } else if (reachingChunks.length === 1) {
+      // Only one chunk reaches it - assign there
+      const chunkName = reachingChunks[0];
+      assigned.set(moduleId, chunkName);
+      const existing = chunks.get(chunkName);
+      if (existing) {
+        existing.push(moduleId);
+      } else {
+        chunks.set(chunkName, [moduleId]);
+      }
+    } else {
+      // Multiple chunks reach it - shared chunk
+      const sharedName = "shared";
+      assigned.set(moduleId, sharedName);
+      const existing = chunks.get(sharedName);
+      if (existing) {
+        existing.push(moduleId);
+      } else {
+        chunks.set(sharedName, [moduleId]);
+      }
+    }
+  }
+
+  return chunks;
+};

--- a/src/splitting/chunk-naming.ts
+++ b/src/splitting/chunk-naming.ts
@@ -1,0 +1,184 @@
+/**
+ * @module splitting/chunk-naming
+ * @description Resolves chunk file names from patterns with placeholder
+ * substitution. Supports [name], [hash], [format], and [extname] placeholders.
+ */
+
+import type { HashCharacters, ModuleFormat } from "../types.js";
+import { contentHash } from "../codegen/hash.js";
+
+/** Information about a chunk needed for name resolution. */
+export interface ChunkNamingInfo {
+  readonly name: string;
+  readonly content: string;
+  readonly format: ModuleFormat;
+  readonly isEntry: boolean;
+}
+
+/** Options controlling chunk file naming. */
+export interface ChunkNamingOptions {
+  readonly entryFileNames?: string;
+  readonly chunkFileNames?: string;
+  readonly assetFileNames?: string;
+  readonly hashLength?: number;
+  readonly hashChars?: HashCharacters;
+}
+
+/** Default file name patterns. */
+const DEFAULT_ENTRY_PATTERN = "[name].js";
+const DEFAULT_CHUNK_PATTERN = "[name]-[hash].js";
+const DEFAULT_ASSET_PATTERN = "assets/[name]-[hash][extname]";
+const DEFAULT_HASH_LENGTH = 8;
+const DEFAULT_HASH_CHARS: HashCharacters = "base64";
+
+/**
+ * Get the file extension for a given output format.
+ */
+const getFormatExtension = (format: ModuleFormat): string => {
+  switch (format) {
+    case "es":
+      return ".mjs";
+    case "cjs":
+      return ".cjs";
+    case "amd":
+    case "iife":
+    case "umd":
+    case "system":
+      return ".js";
+  }
+};
+
+/**
+ * Sanitize a file name by removing unsafe characters.
+ * Replaces non-alphanumeric characters (except hyphens, underscores, dots,
+ * and forward slashes) with underscores.
+ */
+const sanitizeFileName = (name: string): string => {
+  return name.replace(/[^a-zA-Z0-9\-_./]/g, "_");
+};
+
+/**
+ * Substitute placeholders in a file name pattern.
+ *
+ * Supported placeholders:
+ * - [name] - The chunk name (derived from entry or manual assignment)
+ * - [hash] - Content hash of the chunk
+ * - [format] - Output format (es, cjs, etc.)
+ * - [extname] - File extension including dot (.js, .mjs, etc.)
+ *
+ * @param pattern - Pattern string with placeholders
+ * @param name - Chunk name
+ * @param hash - Computed content hash
+ * @param format - Output module format
+ * @returns Resolved file name with all placeholders replaced
+ */
+const substitutePlaceholders = (
+  pattern: string,
+  name: string,
+  hash: string,
+  format: ModuleFormat,
+): string => {
+  const ext = getFormatExtension(format);
+  const sanitizedName = sanitizeFileName(name);
+
+  let result = pattern;
+  result = result.replace(/\[name\]/g, sanitizedName);
+  result = result.replace(/\[hash\]/g, hash);
+  result = result.replace(/\[format\]/g, format);
+  result = result.replace(/\[extname\]/g, ext);
+
+  return result;
+};
+
+/**
+ * Resolve the file name for a chunk based on its type and naming options.
+ *
+ * Entry chunks use the `entryFileNames` pattern (default: "[name].js").
+ * Non-entry chunks use the `chunkFileNames` pattern (default: "[name]-[hash].js").
+ *
+ * @param chunk - Information about the chunk
+ * @param pattern - Optional override pattern (takes precedence over options)
+ * @param hashLength - Length of hash in characters (default: 8)
+ * @param hashChars - Hash encoding format (default: "base64")
+ * @returns The resolved file name string
+ *
+ * @example
+ * ```typescript
+ * const name = resolveChunkFileName(
+ *   { name: "main", content: "code", format: "es", isEntry: true },
+ *   "[name]-[hash].mjs",
+ *   8,
+ *   "hex"
+ * );
+ * // "main-a1b2c3d4.mjs"
+ * ```
+ */
+export const resolveChunkFileName = (
+  chunk: ChunkNamingInfo,
+  pattern?: string,
+  hashLength?: number,
+  hashChars?: HashCharacters,
+): string => {
+  const effectiveHashLength = hashLength ?? DEFAULT_HASH_LENGTH;
+  const effectiveHashChars = hashChars ?? DEFAULT_HASH_CHARS;
+
+  const hash = contentHash(
+    chunk.content,
+    effectiveHashLength,
+    effectiveHashChars,
+  );
+
+  const effectivePattern =
+    pattern ?? (chunk.isEntry ? DEFAULT_ENTRY_PATTERN : DEFAULT_CHUNK_PATTERN);
+
+  return substitutePlaceholders(
+    effectivePattern,
+    chunk.name,
+    hash,
+    chunk.format,
+  );
+};
+
+/**
+ * Resolve the file name for an asset.
+ *
+ * @param name - Asset name (including extension)
+ * @param content - Asset content for hashing
+ * @param options - Naming options
+ * @returns The resolved asset file name
+ *
+ * @example
+ * ```typescript
+ * const name = resolveAssetFileName("style.css", "body{}", {});
+ * // "assets/style-AbCdEfGh.css"
+ * ```
+ */
+export const resolveAssetFileName = (
+  name: string,
+  content: string,
+  options?: ChunkNamingOptions,
+): string => {
+  const pattern = options?.assetFileNames ?? DEFAULT_ASSET_PATTERN;
+  const hashLength = options?.hashLength ?? DEFAULT_HASH_LENGTH;
+  const hashChars = options?.hashChars ?? DEFAULT_HASH_CHARS;
+
+  const hash = contentHash(content, hashLength, hashChars);
+  const dotIndex = name.lastIndexOf(".");
+  const ext = dotIndex > 0 ? name.slice(dotIndex) : "";
+  const baseName = dotIndex > 0 ? name.slice(0, dotIndex) : name;
+
+  let result = pattern;
+  result = result.replace(/\[name\]/g, sanitizeFileName(baseName));
+  result = result.replace(/\[hash\]/g, hash);
+  result = result.replace(/\[extname\]/g, ext);
+
+  return result;
+};
+
+export {
+  DEFAULT_ENTRY_PATTERN,
+  DEFAULT_CHUNK_PATTERN,
+  DEFAULT_ASSET_PATTERN,
+  DEFAULT_HASH_LENGTH,
+  DEFAULT_HASH_CHARS,
+};

--- a/src/splitting/chunk-optimization.ts
+++ b/src/splitting/chunk-optimization.ts
@@ -1,0 +1,230 @@
+/**
+ * @module splitting/chunk-optimization
+ * @description Optimizes chunk assignments by merging small chunks, hoisting
+ * transitive imports, and supporting inline dynamic imports mode.
+ */
+
+/** Options that control chunk optimization behavior. */
+export interface ChunkOptimizationOptions {
+  /** Minimum chunk size in bytes. Chunks smaller than this are merged. */
+  readonly experimentalMinChunkSize?: number;
+  /** Hoist transitive imports into importing chunk to reduce waterfalls. */
+  readonly hoistTransitiveImports?: boolean;
+  /** Inline all dynamic imports into a single chunk (disables code splitting). */
+  readonly inlineDynamicImports?: boolean;
+}
+
+/** A chunk with its modules and metadata for optimization. */
+export interface OptimizableChunk {
+  readonly name: string;
+  readonly moduleIds: Array<string>;
+  readonly size: number;
+  readonly isEntry: boolean;
+  readonly isDynamicEntry: boolean;
+  readonly imports: ReadonlyArray<string>;
+}
+
+/** Result of chunk optimization. */
+export interface OptimizedChunks {
+  readonly chunks: Array<OptimizableChunk>;
+  readonly merged: ReadonlyArray<string>;
+}
+
+/**
+ * Find the best merge target for a small chunk.
+ * Prefers chunks that import the small chunk. Falls back to the largest
+ * non-entry chunk, then any chunk.
+ */
+const findMergeTarget = (
+  smallChunk: OptimizableChunk,
+  chunks: Array<OptimizableChunk>,
+): OptimizableChunk | null => {
+  // Prefer a chunk that imports this one
+  for (let i = 0; i < chunks.length; i++) {
+    if (chunks[i].name === smallChunk.name) {
+      continue;
+    }
+    if (chunks[i].imports.includes(smallChunk.name)) {
+      return chunks[i];
+    }
+  }
+
+  // Fall back to the smallest non-entry chunk that isn't this one
+  let best: OptimizableChunk | null = null;
+  for (let i = 0; i < chunks.length; i++) {
+    if (chunks[i].name === smallChunk.name) {
+      continue;
+    }
+    if (!chunks[i].isEntry && (!best || chunks[i].size < best.size)) {
+      best = chunks[i];
+    }
+  }
+
+  // Fall back to any chunk
+  if (!best) {
+    for (let i = 0; i < chunks.length; i++) {
+      if (chunks[i].name !== smallChunk.name) {
+        return chunks[i];
+      }
+    }
+  }
+
+  return best;
+};
+
+/**
+ * Optimize chunks based on the provided options.
+ *
+ * Optimizations applied in order:
+ * 1. `inlineDynamicImports` - Merges everything into a single chunk
+ * 2. `experimentalMinChunkSize` - Merges chunks below the size threshold
+ * 3. `hoistTransitiveImports` - Moves transitively imported modules up
+ *
+ * @param chunks - Array of chunks to optimize
+ * @param options - Optimization options
+ * @returns Optimized chunks with merge tracking
+ *
+ * @example
+ * ```typescript
+ * const result = optimizeChunks(chunks, { experimentalMinChunkSize: 1000 });
+ * // Small chunks merged into larger ones
+ * ```
+ */
+export const optimizeChunks = (
+  chunks: ReadonlyArray<OptimizableChunk>,
+  options: ChunkOptimizationOptions,
+): OptimizedChunks => {
+  const merged: Array<string> = [];
+
+  // 1. Inline dynamic imports: merge everything into one chunk
+  if (options.inlineDynamicImports) {
+    if (chunks.length === 0) {
+      return { chunks: [], merged: [] };
+    }
+
+    const allModuleIds: Array<string> = [];
+    let totalSize = 0;
+    let entryName = "bundle";
+
+    for (let i = 0; i < chunks.length; i++) {
+      for (let j = 0; j < chunks[i].moduleIds.length; j++) {
+        allModuleIds.push(chunks[i].moduleIds[j]);
+      }
+      totalSize += chunks[i].size;
+      if (chunks[i].isEntry) {
+        entryName = chunks[i].name;
+      }
+      if (i > 0 || !chunks[i].isEntry) {
+        merged.push(chunks[i].name);
+      }
+    }
+
+    const singleChunk: OptimizableChunk = {
+      name: entryName,
+      moduleIds: allModuleIds,
+      size: totalSize,
+      isEntry: true,
+      isDynamicEntry: false,
+      imports: [],
+    };
+
+    return { chunks: [singleChunk], merged };
+  }
+
+  // Work with a mutable copy
+  let workingChunks: Array<OptimizableChunk> = [];
+  for (let i = 0; i < chunks.length; i++) {
+    workingChunks.push({
+      name: chunks[i].name,
+      moduleIds: [...chunks[i].moduleIds],
+      size: chunks[i].size,
+      isEntry: chunks[i].isEntry,
+      isDynamicEntry: chunks[i].isDynamicEntry,
+      imports: [...chunks[i].imports],
+    });
+  }
+
+  // 2. Merge small chunks
+  const minSize = options.experimentalMinChunkSize ?? 0;
+  if (minSize > 0) {
+    let changed = true;
+    // Bounded iteration: at most N merges where N = number of chunks
+    let iterations = workingChunks.length;
+    while (changed && iterations > 0) {
+      changed = false;
+      iterations--;
+
+      for (let i = workingChunks.length - 1; i >= 0; i--) {
+        const chunk = workingChunks[i];
+        if (chunk.size >= minSize || chunk.isEntry) {
+          continue;
+        }
+
+        const target = findMergeTarget(chunk, workingChunks);
+        if (!target) {
+          continue;
+        }
+
+        // Merge chunk into target
+        for (let j = 0; j < chunk.moduleIds.length; j++) {
+          target.moduleIds.push(chunk.moduleIds[j]);
+        }
+        // Update target size (mutable via cast for optimization)
+        (target as { size: number }).size += chunk.size;
+
+        merged.push(chunk.name);
+        workingChunks.splice(i, 1);
+        changed = true;
+        break; // Restart scan after merge
+      }
+    }
+  }
+
+  // 3. Hoist transitive imports
+  if (options.hoistTransitiveImports) {
+    const chunkByName = new Map<string, OptimizableChunk>();
+    for (let i = 0; i < workingChunks.length; i++) {
+      chunkByName.set(workingChunks[i].name, workingChunks[i]);
+    }
+
+    for (let i = 0; i < workingChunks.length; i++) {
+      const chunk = workingChunks[i];
+      if (!chunk.isEntry) {
+        continue;
+      }
+
+      // BFS through imported chunks, hoisting their modules
+      const visited = new Set<string>([chunk.name]);
+      const queue: Array<string> = [...chunk.imports];
+
+      while (queue.length > 0) {
+        const importName = queue.shift()!;
+        if (visited.has(importName)) {
+          continue;
+        }
+        visited.add(importName);
+
+        const importedChunk = chunkByName.get(importName);
+        if (!importedChunk || importedChunk.isDynamicEntry) {
+          continue;
+        }
+
+        // Hoist modules from the imported chunk into this entry chunk
+        for (let j = 0; j < importedChunk.moduleIds.length; j++) {
+          if (!chunk.moduleIds.includes(importedChunk.moduleIds[j])) {
+            chunk.moduleIds.push(importedChunk.moduleIds[j]);
+          }
+        }
+
+        // Continue BFS through the imported chunk's imports
+        for (let j = 0; j < importedChunk.imports.length; j++) {
+          if (!visited.has(importedChunk.imports[j])) {
+            queue.push(importedChunk.imports[j]);
+          }
+        }
+      }
+    }
+  }
+
+  return { chunks: workingChunks, merged };
+};

--- a/src/splitting/index.ts
+++ b/src/splitting/index.ts
@@ -1,0 +1,38 @@
+/**
+ * @module splitting
+ * @description Code splitting module - split point detection, chunk assignment,
+ * chunk naming, and chunk optimization.
+ */
+
+export {
+  detectSplitPoints,
+  type SplitPoint,
+  type SplitReason,
+  type SplittableModule,
+} from "./split-points.js";
+
+export {
+  assignChunks,
+  type ChunkAssignment,
+  type ManualChunksConfig,
+  type ManualChunksFn,
+} from "./chunk-assignment.js";
+
+export {
+  resolveChunkFileName,
+  resolveAssetFileName,
+  type ChunkNamingInfo,
+  type ChunkNamingOptions,
+  DEFAULT_ENTRY_PATTERN,
+  DEFAULT_CHUNK_PATTERN,
+  DEFAULT_ASSET_PATTERN,
+  DEFAULT_HASH_LENGTH,
+  DEFAULT_HASH_CHARS,
+} from "./chunk-naming.js";
+
+export {
+  optimizeChunks,
+  type ChunkOptimizationOptions,
+  type OptimizableChunk,
+  type OptimizedChunks,
+} from "./chunk-optimization.js";

--- a/src/splitting/split-points.ts
+++ b/src/splitting/split-points.ts
@@ -1,0 +1,148 @@
+/**
+ * @module splitting/split-points
+ * @description Detects code splitting points from dynamic imports and shared
+ * dependencies between multiple entry points.
+ */
+
+import type { ModuleInfo } from "../types.js";
+
+/** Reason why a module is a split point. */
+export type SplitReason = "dynamic-import" | "shared-dependency";
+
+/** A detected code split point with its source module and reason. */
+export interface SplitPoint {
+  readonly moduleId: string;
+  readonly reason: SplitReason;
+  readonly importers: ReadonlyArray<string>;
+}
+
+/**
+ * Simplified module representation for split point detection.
+ * Uses a subset of ModuleInfo fields relevant to splitting.
+ */
+export interface SplittableModule {
+  readonly id: string;
+  readonly isEntry: boolean;
+  readonly importedIds: ReadonlyArray<string>;
+  readonly dynamicallyImportedIds: ReadonlyArray<string>;
+  readonly importers: ReadonlyArray<string>;
+  readonly dynamicImporters: ReadonlyArray<string>;
+}
+
+/**
+ * Build a map of module ID to the set of entry points that can reach it
+ * (via static imports only). Uses iterative BFS.
+ */
+const buildReachabilityMap = (
+  modules: ReadonlyArray<SplittableModule>,
+  entryModuleIds: ReadonlyArray<string>,
+): Map<string, Set<string>> => {
+  const moduleMap = new Map<string, SplittableModule>();
+  for (let i = 0; i < modules.length; i++) {
+    moduleMap.set(modules[i].id, modules[i]);
+  }
+
+  const reachability = new Map<string, Set<string>>();
+
+  // For each entry, BFS through static imports
+  for (let e = 0; e < entryModuleIds.length; e++) {
+    const entryId = entryModuleIds[e];
+    const queue: Array<string> = [entryId];
+    const visited = new Set<string>();
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) {
+        continue;
+      }
+      visited.add(current);
+
+      // Mark this module as reachable from entryId
+      const entries = reachability.get(current);
+      if (entries) {
+        entries.add(entryId);
+      } else {
+        reachability.set(current, new Set([entryId]));
+      }
+
+      // Follow static imports only
+      const mod = moduleMap.get(current);
+      if (mod) {
+        for (let i = 0; i < mod.importedIds.length; i++) {
+          if (!visited.has(mod.importedIds[i])) {
+            queue.push(mod.importedIds[i]);
+          }
+        }
+      }
+    }
+  }
+
+  return reachability;
+};
+
+/**
+ * Detect split points from a module graph. Split points are created for:
+ * 1. Dynamic imports - each `import('./x')` creates a split point at the target
+ * 2. Shared dependencies - modules statically imported by 2+ entry points
+ *
+ * @param modules - Array of modules in the graph
+ * @param entryModuleIds - IDs of entry point modules
+ * @returns Array of detected split points
+ *
+ * @example
+ * ```typescript
+ * const points = detectSplitPoints(modules, ["./src/main.ts"]);
+ * // [{ moduleId: "./lazy", reason: "dynamic-import", importers: ["./main"] }]
+ * ```
+ */
+export const detectSplitPoints = (
+  modules: ReadonlyArray<SplittableModule>,
+  entryModuleIds: ReadonlyArray<string>,
+): Array<SplitPoint> => {
+  const splitPoints: Array<SplitPoint> = [];
+  const seen = new Set<string>();
+
+  // 1. Detect dynamic import split points
+  for (let i = 0; i < modules.length; i++) {
+    const mod = modules[i];
+    for (let j = 0; j < mod.dynamicallyImportedIds.length; j++) {
+      const targetId = mod.dynamicallyImportedIds[j];
+      if (!seen.has(targetId)) {
+        seen.add(targetId);
+        // Collect all dynamic importers of this target
+        const importers: Array<string> = [];
+        for (let k = 0; k < modules.length; k++) {
+          if (modules[k].dynamicallyImportedIds.includes(targetId)) {
+            importers.push(modules[k].id);
+          }
+        }
+        splitPoints.push({
+          moduleId: targetId,
+          reason: "dynamic-import",
+          importers,
+        });
+      }
+    }
+  }
+
+  // 2. Detect shared dependencies (reachable from 2+ entries via static imports)
+  const entrySet = new Set(entryModuleIds);
+  const reachability = buildReachabilityMap(modules, entryModuleIds);
+
+  for (const [moduleId, entries] of reachability) {
+    // Skip entry modules themselves and already-detected split points
+    if (entrySet.has(moduleId) || seen.has(moduleId)) {
+      continue;
+    }
+    if (entries.size >= 2) {
+      seen.add(moduleId);
+      splitPoints.push({
+        moduleId,
+        reason: "shared-dependency",
+        importers: Array.from(entries),
+      });
+    }
+  }
+
+  return splitPoints;
+};

--- a/tests/unit/splitting/chunk-assignment.test.ts
+++ b/tests/unit/splitting/chunk-assignment.test.ts
@@ -1,0 +1,399 @@
+/**
+ * @module tests/unit/splitting/chunk-assignment
+ * @description Unit tests for chunk assignment algorithm.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  assignChunks,
+  type ManualChunksConfig,
+} from "../../../src/splitting/chunk-assignment.js";
+import type { SplittableModule } from "../../../src/splitting/split-points.js";
+import { detectSplitPoints } from "../../../src/splitting/split-points.js";
+
+const makeModule = (
+  id: string,
+  overrides: Partial<SplittableModule> = {},
+): SplittableModule => ({
+  id,
+  isEntry: false,
+  importedIds: [],
+  dynamicallyImportedIds: [],
+  importers: [],
+  dynamicImporters: [],
+  ...overrides,
+});
+
+describe("assignChunks", () => {
+  describe("entry chunks", () => {
+    it("creates a chunk for each entry point", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", { isEntry: true }),
+        makeModule("./other.ts", { isEntry: true }),
+      ];
+
+      const chunks = assignChunks(modules, ["./main.ts", "./other.ts"], []);
+      expect(chunks.has("main")).toBe(true);
+      expect(chunks.has("other")).toBe(true);
+      expect(chunks.get("main")).toContain("./main.ts");
+      expect(chunks.get("other")).toContain("./other.ts");
+    });
+
+    it("assigns static dependencies to their entry chunk", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          importedIds: ["./utils.ts"],
+        }),
+        makeModule("./utils.ts"),
+      ];
+
+      const chunks = assignChunks(modules, ["./main.ts"], []);
+      expect(chunks.get("main")).toContain("./utils.ts");
+    });
+  });
+
+  describe("dynamic import chunks", () => {
+    it("creates separate chunk for dynamic imports", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./lazy.ts", { dynamicImporters: ["./main.ts"] }),
+      ];
+
+      const splitPoints = detectSplitPoints(modules, ["./main.ts"]);
+      const chunks = assignChunks(modules, ["./main.ts"], splitPoints);
+
+      expect(chunks.has("lazy")).toBe(true);
+      expect(chunks.get("lazy")).toContain("./lazy.ts");
+    });
+
+    it("assigns dependencies of dynamic import to its chunk", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./lazy.ts", {
+          dynamicImporters: ["./main.ts"],
+          importedIds: ["./lazy-dep.ts"],
+        }),
+        makeModule("./lazy-dep.ts"),
+      ];
+
+      const splitPoints = detectSplitPoints(modules, ["./main.ts"]);
+      const chunks = assignChunks(modules, ["./main.ts"], splitPoints);
+
+      expect(chunks.get("lazy")).toContain("./lazy-dep.ts");
+    });
+  });
+
+  describe("shared chunks", () => {
+    it("puts shared dependencies in a shared chunk", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./entry-a.ts", {
+          isEntry: true,
+          importedIds: ["./shared.ts"],
+        }),
+        makeModule("./entry-b.ts", {
+          isEntry: true,
+          importedIds: ["./shared.ts"],
+        }),
+        makeModule("./shared.ts"),
+      ];
+
+      const splitPoints = detectSplitPoints(modules, [
+        "./entry-a.ts",
+        "./entry-b.ts",
+      ]);
+      const chunks = assignChunks(
+        modules,
+        ["./entry-a.ts", "./entry-b.ts"],
+        splitPoints,
+      );
+
+      expect(chunks.has("shared")).toBe(true);
+      expect(chunks.get("shared")).toContain("./shared.ts");
+    });
+
+    it("handles multiple shared dependencies", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./a.ts", {
+          isEntry: true,
+          importedIds: ["./util1.ts", "./util2.ts"],
+        }),
+        makeModule("./b.ts", {
+          isEntry: true,
+          importedIds: ["./util1.ts", "./util2.ts"],
+        }),
+        makeModule("./util1.ts"),
+        makeModule("./util2.ts"),
+      ];
+
+      const splitPoints = detectSplitPoints(modules, ["./a.ts", "./b.ts"]);
+      const chunks = assignChunks(modules, ["./a.ts", "./b.ts"], splitPoints);
+
+      const sharedChunk = chunks.get("shared");
+      expect(sharedChunk).toContain("./util1.ts");
+      expect(sharedChunk).toContain("./util2.ts");
+    });
+  });
+
+  describe("manualChunks", () => {
+    it("supports record-based manual chunks", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          importedIds: ["./vendor-a.ts", "./vendor-b.ts"],
+        }),
+        makeModule("./vendor-a.ts"),
+        makeModule("./vendor-b.ts"),
+      ];
+
+      const manualChunks: ManualChunksConfig = {
+        vendor: ["./vendor-a.ts", "./vendor-b.ts"],
+      };
+
+      const chunks = assignChunks(modules, ["./main.ts"], [], manualChunks);
+      expect(chunks.has("vendor")).toBe(true);
+      expect(chunks.get("vendor")).toContain("./vendor-a.ts");
+      expect(chunks.get("vendor")).toContain("./vendor-b.ts");
+    });
+
+    it("supports function-based manual chunks", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          importedIds: ["./node_modules/lodash.ts"],
+        }),
+        makeModule("./node_modules/lodash.ts"),
+      ];
+
+      const manualChunks: ManualChunksConfig = (id: string) =>
+        id.includes("node_modules") ? "vendor" : null;
+
+      const chunks = assignChunks(modules, ["./main.ts"], [], manualChunks);
+      expect(chunks.has("vendor")).toBe(true);
+      expect(chunks.get("vendor")).toContain("./node_modules/lodash.ts");
+    });
+
+    it("manual chunks take priority over automatic assignment", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./a.ts", {
+          isEntry: true,
+          importedIds: ["./lib.ts"],
+        }),
+        makeModule("./b.ts", {
+          isEntry: true,
+          importedIds: ["./lib.ts"],
+        }),
+        makeModule("./lib.ts"),
+      ];
+
+      const manualChunks: ManualChunksConfig = {
+        "my-lib": ["./lib.ts"],
+      };
+
+      const splitPoints = detectSplitPoints(modules, ["./a.ts", "./b.ts"]);
+      const chunks = assignChunks(
+        modules,
+        ["./a.ts", "./b.ts"],
+        splitPoints,
+        manualChunks,
+      );
+
+      expect(chunks.has("my-lib")).toBe(true);
+      expect(chunks.get("my-lib")).toContain("./lib.ts");
+      // Should not be in the shared chunk
+      const shared = chunks.get("shared");
+      if (shared) {
+        expect(shared).not.toContain("./lib.ts");
+      }
+    });
+
+    it("function returning undefined leaves module unassigned", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          importedIds: ["./utils.ts"],
+        }),
+        makeModule("./utils.ts"),
+      ];
+
+      const manualChunks: ManualChunksConfig = () => undefined;
+
+      const chunks = assignChunks(modules, ["./main.ts"], [], manualChunks);
+      expect(chunks.get("main")).toContain("./utils.ts");
+    });
+  });
+
+  describe("unreachable modules", () => {
+    it("assigns unreachable modules to the first entry chunk", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", { isEntry: true }),
+        makeModule("./orphan.ts"),
+      ];
+
+      const chunks = assignChunks(modules, ["./main.ts"], []);
+      expect(chunks.get("main")).toContain("./orphan.ts");
+    });
+
+    it("handles unreachable module when entry chunk already exists", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", { isEntry: true, importedIds: ["./dep.ts"] }),
+        makeModule("./dep.ts"),
+        makeModule("./isolated.ts"),
+      ];
+
+      const chunks = assignChunks(modules, ["./main.ts"], []);
+      expect(chunks.get("main")).toContain("./isolated.ts");
+    });
+
+    it("creates fallback chunk when entry is manually assigned elsewhere", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", { isEntry: true }),
+        makeModule("./orphan.ts"),
+      ];
+
+      // Manual chunks steals the entry, so entry chunk root isn't created normally
+      const manualChunks: ManualChunksConfig = {
+        custom: ["./main.ts"],
+      };
+
+      const chunks = assignChunks(modules, ["./main.ts"], [], manualChunks);
+      // orphan should end up somewhere
+      const allModules = Array.from(chunks.values()).flat();
+      expect(allModules).toContain("./orphan.ts");
+    });
+  });
+
+  describe("single-reaching chunk new creation", () => {
+    it("creates chunk for module reachable from dynamic import only", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./lazy.ts", {
+          dynamicImporters: ["./main.ts"],
+          importedIds: ["./lazy-only.ts"],
+        }),
+        makeModule("./lazy-only.ts"),
+      ];
+
+      const splitPoints = detectSplitPoints(modules, ["./main.ts"]);
+      const chunks = assignChunks(modules, ["./main.ts"], splitPoints);
+      expect(chunks.get("lazy")).toContain("./lazy-only.ts");
+    });
+
+    it("handles new chunk creation for single-reacher when chunk doesnt exist yet", () => {
+      // Scenario: manual chunks takes the entry's own modules, so the
+      // entry chunk root name exists but the chunk in the map was consumed.
+      // Then a module only reachable from a dynamic split point triggers
+      // the else branch on line 225.
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          importedIds: ["./a.ts"],
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./a.ts"),
+        makeModule("./lazy.ts", {
+          dynamicImporters: ["./main.ts"],
+          importedIds: ["./lazy-dep.ts"],
+        }),
+        makeModule("./lazy-dep.ts"),
+      ];
+
+      const splitPoints = detectSplitPoints(modules, ["./main.ts"]);
+      const chunks = assignChunks(modules, ["./main.ts"], splitPoints);
+      // lazy-dep should be in the lazy chunk
+      expect(chunks.get("lazy")).toContain("./lazy-dep.ts");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty modules array", () => {
+      const chunks = assignChunks([], [], []);
+      expect(chunks.size).toBe(0);
+    });
+
+    it("handles module with path-like ID", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("/home/user/project/src/main.ts", { isEntry: true }),
+      ];
+      const chunks = assignChunks(
+        modules,
+        ["/home/user/project/src/main.ts"],
+        [],
+      );
+      expect(chunks.has("main")).toBe(true);
+    });
+
+    it("handles module with no extension", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main", { isEntry: true }),
+      ];
+      const chunks = assignChunks(modules, ["./main"], []);
+      expect(chunks.has("main")).toBe(true);
+    });
+
+    it("does not cross into another chunk root during reachability", () => {
+      // main statically imports lazy, but lazy is also a dynamic import target
+      // So lazy is a chunk root and main should not "reach through" it
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          importedIds: ["./lazy.ts"],
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./lazy.ts", {
+          dynamicImporters: ["./main.ts"],
+          importedIds: ["./lazy-dep.ts"],
+        }),
+        makeModule("./lazy-dep.ts"),
+      ];
+
+      const splitPoints = detectSplitPoints(modules, ["./main.ts"]);
+      const chunks = assignChunks(modules, ["./main.ts"], splitPoints);
+      // lazy-dep should be in lazy chunk, not main
+      expect(chunks.get("lazy")).toContain("./lazy-dep.ts");
+      const mainChunk = chunks.get("main") || [];
+      expect(mainChunk).not.toContain("./lazy-dep.ts");
+    });
+
+    it("handles two entries with same basename (name collision)", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./src/main.ts", { isEntry: true }),
+        makeModule("./lib/main.ts", { isEntry: true }),
+      ];
+
+      const chunks = assignChunks(
+        modules,
+        ["./src/main.ts", "./lib/main.ts"],
+        [],
+      );
+      // Both should be assigned (same chunk name "main")
+      const mainChunk = chunks.get("main");
+      expect(mainChunk).toContain("./src/main.ts");
+      expect(mainChunk).toContain("./lib/main.ts");
+    });
+
+    it("handles circular dependencies in reachability", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          importedIds: ["./a.ts"],
+        }),
+        makeModule("./a.ts", { importedIds: ["./b.ts"] }),
+        makeModule("./b.ts", { importedIds: ["./a.ts"] }),
+      ];
+
+      const chunks = assignChunks(modules, ["./main.ts"], []);
+      expect(chunks.get("main")).toContain("./a.ts");
+      expect(chunks.get("main")).toContain("./b.ts");
+    });
+  });
+});

--- a/tests/unit/splitting/chunk-naming.test.ts
+++ b/tests/unit/splitting/chunk-naming.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @module tests/unit/splitting/chunk-naming
+ * @description Unit tests for chunk naming and file pattern resolution.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveChunkFileName,
+  resolveAssetFileName,
+  DEFAULT_ENTRY_PATTERN,
+  DEFAULT_CHUNK_PATTERN,
+  DEFAULT_ASSET_PATTERN,
+  DEFAULT_HASH_LENGTH,
+  DEFAULT_HASH_CHARS,
+  type ChunkNamingInfo,
+} from "../../../src/splitting/chunk-naming.js";
+
+describe("resolveChunkFileName", () => {
+  const entryChunk: ChunkNamingInfo = {
+    name: "main",
+    content: "const x = 1;",
+    format: "es",
+    isEntry: true,
+  };
+
+  const nonEntryChunk: ChunkNamingInfo = {
+    name: "shared",
+    content: "export const y = 2;",
+    format: "es",
+    isEntry: false,
+  };
+
+  describe("default patterns", () => {
+    it("uses entry pattern for entry chunks", () => {
+      const result = resolveChunkFileName(entryChunk);
+      expect(result).toBe("main.js");
+    });
+
+    it("uses chunk pattern with hash for non-entry chunks", () => {
+      const result = resolveChunkFileName(nonEntryChunk);
+      expect(result).toMatch(/^shared-[A-Za-z0-9\-_]+\.js$/);
+    });
+  });
+
+  describe("pattern substitution", () => {
+    it("substitutes [name] placeholder", () => {
+      const result = resolveChunkFileName(entryChunk, "[name].bundle.js");
+      expect(result).toBe("main.bundle.js");
+    });
+
+    it("substitutes [hash] placeholder", () => {
+      const result = resolveChunkFileName(entryChunk, "[hash].js", 8, "hex");
+      expect(result).toMatch(/^[0-9a-f]{8}\.js$/);
+    });
+
+    it("substitutes [format] placeholder", () => {
+      const result = resolveChunkFileName(entryChunk, "[name].[format].js");
+      expect(result).toBe("main.es.js");
+    });
+
+    it("substitutes [extname] placeholder for es format", () => {
+      const result = resolveChunkFileName(entryChunk, "[name][extname]");
+      expect(result).toBe("main.mjs");
+    });
+
+    it("substitutes [extname] for cjs format", () => {
+      const cjsChunk: ChunkNamingInfo = {
+        name: "lib",
+        content: "module.exports = {}",
+        format: "cjs",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(cjsChunk, "[name][extname]");
+      expect(result).toBe("lib.cjs");
+    });
+
+    it("substitutes [extname] for iife format", () => {
+      const iifeChunk: ChunkNamingInfo = {
+        name: "app",
+        content: "(function(){})()",
+        format: "iife",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(iifeChunk, "[name][extname]");
+      expect(result).toBe("app.js");
+    });
+
+    it("substitutes [extname] for amd format", () => {
+      const amdChunk: ChunkNamingInfo = {
+        name: "mod",
+        content: "define([])",
+        format: "amd",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(amdChunk, "[name][extname]");
+      expect(result).toBe("mod.js");
+    });
+
+    it("substitutes [extname] for umd format", () => {
+      const umdChunk: ChunkNamingInfo = {
+        name: "lib",
+        content: "(function(){})()",
+        format: "umd",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(umdChunk, "[name][extname]");
+      expect(result).toBe("lib.js");
+    });
+
+    it("substitutes [extname] for system format", () => {
+      const sysChunk: ChunkNamingInfo = {
+        name: "sys",
+        content: "System.register()",
+        format: "system",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(sysChunk, "[name][extname]");
+      expect(result).toBe("sys.js");
+    });
+
+    it("handles multiple placeholders in one pattern", () => {
+      const result = resolveChunkFileName(
+        entryChunk,
+        "[name]-[hash].[format][extname]",
+        4,
+        "hex",
+      );
+      expect(result).toMatch(/^main-[0-9a-f]{4}\.es\.mjs$/);
+    });
+
+    it("handles repeated placeholders", () => {
+      const result = resolveChunkFileName(entryChunk, "[name]/[name].js");
+      expect(result).toBe("main/main.js");
+    });
+  });
+
+  describe("hash generation", () => {
+    it("produces deterministic hash", () => {
+      const result1 = resolveChunkFileName(entryChunk, "[hash].js", 8, "hex");
+      const result2 = resolveChunkFileName(entryChunk, "[hash].js", 8, "hex");
+      expect(result1).toBe(result2);
+    });
+
+    it("produces different hash for different content", () => {
+      const chunk1: ChunkNamingInfo = {
+        name: "a",
+        content: "content 1",
+        format: "es",
+        isEntry: false,
+      };
+      const chunk2: ChunkNamingInfo = {
+        name: "a",
+        content: "content 2",
+        format: "es",
+        isEntry: false,
+      };
+      const result1 = resolveChunkFileName(chunk1, "[hash].js", 8, "hex");
+      const result2 = resolveChunkFileName(chunk2, "[hash].js", 8, "hex");
+      expect(result1).not.toBe(result2);
+    });
+
+    it("respects hashLength parameter", () => {
+      const result = resolveChunkFileName(entryChunk, "[hash].js", 12, "hex");
+      expect(result).toMatch(/^[0-9a-f]{12}\.js$/);
+    });
+
+    it("respects hashChars parameter", () => {
+      const hexResult = resolveChunkFileName(entryChunk, "[hash].js", 8, "hex");
+      expect(hexResult).toMatch(/^[0-9a-f]{8}\.js$/);
+
+      const b36Result = resolveChunkFileName(
+        entryChunk,
+        "[hash].js",
+        8,
+        "base36",
+      );
+      expect(b36Result).toMatch(/^[0-9a-z]{8}\.js$/);
+    });
+  });
+
+  describe("name sanitization", () => {
+    it("replaces spaces with underscores", () => {
+      const chunk: ChunkNamingInfo = {
+        name: "my chunk",
+        content: "code",
+        format: "es",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(chunk, "[name].js");
+      expect(result).toBe("my_chunk.js");
+    });
+
+    it("replaces special characters", () => {
+      const chunk: ChunkNamingInfo = {
+        name: "chunk@v2!",
+        content: "code",
+        format: "es",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(chunk, "[name].js");
+      expect(result).toBe("chunk_v2_.js");
+    });
+
+    it("preserves valid characters", () => {
+      const chunk: ChunkNamingInfo = {
+        name: "my-chunk_v2.0",
+        content: "code",
+        format: "es",
+        isEntry: true,
+      };
+      const result = resolveChunkFileName(chunk, "[name].js");
+      expect(result).toBe("my-chunk_v2.0.js");
+    });
+  });
+
+  describe("constants", () => {
+    it("exports correct default patterns", () => {
+      expect(DEFAULT_ENTRY_PATTERN).toBe("[name].js");
+      expect(DEFAULT_CHUNK_PATTERN).toBe("[name]-[hash].js");
+      expect(DEFAULT_ASSET_PATTERN).toBe("assets/[name]-[hash][extname]");
+    });
+
+    it("exports correct default hash config", () => {
+      expect(DEFAULT_HASH_LENGTH).toBe(8);
+      expect(DEFAULT_HASH_CHARS).toBe("base64");
+    });
+  });
+});
+
+describe("resolveAssetFileName", () => {
+  it("uses default asset pattern", () => {
+    const result = resolveAssetFileName("style.css", "body {}");
+    expect(result).toMatch(/^assets\/style-[A-Za-z0-9\-_]+\.css$/);
+  });
+
+  it("substitutes [name] without extension", () => {
+    const result = resolveAssetFileName("icon.png", "data", {
+      assetFileNames: "[name].out[extname]",
+    });
+    expect(result).toBe("icon.out.png");
+  });
+
+  it("substitutes [hash]", () => {
+    const result = resolveAssetFileName("file.txt", "content", {
+      assetFileNames: "[hash][extname]",
+      hashLength: 6,
+      hashChars: "hex",
+    });
+    expect(result).toMatch(/^[0-9a-f]{6}\.txt$/);
+  });
+
+  it("handles file with no extension", () => {
+    const result = resolveAssetFileName("LICENSE", "MIT License", {
+      assetFileNames: "[name][extname]",
+    });
+    expect(result).toBe("LICENSE");
+  });
+
+  it("produces deterministic names", () => {
+    const result1 = resolveAssetFileName("a.css", "same content");
+    const result2 = resolveAssetFileName("a.css", "same content");
+    expect(result1).toBe(result2);
+  });
+});

--- a/tests/unit/splitting/chunk-optimization.test.ts
+++ b/tests/unit/splitting/chunk-optimization.test.ts
@@ -1,0 +1,352 @@
+/**
+ * @module tests/unit/splitting/chunk-optimization
+ * @description Unit tests for chunk optimization.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  optimizeChunks,
+  type OptimizableChunk,
+} from "../../../src/splitting/chunk-optimization.js";
+
+const makeChunk = (
+  name: string,
+  overrides: Partial<OptimizableChunk> = {},
+): OptimizableChunk => ({
+  name,
+  moduleIds: [`./src/${name}.ts`],
+  size: 1000,
+  isEntry: false,
+  isDynamicEntry: false,
+  imports: [],
+  ...overrides,
+});
+
+describe("optimizeChunks", () => {
+  describe("inlineDynamicImports", () => {
+    it("merges all chunks into one when enabled", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 500 }),
+        makeChunk("lazy", { isDynamicEntry: true, size: 300 }),
+        makeChunk("shared", { size: 200 }),
+      ];
+
+      const result = optimizeChunks(chunks, { inlineDynamicImports: true });
+      expect(result.chunks).toHaveLength(1);
+      expect(result.chunks[0].name).toBe("main");
+      expect(result.chunks[0].moduleIds).toHaveLength(3);
+      expect(result.chunks[0].size).toBe(1000);
+      expect(result.chunks[0].isEntry).toBe(true);
+    });
+
+    it("uses entry chunk name for the merged result", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("app", { isEntry: true }),
+        makeChunk("vendor"),
+      ];
+
+      const result = optimizeChunks(chunks, { inlineDynamicImports: true });
+      expect(result.chunks[0].name).toBe("app");
+    });
+
+    it("tracks merged chunk names", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true }),
+        makeChunk("a"),
+        makeChunk("b"),
+      ];
+
+      const result = optimizeChunks(chunks, { inlineDynamicImports: true });
+      expect(result.merged).toContain("a");
+      expect(result.merged).toContain("b");
+    });
+
+    it("handles empty chunks array", () => {
+      const result = optimizeChunks([], { inlineDynamicImports: true });
+      expect(result.chunks).toHaveLength(0);
+      expect(result.merged).toHaveLength(0);
+    });
+
+    it("handles single chunk", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true }),
+      ];
+
+      const result = optimizeChunks(chunks, { inlineDynamicImports: true });
+      expect(result.chunks).toHaveLength(1);
+      expect(result.chunks[0].name).toBe("main");
+    });
+  });
+
+  describe("experimentalMinChunkSize", () => {
+    it("merges chunks below the size threshold", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000 }),
+        makeChunk("tiny", { size: 50, imports: [] }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 100,
+      });
+      expect(result.chunks).toHaveLength(1);
+      expect(result.merged).toContain("tiny");
+    });
+
+    it("does not merge entry chunks", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 50 }),
+        makeChunk("other", { size: 5000 }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 100,
+      });
+      const names = result.chunks.map((c) => c.name);
+      expect(names).toContain("main");
+    });
+
+    it("prefers merging into chunk that imports the small chunk", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000, imports: ["tiny"] }),
+        makeChunk("other", { size: 5000 }),
+        makeChunk("tiny", { size: 50 }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 100,
+      });
+      const mainChunk = result.chunks.find((c) => c.name === "main");
+      expect(mainChunk!.moduleIds).toContain("./src/tiny.ts");
+    });
+
+    it("does not merge chunks above the threshold", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000 }),
+        makeChunk("big-enough", { size: 200 }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 100,
+      });
+      expect(result.chunks).toHaveLength(2);
+      expect(result.merged).toHaveLength(0);
+    });
+
+    it("handles multiple small chunks", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000 }),
+        makeChunk("tiny-a", { size: 30 }),
+        makeChunk("tiny-b", { size: 40 }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 100,
+      });
+      // Both tiny chunks should be merged
+      expect(result.merged.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("no-ops when minChunkSize is 0", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000 }),
+        makeChunk("small", { size: 10 }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 0,
+      });
+      expect(result.chunks).toHaveLength(2);
+    });
+  });
+
+  describe("hoistTransitiveImports", () => {
+    it("hoists modules from imported chunks into entry chunk", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000, imports: ["shared"] }),
+        makeChunk("shared", {
+          size: 1000,
+          moduleIds: ["./src/shared.ts", "./src/util.ts"],
+        }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        hoistTransitiveImports: true,
+      });
+      const mainChunk = result.chunks.find((c) => c.name === "main");
+      expect(mainChunk!.moduleIds).toContain("./src/shared.ts");
+      expect(mainChunk!.moduleIds).toContain("./src/util.ts");
+    });
+
+    it("does not hoist from dynamic entry chunks", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000, imports: ["lazy"] }),
+        makeChunk("lazy", {
+          isDynamicEntry: true,
+          size: 1000,
+          moduleIds: ["./src/lazy.ts"],
+        }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        hoistTransitiveImports: true,
+      });
+      const mainChunk = result.chunks.find((c) => c.name === "main");
+      expect(mainChunk!.moduleIds).not.toContain("./src/lazy.ts");
+    });
+
+    it("hoists transitively through multiple levels", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, imports: ["mid"] }),
+        makeChunk("mid", {
+          imports: ["deep"],
+          moduleIds: ["./src/mid.ts"],
+        }),
+        makeChunk("deep", {
+          moduleIds: ["./src/deep.ts"],
+        }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        hoistTransitiveImports: true,
+      });
+      const mainChunk = result.chunks.find((c) => c.name === "main");
+      expect(mainChunk!.moduleIds).toContain("./src/mid.ts");
+      expect(mainChunk!.moduleIds).toContain("./src/deep.ts");
+    });
+
+    it("does not duplicate already-present modules", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", {
+          isEntry: true,
+          imports: ["shared"],
+          moduleIds: ["./src/main.ts", "./src/shared.ts"],
+        }),
+        makeChunk("shared", {
+          moduleIds: ["./src/shared.ts"],
+        }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        hoistTransitiveImports: true,
+      });
+      const mainChunk = result.chunks.find((c) => c.name === "main");
+      const sharedCount = mainChunk!.moduleIds.filter(
+        (id) => id === "./src/shared.ts",
+      ).length;
+      expect(sharedCount).toBe(1);
+    });
+
+    it("only hoists into entry chunks", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, imports: [] }),
+        makeChunk("non-entry", {
+          isEntry: false,
+          imports: ["lib"],
+          moduleIds: ["./src/non-entry.ts"],
+        }),
+        makeChunk("lib", { moduleIds: ["./src/lib.ts"] }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        hoistTransitiveImports: true,
+      });
+      const nonEntry = result.chunks.find((c) => c.name === "non-entry");
+      expect(nonEntry!.moduleIds).not.toContain("./src/lib.ts");
+    });
+  });
+
+  describe("combined options", () => {
+    it("applies minChunkSize before hoisting", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000, imports: ["small"] }),
+        makeChunk("small", { size: 50, moduleIds: ["./src/small.ts"] }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 100,
+        hoistTransitiveImports: true,
+      });
+      // small should be merged
+      expect(result.merged).toContain("small");
+    });
+
+    it("inlineDynamicImports takes precedence over other options", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true, size: 5000 }),
+        makeChunk("large", { size: 10000 }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        inlineDynamicImports: true,
+        experimentalMinChunkSize: 100,
+        hoistTransitiveImports: true,
+      });
+      expect(result.chunks).toHaveLength(1);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty options", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", { isEntry: true }),
+        makeChunk("other"),
+      ];
+
+      const result = optimizeChunks(chunks, {});
+      expect(result.chunks).toHaveLength(2);
+      expect(result.merged).toHaveLength(0);
+    });
+
+    it("handles empty chunks array with all options", () => {
+      const result = optimizeChunks([], {
+        experimentalMinChunkSize: 100,
+        hoistTransitiveImports: true,
+      });
+      expect(result.chunks).toHaveLength(0);
+    });
+
+    it("does not merge when no target found (single small chunk only)", () => {
+      const chunks: Array<OptimizableChunk> = [makeChunk("only", { size: 10 })];
+
+      const result = optimizeChunks(chunks, {
+        experimentalMinChunkSize: 100,
+      });
+      // Only one chunk, nothing to merge into since findMergeTarget returns null
+      // Actually with only one chunk there's no other chunk to merge into
+      expect(result.chunks).toHaveLength(1);
+    });
+
+    it("handles circular import references during hoisting", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", {
+          isEntry: true,
+          imports: ["a"],
+        }),
+        makeChunk("a", { imports: ["b"] }),
+        makeChunk("b", { imports: ["a"] }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        hoistTransitiveImports: true,
+      });
+      const mainChunk = result.chunks.find((c) => c.name === "main");
+      expect(mainChunk!.moduleIds).toContain("./src/a.ts");
+      expect(mainChunk!.moduleIds).toContain("./src/b.ts");
+    });
+
+    it("handles chunk importing non-existent chunk during hoisting", () => {
+      const chunks: Array<OptimizableChunk> = [
+        makeChunk("main", {
+          isEntry: true,
+          imports: ["ghost"],
+        }),
+      ];
+
+      const result = optimizeChunks(chunks, {
+        hoistTransitiveImports: true,
+      });
+      // Should not crash; ghost chunk doesn't exist
+      expect(result.chunks).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/splitting/hash.test.ts
+++ b/tests/unit/splitting/hash.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @module tests/unit/splitting/hash
+ * @description Unit tests for FNV-1a content hashing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { contentHash } from "../../../src/codegen/hash.js";
+
+describe("contentHash", () => {
+  describe("determinism", () => {
+    it("produces the same hash for the same input", () => {
+      const hash1 = contentHash("hello world", 8, "hex");
+      const hash2 = contentHash("hello world", 8, "hex");
+      expect(hash1).toBe(hash2);
+    });
+
+    it("produces the same hash across multiple calls", () => {
+      const results: Array<string> = [];
+      for (let i = 0; i < 100; i++) {
+        results.push(contentHash("deterministic", 12, "base64"));
+      }
+      const first = results[0];
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i]).toBe(first);
+      }
+    });
+
+    it("produces different hashes for different inputs", () => {
+      const hash1 = contentHash("hello", 8, "hex");
+      const hash2 = contentHash("world", 8, "hex");
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("produces different hashes for similar inputs", () => {
+      const hash1 = contentHash("abc", 16, "hex");
+      const hash2 = contentHash("abd", 16, "hex");
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+
+  describe("hex encoding", () => {
+    it("produces valid hex characters only", () => {
+      const hash = contentHash("test content", 16, "hex");
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it("produces the requested length", () => {
+      const hash4 = contentHash("test", 4, "hex");
+      const hash8 = contentHash("test", 8, "hex");
+      const hash16 = contentHash("test", 16, "hex");
+      expect(hash4).toHaveLength(4);
+      expect(hash8).toHaveLength(8);
+      expect(hash16).toHaveLength(16);
+    });
+
+    it("handles length of 1", () => {
+      const hash = contentHash("x", 1, "hex");
+      expect(hash).toHaveLength(1);
+      expect(hash).toMatch(/^[0-9a-f]$/);
+    });
+
+    it("handles length of 32 (full 128-bit)", () => {
+      const hash = contentHash("full hash", 32, "hex");
+      expect(hash).toHaveLength(32);
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+  });
+
+  describe("base64 encoding", () => {
+    it("produces valid base64url characters only", () => {
+      const hash = contentHash("test content", 16, "base64");
+      expect(hash).toMatch(/^[A-Za-z0-9\-_]+$/);
+    });
+
+    it("produces the requested length", () => {
+      const hash6 = contentHash("test", 6, "base64");
+      const hash12 = contentHash("test", 12, "base64");
+      expect(hash6).toHaveLength(6);
+      expect(hash12).toHaveLength(12);
+    });
+
+    it("does not include padding characters", () => {
+      const hash = contentHash("no padding", 10, "base64");
+      expect(hash).not.toContain("=");
+    });
+  });
+
+  describe("base36 encoding", () => {
+    it("produces valid base36 characters only", () => {
+      const hash = contentHash("test content", 16, "base36");
+      expect(hash).toMatch(/^[0-9a-z]+$/);
+    });
+
+    it("produces the requested length", () => {
+      const hash8 = contentHash("test", 8, "base36");
+      const hash16 = contentHash("test", 16, "base36");
+      expect(hash8).toHaveLength(8);
+      expect(hash16).toHaveLength(16);
+    });
+
+    it("uses only lowercase letters", () => {
+      const hash = contentHash("UPPERCASE input", 20, "base36");
+      expect(hash).toMatch(/^[0-9a-z]+$/);
+    });
+  });
+
+  describe("base64 remainder bits path", () => {
+    it("handles length requiring remainder bits encoding", () => {
+      // Request a length that forces the remainder-bits branch
+      // 16 bytes = 128 bits. 128/6 = 21 full chars + 2 remainder bits
+      // So requesting 22 chars will trigger the remainder path
+      const hash = contentHash("trigger remainder", 22, "base64");
+      expect(hash).toHaveLength(22);
+      expect(hash).toMatch(/^[A-Za-z0-9\-_]+$/);
+    });
+  });
+
+  describe("base36 padding path", () => {
+    it("pads output when requested length exceeds natural digits", () => {
+      // A 128-bit number in base36 is about 25 chars max
+      // Request more than that to trigger padding
+      const hash = contentHash("x", 30, "base36");
+      expect(hash).toHaveLength(30);
+      expect(hash).toMatch(/^[0-9a-z]+$/);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string input", () => {
+      const hash = contentHash("", 8, "hex");
+      expect(hash).toHaveLength(8);
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it("handles very long input", () => {
+      const longInput = "x".repeat(10000);
+      const hash = contentHash(longInput, 8, "hex");
+      expect(hash).toHaveLength(8);
+    });
+
+    it("handles unicode input", () => {
+      const hash = contentHash("こんにちは", 8, "hex");
+      expect(hash).toHaveLength(8);
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it("handles newlines and special characters", () => {
+      const hash = contentHash("line1\nline2\ttab\r\n", 8, "hex");
+      expect(hash).toHaveLength(8);
+    });
+
+    it("different encodings produce different strings for same input", () => {
+      const hex = contentHash("same input", 8, "hex");
+      const b64 = contentHash("same input", 8, "base64");
+      const b36 = contentHash("same input", 8, "base36");
+      // At least two should differ (all three likely differ)
+      const unique = new Set([hex, b64, b36]);
+      expect(unique.size).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/tests/unit/splitting/split-points.test.ts
+++ b/tests/unit/splitting/split-points.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @module tests/unit/splitting/split-points
+ * @description Unit tests for split point detection.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectSplitPoints,
+  type SplittableModule,
+} from "../../../src/splitting/index.js";
+
+const makeModule = (
+  id: string,
+  overrides: Partial<SplittableModule> = {},
+): SplittableModule => ({
+  id,
+  isEntry: false,
+  importedIds: [],
+  dynamicallyImportedIds: [],
+  importers: [],
+  dynamicImporters: [],
+  ...overrides,
+});
+
+describe("detectSplitPoints", () => {
+  describe("dynamic imports", () => {
+    it("detects a single dynamic import as a split point", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./lazy.ts", {
+          dynamicImporters: ["./main.ts"],
+        }),
+      ];
+
+      const points = detectSplitPoints(modules, ["./main.ts"]);
+      expect(points).toHaveLength(1);
+      expect(points[0].moduleId).toBe("./lazy.ts");
+      expect(points[0].reason).toBe("dynamic-import");
+      expect(points[0].importers).toContain("./main.ts");
+    });
+
+    it("detects multiple dynamic imports", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./page-a.ts", "./page-b.ts"],
+        }),
+        makeModule("./page-a.ts", { dynamicImporters: ["./main.ts"] }),
+        makeModule("./page-b.ts", { dynamicImporters: ["./main.ts"] }),
+      ];
+
+      const points = detectSplitPoints(modules, ["./main.ts"]);
+      const dynamicPoints = points.filter((p) => p.reason === "dynamic-import");
+      expect(dynamicPoints).toHaveLength(2);
+
+      const ids = dynamicPoints.map((p) => p.moduleId).sort();
+      expect(ids).toEqual(["./page-a.ts", "./page-b.ts"]);
+    });
+
+    it("collects all importers of a dynamic import", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./a.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./shared-lazy.ts"],
+        }),
+        makeModule("./b.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./shared-lazy.ts"],
+        }),
+        makeModule("./shared-lazy.ts", {
+          dynamicImporters: ["./a.ts", "./b.ts"],
+        }),
+      ];
+
+      const points = detectSplitPoints(modules, ["./a.ts", "./b.ts"]);
+      const lazyPoint = points.find((p) => p.moduleId === "./shared-lazy.ts");
+      expect(lazyPoint).toBeDefined();
+      expect(lazyPoint!.importers).toContain("./a.ts");
+      expect(lazyPoint!.importers).toContain("./b.ts");
+    });
+
+    it("does not duplicate dynamic import split points", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./a.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./b.ts", {
+          isEntry: true,
+          dynamicallyImportedIds: ["./lazy.ts"],
+        }),
+        makeModule("./lazy.ts", { dynamicImporters: ["./a.ts", "./b.ts"] }),
+      ];
+
+      const points = detectSplitPoints(modules, ["./a.ts", "./b.ts"]);
+      const lazyPoints = points.filter((p) => p.moduleId === "./lazy.ts");
+      expect(lazyPoints).toHaveLength(1);
+    });
+  });
+
+  describe("shared dependencies", () => {
+    it("detects shared dependency between two entries", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./entry-a.ts", {
+          isEntry: true,
+          importedIds: ["./shared.ts"],
+        }),
+        makeModule("./entry-b.ts", {
+          isEntry: true,
+          importedIds: ["./shared.ts"],
+        }),
+        makeModule("./shared.ts", {
+          importers: ["./entry-a.ts", "./entry-b.ts"],
+        }),
+      ];
+
+      const points = detectSplitPoints(modules, [
+        "./entry-a.ts",
+        "./entry-b.ts",
+      ]);
+      const sharedPoints = points.filter(
+        (p) => p.reason === "shared-dependency",
+      );
+      expect(sharedPoints).toHaveLength(1);
+      expect(sharedPoints[0].moduleId).toBe("./shared.ts");
+      expect(sharedPoints[0].importers).toContain("./entry-a.ts");
+      expect(sharedPoints[0].importers).toContain("./entry-b.ts");
+    });
+
+    it("detects transitively shared dependencies", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./entry-a.ts", {
+          isEntry: true,
+          importedIds: ["./mid-a.ts"],
+        }),
+        makeModule("./entry-b.ts", {
+          isEntry: true,
+          importedIds: ["./mid-b.ts"],
+        }),
+        makeModule("./mid-a.ts", { importedIds: ["./deep-shared.ts"] }),
+        makeModule("./mid-b.ts", { importedIds: ["./deep-shared.ts"] }),
+        makeModule("./deep-shared.ts"),
+      ];
+
+      const points = detectSplitPoints(modules, [
+        "./entry-a.ts",
+        "./entry-b.ts",
+      ]);
+      const sharedPoints = points.filter(
+        (p) => p.reason === "shared-dependency",
+      );
+      expect(sharedPoints.some((p) => p.moduleId === "./deep-shared.ts")).toBe(
+        true,
+      );
+    });
+
+    it("does not mark module used by only one entry as shared", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./entry-a.ts", {
+          isEntry: true,
+          importedIds: ["./only-a.ts"],
+        }),
+        makeModule("./entry-b.ts", { isEntry: true, importedIds: [] }),
+        makeModule("./only-a.ts"),
+      ];
+
+      const points = detectSplitPoints(modules, [
+        "./entry-a.ts",
+        "./entry-b.ts",
+      ]);
+      const sharedPoints = points.filter(
+        (p) => p.reason === "shared-dependency",
+      );
+      expect(sharedPoints).toHaveLength(0);
+    });
+
+    it("does not mark entry modules themselves as shared", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./entry-a.ts", { isEntry: true, importedIds: [] }),
+        makeModule("./entry-b.ts", { isEntry: true, importedIds: [] }),
+      ];
+
+      const points = detectSplitPoints(modules, [
+        "./entry-a.ts",
+        "./entry-b.ts",
+      ]);
+      expect(points).toHaveLength(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty array for no modules", () => {
+      const points = detectSplitPoints([], []);
+      expect(points).toEqual([]);
+    });
+
+    it("returns empty array for single entry with no imports", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./main.ts", { isEntry: true }),
+      ];
+      const points = detectSplitPoints(modules, ["./main.ts"]);
+      expect(points).toEqual([]);
+    });
+
+    it("handles circular static imports without infinite loop", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./a.ts", { isEntry: true, importedIds: ["./b.ts"] }),
+        makeModule("./b.ts", { importedIds: ["./a.ts"] }),
+      ];
+      const points = detectSplitPoints(modules, ["./a.ts"]);
+      // Should not hang and should return valid result
+      expect(Array.isArray(points)).toBe(true);
+    });
+
+    it("handles diamond dependency pattern (visited node in BFS)", () => {
+      // Diamond: entry -> a, entry -> b, a -> shared, b -> shared
+      // This forces the BFS to encounter 'shared' via two paths
+      const modules: Array<SplittableModule> = [
+        makeModule("./entry.ts", {
+          isEntry: true,
+          importedIds: ["./a.ts", "./b.ts"],
+        }),
+        makeModule("./a.ts", { importedIds: ["./shared.ts"] }),
+        makeModule("./b.ts", { importedIds: ["./shared.ts"] }),
+        makeModule("./shared.ts"),
+      ];
+
+      const points = detectSplitPoints(modules, ["./entry.ts"]);
+      // shared is reachable from only one entry, so no shared split point
+      expect(points.filter((p) => p.moduleId === "./shared.ts")).toHaveLength(
+        0,
+      );
+    });
+
+    it("does not count dynamic import target as shared dependency", () => {
+      const modules: Array<SplittableModule> = [
+        makeModule("./entry-a.ts", {
+          isEntry: true,
+          importedIds: ["./util.ts"],
+          dynamicallyImportedIds: ["./util.ts"],
+        }),
+        makeModule("./entry-b.ts", {
+          isEntry: true,
+          importedIds: ["./util.ts"],
+        }),
+        makeModule("./util.ts"),
+      ];
+
+      const points = detectSplitPoints(modules, [
+        "./entry-a.ts",
+        "./entry-b.ts",
+      ]);
+      // util.ts is detected as dynamic-import first, so not duplicated as shared
+      const utilPoints = points.filter((p) => p.moduleId === "./util.ts");
+      expect(utilPoints).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Split point detection** (#74): Detects dynamic imports and shared dependencies between entry points as code splitting boundaries
- **Chunk assignment algorithm** (#76): Assigns modules to chunks based on entries, split points, and optional `manualChunks` configuration
- **Chunk naming and file patterns** (#78): Resolves chunk file names from patterns with `[name]`, `[hash]`, `[format]`, `[extname]` placeholders
- **Chunk optimization** (#80): Supports `experimentalMinChunkSize` (merge small chunks), `hoistTransitiveImports`, and `inlineDynamicImports`
- **Content hashing** (#83): FNV-1a based deterministic hashing with hex/base64/base36 output encoding

## Test plan

- [x] 90+ unit tests covering all five modules
- [x] Hash determinism, encoding correctness, edge cases (empty, unicode, long input)
- [x] Split point detection for dynamic imports and shared deps
- [x] Chunk assignment: entry chunks, dynamic chunks, shared chunks, manualChunks (record + function)
- [x] Naming: pattern substitution, all format extensions, sanitization
- [x] Optimization: min chunk size merging, inline dynamic imports, hoist transitive imports
- [x] Full typecheck passes (strict mode)
- [x] All 4128 tests pass, coverage thresholds met

Closes #74, #76, #78, #80, #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)