### PR TITLE
feat: wire closeBundle hook and resource cleanup into close()

### DIFF
--- a/src/build/rollup-build.ts
+++ b/src/build/rollup-build.ts
@@ -31,6 +31,7 @@ import type {
   ExportBinding,
 } from "../formats/shared.js";
 import { getExportMode } from "../formats/shared.js";
+import { OutputHookExecutor } from "../plugins/output-hooks.js";
 
 /**
  * Immutable state describing the result of a build phase.
@@ -45,6 +46,8 @@ export interface BuildState {
   readonly watchFiles: ReadonlyArray<string>;
   /** Optional timing function when perf mode is enabled. */
   readonly getTimings?: () => SerializedTimings;
+  /** Optional executor for firing output-phase plugin hooks (e.g. closeBundle). */
+  readonly outputHookExecutor?: OutputHookExecutor;
 }
 
 /**
@@ -476,6 +479,9 @@ export const createRollupBuild = (state: BuildState): RollupBuild => {
     },
 
     async close(): Promise<void> {
+      if (state.outputHookExecutor) {
+        await state.outputHookExecutor.closeBundle();
+      }
       internal.closed = true;
     },
   };

--- a/tests/unit/build/rollup-build.test.ts
+++ b/tests/unit/build/rollup-build.test.ts
@@ -4,13 +4,15 @@
  * Covers createRollupBuild() interface shape, generate(), write(), close(),
  * post-close error behavior, and cache/watchFiles/getTimings accessors.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createRollupBuild } from "../../../src/build/rollup-build.js";
 import type { BuildState } from "../../../src/build/rollup-build.js";
 import type {
   RollupCache as RollupCacheType,
   SerializedTimings,
 } from "../../../src/types.js";
+import { PluginDriver } from "../../../src/plugins/driver.js";
+import { OutputHookExecutor } from "../../../src/plugins/output-hooks.js";
 
 const createMinimalState = (
   overrides: Partial<BuildState> = {},
@@ -275,6 +277,66 @@ describe("createRollupBuild", () => {
       const build = createRollupBuild(createMinimalState());
       await build.close();
       await expect(build.close()).resolves.toBeUndefined();
+    });
+
+    it("fires closeBundle hook when outputHookExecutor is provided", async () => {
+      const closeBundleSpy = vi.fn();
+      const plugin = { name: "test-close", closeBundle: closeBundleSpy };
+      const driver = new PluginDriver([plugin]);
+      const executor = new OutputHookExecutor(driver);
+      const build = createRollupBuild(
+        createMinimalState({ outputHookExecutor: executor }),
+      );
+      await build.close();
+      expect(closeBundleSpy).toHaveBeenCalledOnce();
+    });
+
+    it("fires closeBundle before setting closed flag", async () => {
+      let closedDuringHook: boolean | undefined;
+      const plugin = {
+        name: "test-order",
+        closeBundle: vi.fn(() => {
+          closedDuringHook = build.closed;
+        }),
+      };
+      const driver = new PluginDriver([plugin]);
+      const executor = new OutputHookExecutor(driver);
+      const build = createRollupBuild(
+        createMinimalState({ outputHookExecutor: executor }),
+      );
+      await build.close();
+      expect(closedDuringHook).toBe(false);
+      expect(build.closed).toBe(true);
+    });
+
+    it("still sets closed flag when no outputHookExecutor is provided", async () => {
+      const build = createRollupBuild(createMinimalState());
+      await build.close();
+      expect(build.closed).toBe(true);
+    });
+
+    it("generate throws after close with outputHookExecutor", async () => {
+      const plugin = { name: "test-noop", closeBundle: vi.fn() };
+      const driver = new PluginDriver([plugin]);
+      const executor = new OutputHookExecutor(driver);
+      const build = createRollupBuild(
+        createMinimalState({ outputHookExecutor: executor }),
+      );
+      await build.close();
+      await expect(build.generate({})).rejects.toThrow(
+        "Bundle is already closed",
+      );
+    });
+
+    it("write throws after close with outputHookExecutor", async () => {
+      const plugin = { name: "test-noop", closeBundle: vi.fn() };
+      const driver = new PluginDriver([plugin]);
+      const executor = new OutputHookExecutor(driver);
+      const build = createRollupBuild(
+        createMinimalState({ outputHookExecutor: executor }),
+      );
+      await build.close();
+      await expect(build.write({})).rejects.toThrow("Bundle is already closed");
     });
   });
 


### PR DESCRIPTION
## Summary

- `close()` now fires the `closeBundle` plugin hook (via `OutputHookExecutor`) before setting the `closed` flag
- Added optional `outputHookExecutor` field to `BuildState` interface
- Added 5 new tests verifying hook invocation, ordering (hook fires before flag is set), and post-close error behavior

## Test plan

- [x] New test: closeBundle hook fires when outputHookExecutor is provided
- [x] New test: closeBundle fires before closed flag is set
- [x] New test: close still works without outputHookExecutor
- [x] New test: generate/write throw after close with executor
- [x] Full test suite passes (4882 tests, 118 files)
- [x] TypeScript strict mode typecheck passes

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)