### PR TITLE
feat: wire code generation into generate()

### DIFF
--- a/src/build/rollup-build.ts
+++ b/src/build/rollup-build.ts
@@ -12,7 +12,23 @@ import type {
   RollupCache as RollupCacheType,
   OutputChunk,
   SerializedTimings,
+  ModuleFormat,
+  RenderedModule as OutputRenderedModule,
 } from "../types.js";
+import { Module } from "../module/Module.js";
+import { ExternalModule } from "../module/ExternalModule.js";
+import { MagicString } from "../sourcemap/magic-string.js";
+import { concatenateModules } from "../codegen/concatenate.js";
+import type { RenderedModule as ConcatModule } from "../codegen/concatenate.js";
+import { resolveAllAddons, applyAddons } from "../codegen/addons.js";
+import type { AddonValue } from "../codegen/addons.js";
+import { getFormatWrapper } from "../formats/index.js";
+import type {
+  FormatOptions,
+  ImportBinding,
+  ExportBinding,
+} from "../formats/shared.js";
+import { getExportMode } from "../formats/shared.js";
 
 /**
  * Immutable state describing the result of a build phase.
@@ -30,45 +46,343 @@ export interface BuildState {
 }
 
 /**
+ * Determines whether a given import source is internal (bundled) given the module set.
+ *
+ * @param source - The import source string
+ * @param moduleIds - Set of all internal module IDs
+ * @param importerModule - The module containing the import
+ * @returns true if the import is internal
+ */
+const isInternalImport = (source: string, importerModule: Module): boolean => {
+  for (const dep of importerModule.dependencies) {
+    if (dep instanceof Module) {
+      // Check if the source resolves to this dependency
+      if (
+        dep.id.endsWith(source) ||
+        dep.id.includes(source.replace(/^\.\//, ""))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * Get external imports for a module by checking its dependencies.
+ *
+ * @param mod - The module to inspect
+ * @returns Array of import bindings for external dependencies
+ */
+const getExternalImportBindings = (
+  mod: Module,
+): ReadonlyArray<ImportBinding> => {
+  const bindings: Array<ImportBinding> = [];
+  for (let i = 0; i < mod.imports.length; i++) {
+    const imp = mod.imports[i];
+    let isExternal = false;
+    for (const dep of mod.dependencies) {
+      if (dep instanceof ExternalModule) {
+        if (dep.id === imp.source) {
+          isExternal = true;
+          break;
+        }
+      }
+    }
+    if (isExternal) {
+      for (let j = 0; j < imp.specifiers.length; j++) {
+        const spec = imp.specifiers[j];
+        bindings.push({
+          source: imp.source,
+          imported: spec.imported,
+          local: spec.local,
+        });
+      }
+    }
+  }
+  return bindings;
+};
+
+/**
+ * Get export bindings from the entry module.
+ *
+ * @param mod - The entry module
+ * @returns Array of export bindings
+ */
+const getExportBindings = (mod: Module): ReadonlyArray<ExportBinding> => {
+  const bindings: Array<ExportBinding> = [];
+  for (let i = 0; i < mod.exports.length; i++) {
+    const exp = mod.exports[i];
+    if (exp.type === "default") {
+      bindings.push({ exported: "default", local: exp.local ?? "default" });
+    } else if (exp.type === "named") {
+      bindings.push({
+        exported: exp.exported ?? exp.local ?? "",
+        local: exp.local ?? exp.exported ?? "",
+      });
+    }
+  }
+  return bindings;
+};
+
+/**
+ * Render a single module by removing internal import declarations and
+ * stripping export keywords from declarations.
+ *
+ * @param mod - The module to render
+ * @param isEntry - Whether this module is the entry point
+ * @param format - The output format
+ * @returns The rendered code string
+ */
+const renderSingleModule = (
+  mod: Module,
+  isEntry: boolean,
+  format: ModuleFormat,
+): string => {
+  const ms = new MagicString(mod.code);
+
+  if (mod.ast === null) {
+    return mod.code;
+  }
+
+  const body = mod.ast.body;
+  for (let i = 0; i < body.length; i++) {
+    const node = body[i];
+
+    if (node.type === "ImportDeclaration") {
+      // Check if this is an internal import (should be removed)
+      const source = (node as { source: { value: unknown } }).source
+        .value as string;
+      if (isInternalImport(source, mod)) {
+        ms.remove(node.start, node.end);
+      } else if (format === "cjs") {
+        // External imports are handled by the format wrapper, remove them
+        ms.remove(node.start, node.end);
+      }
+      // For ES format, external imports are kept as-is
+    } else if (node.type === "ExportNamedDeclaration") {
+      const exportNode = node as {
+        start: number;
+        end: number;
+        declaration: { start: number; end: number; type: string } | null;
+        specifiers: ReadonlyArray<unknown>;
+        source: { value: unknown } | null;
+      };
+
+      if (exportNode.source !== null) {
+        // Re-export from another module - remove for internal, keep for external
+        const reSource = exportNode.source.value as string;
+        if (isInternalImport(reSource, mod)) {
+          ms.remove(node.start, node.end);
+        }
+      } else if (exportNode.declaration !== null) {
+        // export const x = ... -> const x = ...
+        // Remove the 'export ' keyword prefix
+        if (!isEntry || format === "cjs") {
+          ms.overwrite(node.start, exportNode.declaration.start, "");
+        }
+      } else if (exportNode.specifiers.length > 0) {
+        // export { x, y } — remove if not entry or if CJS
+        if (!isEntry || format === "cjs") {
+          ms.remove(node.start, node.end);
+        }
+      }
+    } else if (node.type === "ExportDefaultDeclaration") {
+      const exportDefault = node as {
+        start: number;
+        end: number;
+        declaration: { start: number; end: number; type: string };
+      };
+      if (!isEntry || format === "cjs") {
+        // Remove 'export default ' for non-entry or CJS
+        if (
+          exportDefault.declaration.type === "FunctionDeclaration" ||
+          exportDefault.declaration.type === "ClassDeclaration"
+        ) {
+          ms.overwrite(node.start, exportDefault.declaration.start, "");
+        }
+      }
+    } else if (node.type === "ExportAllDeclaration") {
+      const exportAll = node as {
+        source: { value: unknown };
+        start: number;
+        end: number;
+      };
+      const reSource = exportAll.source.value as string;
+      if (isInternalImport(reSource, mod)) {
+        ms.remove(node.start, node.end);
+      }
+    }
+  }
+
+  return ms.toString().trim();
+};
+
+/**
  * Generates output from build state and output options.
- * Creates a minimal output with an entry chunk.
- * Future format implementations will fill in full code generation.
+ * Renders modules via MagicString, concatenates in topological order,
+ * and applies format wrappers.
  *
  * @param state - The build state containing modules and cache
  * @param options - Output options controlling format, file names, etc.
  * @returns A RollupOutput containing at least one entry chunk
  */
 const generateOutput = async (
-  _state: BuildState,
+  state: BuildState,
   options: OutputOptions,
 ): Promise<RollupOutput> => {
   const fileName = options.file ?? "bundle.js";
-  const format = options.format ?? "es";
+  const format: ModuleFormat = (options.format ?? "es") as ModuleFormat;
+
+  const modules = state.modules as ReadonlyArray<Module>;
+
+  // If no modules, return empty chunk
+  if (modules.length === 0) {
+    const chunk: OutputChunk = {
+      type: "chunk",
+      code: "",
+      fileName,
+      preliminaryFileName: fileName,
+      sourcemapFileName: null,
+      map: null,
+      exports: [],
+      facadeModuleId: null,
+      isDynamicEntry: false,
+      isEntry: true,
+      isImplicitEntry: false,
+      moduleIds: [],
+      name: "bundle",
+      dynamicImports: [],
+      implicitlyLoadedBefore: [],
+      importedBindings: {},
+      imports: [],
+      modules: {},
+      referencedFiles: [],
+    };
+    return { output: [chunk] };
+  }
+
+  // Find the entry module (last module in topological order is typically the entry)
+  let entryModule: Module | undefined;
+  for (let i = 0; i < modules.length; i++) {
+    if (modules[i].isEntry) {
+      entryModule = modules[i];
+      break;
+    }
+  }
+  if (entryModule === undefined) {
+    entryModule = modules[modules.length - 1];
+  }
+
+  // Render each module
+  const renderedModules: Array<ConcatModule> = [];
+  for (let i = 0; i < modules.length; i++) {
+    const mod = modules[i];
+    const isEntry = mod === entryModule;
+    const rendered = renderSingleModule(mod, isEntry, format);
+    if (rendered.length > 0) {
+      renderedModules.push({
+        id: mod.id,
+        code: rendered,
+      });
+    }
+  }
+
+  // Concatenate modules
+  const concatenated = concatenateModules(renderedModules);
+
+  // Collect external imports and export bindings from entry
+  const externalImports = getExternalImportBindings(entryModule);
+  const exportBindings = getExportBindings(entryModule);
+  const exportNames: Array<string> = [];
+  for (let i = 0; i < exportBindings.length; i++) {
+    exportNames.push(exportBindings[i].exported);
+  }
+
+  // Get external module IDs for imports array
+  const externalImportSources: Array<string> = [];
+  const importedBindingsRecord: Record<string, Array<string>> = {};
+  for (let i = 0; i < externalImports.length; i++) {
+    const imp = externalImports[i];
+    if (!externalImportSources.includes(imp.source)) {
+      externalImportSources.push(imp.source);
+    }
+    if (importedBindingsRecord[imp.source] === undefined) {
+      importedBindingsRecord[imp.source] = [];
+    }
+    importedBindingsRecord[imp.source].push(imp.imported);
+  }
+
+  // Apply format wrapper
+  const formatWrapper = getFormatWrapper(format);
+  const exports = getExportMode(exportNames, format);
+  const formatOptions: FormatOptions = {
+    exports,
+    strict: true,
+    externalImports,
+    exportBindings,
+  };
+
+  const wrappedCode =
+    formatWrapper !== undefined
+      ? formatWrapper.wrapChunk(concatenated.code, formatOptions)
+      : concatenated.code;
+
+  // Apply addons (banner/footer/intro/outro)
+  const resolvedAddons = await resolveAllAddons({
+    banner: options.banner as AddonValue,
+    footer: options.footer as AddonValue,
+    intro: options.intro as AddonValue,
+    outro: options.outro as AddonValue,
+  });
+  const finalCode = applyAddons(wrappedCode, resolvedAddons);
+
+  // Build module info record
+  const modulesRecord: Record<string, OutputRenderedModule> = {};
+  for (let i = 0; i < modules.length; i++) {
+    const mod = modules[i];
+    const renderedExports: Array<string> = [];
+    for (let j = 0; j < mod.exports.length; j++) {
+      renderedExports.push(
+        mod.exports[j].exported ?? mod.exports[j].local ?? "",
+      );
+    }
+    modulesRecord[mod.id] = {
+      code: mod.code,
+      originalLength: mod.code.length,
+      removedExports: [],
+      renderedExports,
+      renderedLength: mod.code.length,
+    };
+  }
+
+  // Collect moduleIds
+  const moduleIds: Array<string> = [];
+  for (let i = 0; i < modules.length; i++) {
+    moduleIds.push(modules[i].id);
+  }
 
   const chunk: OutputChunk = {
     type: "chunk",
-    code: "",
+    code: finalCode,
     fileName,
     preliminaryFileName: fileName,
     sourcemapFileName: null,
     map: null,
-    exports: [],
-    facadeModuleId: null,
+    exports: exportNames,
+    facadeModuleId: entryModule.id,
     isDynamicEntry: false,
     isEntry: true,
     isImplicitEntry: false,
-    moduleIds: [],
+    moduleIds,
     name: "bundle",
-    dynamicImports: [],
+    dynamicImports: [...entryModule.dynamicImports],
     implicitlyLoadedBefore: [],
-    importedBindings: {},
-    imports: [],
-    modules: {},
+    importedBindings: importedBindingsRecord,
+    imports: externalImportSources,
+    modules: modulesRecord,
     referencedFiles: [],
   };
-
-  // Suppress unused variable warning — format will be used by format implementations
-  void format;
 
   return { output: [chunk] };
 };

--- a/tests/integration/basic-bundle.test.ts
+++ b/tests/integration/basic-bundle.test.ts
@@ -173,3 +173,234 @@ describe("rollup() module graph integration", () => {
     await build.close();
   });
 });
+
+describe("generate() code generation", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "steamroller-codegen-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("produces non-empty code from a single module", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(indexPath, "export const greeting = 'hello';\n");
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    expect(chunk.type).toBe("chunk");
+    if (chunk.type === "chunk") {
+      expect(chunk.code.length).toBeGreaterThan(0);
+      expect(chunk.code).toContain("greeting");
+      expect(chunk.code).toContain("hello");
+    }
+    await build.close();
+  });
+
+  it("concatenates multiple modules and removes internal imports", async () => {
+    const helperPath = join(tempDir, "helper.js");
+    await writeFile(helperPath, "export const value = 42;\n");
+
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(
+      indexPath,
+      'import { value } from "./helper.js";\nexport const result = value + 1;\n',
+    );
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.code.length).toBeGreaterThan(0);
+      expect(chunk.code).toContain("value");
+      expect(chunk.code).toContain("42");
+      expect(chunk.code).toContain("result");
+      // Internal imports should be removed
+      expect(chunk.code).not.toContain('from "./helper.js"');
+      expect(chunk.code).not.toContain("from './helper.js'");
+    }
+    await build.close();
+  });
+
+  it("preserves external imports in ES format", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(
+      indexPath,
+      'import { readFile } from "node:fs/promises";\nexport const read = readFile;\n',
+    );
+
+    const build = await rollup({
+      input: indexPath,
+      external: ["node:fs/promises"],
+    });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("node:fs/promises");
+      expect(chunk.imports).toContain("node:fs/promises");
+    }
+    await build.close();
+  });
+
+  it("generates CJS format with require() wrapping", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(
+      indexPath,
+      'import { readFile } from "node:fs/promises";\nexport const read = readFile;\n',
+    );
+
+    const build = await rollup({
+      input: indexPath,
+      external: ["node:fs/promises"],
+    });
+    const { output } = await build.generate({ format: "cjs" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("require");
+      expect(chunk.code).toContain("node:fs/promises");
+      expect(chunk.code).toContain("'use strict'");
+    }
+    await build.close();
+  });
+
+  it("includes module IDs in the output chunk", async () => {
+    const helperPath = join(tempDir, "helper.js");
+    await writeFile(helperPath, "export const h = 1;\n");
+
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(
+      indexPath,
+      'import { h } from "./helper.js";\nexport const x = h;\n',
+    );
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.moduleIds).toContain(indexPath);
+      expect(chunk.moduleIds).toContain(helperPath);
+    }
+    await build.close();
+  });
+
+  it("populates exports array from entry module exports", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(
+      indexPath,
+      "export const foo = 1;\nexport const bar = 2;\n",
+    );
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.exports).toContain("foo");
+      expect(chunk.exports).toContain("bar");
+    }
+    await build.close();
+  });
+
+  it("sets facadeModuleId to entry module ID", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(indexPath, "export const x = 1;\n");
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.facadeModuleId).toBe(indexPath);
+    }
+    await build.close();
+  });
+
+  it("applies banner addon to output", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(indexPath, "export const x = 1;\n");
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({
+      format: "es",
+      banner: "/* MIT License */",
+    });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toMatch(/^\/\* MIT License \*\//);
+    }
+    await build.close();
+  });
+
+  it("applies footer addon to output", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(indexPath, "export const x = 1;\n");
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({
+      format: "es",
+      footer: "/* end */",
+    });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("/* end */");
+    }
+    await build.close();
+  });
+
+  it("handles default exports", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(indexPath, "const x = 42;\nexport default x;\n");
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.code.length).toBeGreaterThan(0);
+      expect(chunk.exports).toContain("default");
+    }
+    await build.close();
+  });
+
+  it("handles three-module dependency chain", async () => {
+    const aPath = join(tempDir, "a.js");
+    await writeFile(aPath, "export const a = 'aaa';\n");
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(
+      bPath,
+      'import { a } from "./a.js";\nexport const b = a + "bbb";\n',
+    );
+
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(
+      indexPath,
+      'import { b } from "./b.js";\nexport const result = b;\n',
+    );
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0];
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("aaa");
+      expect(chunk.code).toContain("bbb");
+      expect(chunk.code).toContain("result");
+      // Internal imports removed
+      expect(chunk.code).not.toContain('from "./a.js"');
+      expect(chunk.code).not.toContain('from "./b.js"');
+    }
+    await build.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the stub `generateOutput()` in `src/build/rollup-build.ts` with real code generation that renders modules via MagicString, concatenates them in topological order, and applies format wrappers
- Supports ES format (preserves external imports, removes internal imports) and CJS format (wraps with `'use strict'`, `__esModule`, and `require()` calls)
- Applies addons (banner/footer/intro/outro) and populates OutputChunk metadata (exports, imports, moduleIds, facadeModuleId, modules record)

## Test plan

- [x] All 117 existing test files pass (4866 tests)
- [x] New integration tests verify: non-empty output code, internal import removal, external import preservation (ES), CJS require() wrapping, module IDs populated, exports array, facadeModuleId, banner/footer addons, default exports, multi-module dependency chains
- [x] TypeScript strict mode passes with no errors
- [x] Prettier formatting verified

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)