### PR TITLE
feat: wire tree-shaking into build pipeline

### DIFF
--- a/src/build/rollup-build.ts
+++ b/src/build/rollup-build.ts
@@ -31,6 +31,7 @@ import type {
   ExportBinding,
 } from "../formats/shared.js";
 import { getExportMode } from "../formats/shared.js";
+import type { TreeShakeResult } from "../tree-shaking/engine.js";
 
 /**
  * Immutable state describing the result of a build phase.
@@ -45,6 +46,13 @@ export interface BuildState {
   readonly watchFiles: ReadonlyArray<string>;
   /** Optional timing function when perf mode is enabled. */
   readonly getTimings?: () => SerializedTimings;
+  /** Tree-shaking result summary, undefined if tree-shaking was disabled. */
+  readonly treeShakeResult?: TreeShakeResult;
+  /** Map from module ID to the set of included statement indices. */
+  readonly includedStatementsByModule?: ReadonlyMap<
+    string,
+    ReadonlySet<number>
+  >;
 }
 
 /**
@@ -129,17 +137,20 @@ const getExportBindings = (mod: Module): ReadonlyArray<ExportBinding> => {
 
 /**
  * Render a single module by removing internal import declarations and
- * stripping export keywords from declarations.
+ * stripping export keywords from declarations. When tree-shaking results
+ * are available, excluded statements are removed from the output.
  *
  * @param mod - The module to render
  * @param isEntry - Whether this module is the entry point
  * @param format - The output format
+ * @param includedStatements - Optional set of statement indices that tree-shaking included
  * @returns The rendered code string
  */
 const renderSingleModule = (
   mod: Module,
   isEntry: boolean,
   format: ModuleFormat,
+  includedStatements?: ReadonlySet<number>,
 ): string => {
   const ms = new MagicString(mod.code);
 
@@ -150,6 +161,17 @@ const renderSingleModule = (
   const body = mod.ast.body;
   for (let i = 0; i < body.length; i++) {
     const node = body[i];
+
+    // If tree-shaking is active and this statement is not included, remove it
+    // (but always keep import declarations — they are handled separately below)
+    if (
+      includedStatements !== undefined &&
+      !includedStatements.has(i) &&
+      node.type !== "ImportDeclaration"
+    ) {
+      ms.remove(node.start, node.end);
+      continue;
+    }
 
     if (node.type === "ImportDeclaration") {
       // Check if this is an internal import (should be removed)
@@ -276,12 +298,24 @@ const generateOutput = async (
     entryModule = modules[modules.length - 1];
   }
 
-  // Render each module
+  // Render each module, skipping those excluded by tree-shaking
   const renderedModules: Array<ConcatModule> = [];
   for (let i = 0; i < modules.length; i++) {
     const mod = modules[i];
+
+    // If tree-shaking ran and the module is not included, skip it entirely
+    // (unless it is the entry module — always render entries)
+    if (
+      state.includedStatementsByModule !== undefined &&
+      !mod.isIncluded &&
+      mod !== entryModule
+    ) {
+      continue;
+    }
+
     const isEntry = mod === entryModule;
-    const rendered = renderSingleModule(mod, isEntry, format);
+    const modStatements = state.includedStatementsByModule?.get(mod.id);
+    const rendered = renderSingleModule(mod, isEntry, format, modStatements);
     if (rendered.length > 0) {
       renderedModules.push({
         id: mod.id,
@@ -341,20 +375,26 @@ const generateOutput = async (
 
   // Build module info record
   const modulesRecord: Record<string, OutputRenderedModule> = {};
+  const removedBindingNames: ReadonlyArray<string> =
+    state.treeShakeResult?.removedBindings ?? [];
   for (let i = 0; i < modules.length; i++) {
     const mod = modules[i];
     const renderedExports: Array<string> = [];
+    const removedExports: Array<string> = [];
     for (let j = 0; j < mod.exports.length; j++) {
-      renderedExports.push(
-        mod.exports[j].exported ?? mod.exports[j].local ?? "",
-      );
+      const name = mod.exports[j].exported ?? mod.exports[j].local ?? "";
+      if (removedBindingNames.includes(name) && !mod.isEntry) {
+        removedExports.push(name);
+      } else {
+        renderedExports.push(name);
+      }
     }
     modulesRecord[mod.id] = {
-      code: mod.code,
+      code: mod.isIncluded ? mod.code : "",
       originalLength: mod.code.length,
-      removedExports: [],
+      removedExports,
       renderedExports,
-      renderedLength: mod.code.length,
+      renderedLength: mod.isIncluded ? mod.code.length : 0,
     };
   }
 

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -28,6 +28,43 @@ import type {
 import { buildModuleGraph } from "./module/graph.js";
 import { defaultResolve, isExternal } from "./module/resolve.js";
 import { createNodeFs } from "./fs/node-fs.js";
+import { analyzeScopes } from "./tree-shaking/scope.js";
+import type { Scope } from "./tree-shaking/scope.js";
+import type { Binding, Reference } from "./tree-shaking/scope.js";
+import { collectPureAnnotations } from "./tree-shaking/pure.js";
+import { analyzeModuleSideEffects } from "./tree-shaking/side-effects.js";
+import { treeShake } from "./tree-shaking/engine.js";
+import type {
+  ModuleBindingInfo,
+  StatementInfo,
+  TreeShakeResult,
+} from "./tree-shaking/engine.js";
+import { Module } from "./module/Module.js";
+import type * as AST from "./ast/types.js";
+
+/**
+ * Collect all references from a scope tree using iterative traversal.
+ * Walks the scope and all child scopes to gather every reference.
+ *
+ * @param rootScope - The root scope to traverse.
+ * @returns All references found in the scope tree.
+ */
+const collectAllReferences = (rootScope: Scope): ReadonlyArray<Reference> => {
+  const refs: Array<Reference> = [];
+  const scopeStack: Array<Scope> = [rootScope];
+
+  while (scopeStack.length > 0) {
+    const current = scopeStack.pop()!;
+    for (let i = 0; i < current.references.length; i++) {
+      refs.push(current.references[i]);
+    }
+    for (let i = current.children.length - 1; i >= 0; i--) {
+      scopeStack.push(current.children[i]);
+    }
+  }
+
+  return refs;
+};
 
 /**
  * Run the options hook across all plugins, allowing them to mutate options.
@@ -245,8 +282,262 @@ export const rollup = async (
     shimMissingExports: finalOptions.shimMissingExports,
   });
 
-  // Step 7: Tree-shaking is applied during module graph construction
-  // (handled by the tree-shaking engine when modules are loaded)
+  // Step 7: Tree-shaking
+  let treeShakeResult: TreeShakeResult | undefined;
+  const includedStatementsByModule = new Map<string, ReadonlySet<number>>();
+
+  if (finalOptions.treeshake !== false) {
+    const tsOpts = finalOptions.treeshake;
+    const modules = graph.modules.filter(
+      (m): m is Module => m instanceof Module,
+    );
+    const moduleInfos = new Map<Module, ModuleBindingInfo>();
+
+    // Build binding info for each module
+    for (let i = 0; i < modules.length; i++) {
+      const mod = modules[i];
+      if (mod.ast === null) {
+        continue;
+      }
+
+      const scope = analyzeScopes(mod.ast);
+      const pureAnnotations = collectPureAnnotations(mod.code, mod.ast);
+      const sideEffectAnalysis = analyzeModuleSideEffects(
+        mod.ast,
+        scope,
+        pureAnnotations,
+        tsOpts.manualPureFunctions as ReadonlyArray<string>,
+      );
+
+      // Build a set of side-effect node positions for quick lookup
+      const sideEffectNodeStarts = new Set<number>();
+      for (let se = 0; se < sideEffectAnalysis.sideEffectNodes.length; se++) {
+        sideEffectNodeStarts.add(sideEffectAnalysis.sideEffectNodes[se].start);
+      }
+
+      // Collect all resolved references from the scope (including child scopes)
+      const allReferences = collectAllReferences(scope);
+
+      // Build StatementInfo for each top-level statement
+      const statements: Array<StatementInfo> = [];
+      const sideEffectStatements: Array<StatementInfo> = [];
+      const body = mod.ast.body;
+      const allBindings = Array.from(scope.bindings.values());
+
+      for (let j = 0; j < body.length; j++) {
+        const node = body[j] as AST.BaseNode;
+
+        // Find bindings declared in this statement
+        const declaredBindings: Array<Binding> = [];
+        for (let k = 0; k < allBindings.length; k++) {
+          const binding = allBindings[k];
+          if (
+            binding.node.start >= node.start &&
+            binding.node.end <= node.end
+          ) {
+            declaredBindings.push(binding);
+          }
+        }
+
+        // Find all references within this statement and link them to declared
+        // bindings so the engine can trace from a binding's inclusion to
+        // all other bindings referenced in the same statement.
+        const stmtRefs: Array<Binding> = [];
+        for (let k = 0; k < allReferences.length; k++) {
+          const ref = allReferences[k];
+          if (
+            ref.node.start >= node.start &&
+            ref.node.end <= node.end &&
+            ref.binding !== null
+          ) {
+            stmtRefs.push(ref.binding);
+          }
+        }
+
+        // For each declared binding, add synthetic references to all other
+        // bindings referenced in the same statement, so the engine can
+        // discover them via reference tracing.
+        for (let k = 0; k < declaredBindings.length; k++) {
+          const decl = declaredBindings[k];
+          for (let r = 0; r < stmtRefs.length; r++) {
+            const target = stmtRefs[r];
+            if (target !== decl) {
+              decl.references.push({
+                name: target.name,
+                node: target.node,
+                scope: target.scope,
+                binding: target,
+              });
+            }
+          }
+        }
+
+        // Use analyzeModuleSideEffects result to determine side effects
+        const isSideEffectNode = sideEffectNodeStarts.has(node.start);
+
+        const stmtInfo: StatementInfo = {
+          index: j,
+          sideEffectResult: isSideEffectNode ? "definite" : "none",
+          declaredBindings,
+          isIncluded: false,
+        };
+
+        statements.push(stmtInfo);
+
+        if (isSideEffectNode) {
+          sideEffectStatements.push(stmtInfo);
+        }
+      }
+
+      moduleInfos.set(mod, {
+        module: mod,
+        scope,
+        bindings: allBindings,
+        sideEffectStatements,
+        statements,
+      });
+    }
+
+    // Build a map from module ID to Module for cross-module resolution
+    const moduleById = new Map<string, Module>();
+    for (let i = 0; i < modules.length; i++) {
+      moduleById.set(modules[i].id, modules[i]);
+    }
+
+    // Link import bindings to their corresponding export bindings across modules.
+    // When an import binding is included by the engine, it traces references;
+    // we add a synthetic reference from the import binding to the target
+    // module's export binding so the engine can cross module boundaries.
+    for (let i = 0; i < modules.length; i++) {
+      const mod = modules[i];
+      const info = moduleInfos.get(mod);
+      if (info === undefined) {
+        continue;
+      }
+
+      for (let j = 0; j < mod.imports.length; j++) {
+        const imp = mod.imports[j];
+
+        // Find the dependency module
+        let depModule: Module | undefined;
+        for (const dep of mod.dependencies) {
+          if (
+            dep instanceof Module &&
+            (dep.id.endsWith(imp.source) ||
+              dep.id.includes(imp.source.replace(/^\.\//, "")))
+          ) {
+            depModule = dep;
+            break;
+          }
+        }
+        if (depModule === undefined) {
+          continue;
+        }
+
+        const depInfo = moduleInfos.get(depModule);
+        if (depInfo === undefined) {
+          continue;
+        }
+
+        // For each specifier, link the local import binding to the
+        // exported binding in the dependency
+        for (let k = 0; k < imp.specifiers.length; k++) {
+          const spec = imp.specifiers[k];
+          const importBinding = info.scope.bindings.get(spec.local);
+          if (importBinding === undefined) {
+            continue;
+          }
+
+          // Find the exported binding name in the dep module
+          const importedName =
+            spec.imported === "default" ? "default" : spec.imported;
+          let targetBindingName: string | undefined;
+
+          for (let e = 0; e < depModule.exports.length; e++) {
+            const exp = depModule.exports[e];
+            const exportedName = exp.exported ?? exp.local ?? "";
+            if (exportedName === importedName) {
+              targetBindingName = exp.local ?? exp.exported ?? "";
+              break;
+            }
+          }
+
+          if (targetBindingName === undefined) {
+            continue;
+          }
+
+          const targetBinding = depInfo.scope.bindings.get(targetBindingName);
+          if (targetBinding === undefined) {
+            continue;
+          }
+
+          // Add a synthetic reference from the import binding to the
+          // target binding so the engine traces across modules
+          importBinding.references.push({
+            name: targetBinding.name,
+            node: targetBinding.node,
+            scope: targetBinding.scope,
+            binding: targetBinding,
+          });
+        }
+      }
+    }
+
+    // Determine entry exports
+    const entryExports = new Map<Module, ReadonlyArray<string>>();
+    for (let i = 0; i < modules.length; i++) {
+      const mod = modules[i];
+      if (mod.isEntry) {
+        const exportNames: Array<string> = [];
+        for (let j = 0; j < mod.exports.length; j++) {
+          const exp = mod.exports[j];
+          if (exp.type === "all") {
+            exportNames.push("*");
+          } else {
+            const name = exp.exported ?? exp.local ?? "";
+            if (name.length > 0) {
+              exportNames.push(name);
+            }
+          }
+        }
+        entryExports.set(mod, exportNames);
+      }
+    }
+
+    // Run tree-shaking engine
+    treeShakeResult = treeShake(
+      modules,
+      entryExports,
+      {
+        enabled: true,
+        moduleSideEffects: tsOpts.moduleSideEffects,
+        propertyReadSideEffects: tsOpts.propertyReadSideEffects,
+        tryCatchDeoptimization: tsOpts.tryCatchDeoptimization,
+        unknownGlobalSideEffects: tsOpts.unknownGlobalSideEffects,
+        manualPureFunctions: tsOpts.manualPureFunctions,
+      },
+      moduleInfos,
+    );
+
+    // Record which statement indices are included per module
+    for (const [mod, info] of moduleInfos) {
+      const included = new Set<number>();
+      for (let i = 0; i < info.statements.length; i++) {
+        if (info.statements[i].isIncluded) {
+          included.add(info.statements[i].index);
+        }
+      }
+      includedStatementsByModule.set(mod.id, included);
+    }
+  } else {
+    // Tree-shaking disabled: mark all modules as included
+    for (let i = 0; i < graph.modules.length; i++) {
+      const mod = graph.modules[i];
+      if (mod instanceof Module) {
+        mod.isIncluded = true;
+      }
+    }
+  }
 
   // Step 8: Run buildEnd hook
   await pluginDriver.hookParallel("buildEnd", []);
@@ -273,6 +564,8 @@ export const rollup = async (
     cache: finalOptions.cache || undefined,
     watchFiles,
     getTimings: finalOptions.perf ? () => ({}) : undefined,
+    treeShakeResult,
+    includedStatementsByModule,
   };
 
   return createRollupBuild(buildState);

--- a/tests/integration/tree-shaking.test.ts
+++ b/tests/integration/tree-shaking.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests for tree-shaking wired into the build pipeline.
+ *
+ * Verifies that tree-shaking correctly removes unused exports,
+ * preserves side effects, and can be disabled.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rollup } from "../../src/rollup.js";
+
+describe("tree-shaking integration", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "steamroller-treeshake-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("removes unused exports from dependency modules", async () => {
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      ["export const used = 'yes';", "export const unused = 'no';", ""].join(
+        "\n",
+      ),
+    );
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(
+      bPath,
+      [
+        'import { used } from "./a.js";',
+        "export const result = used;",
+        "",
+      ].join("\n"),
+    );
+
+    const build = await rollup({ input: bPath });
+    const { output } = await build.generate({ format: "es" });
+    const chunk = output[0];
+
+    expect(chunk.type).toBe("chunk");
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("used");
+      expect(chunk.code).toContain("yes");
+      expect(chunk.code).not.toContain("unused");
+      expect(chunk.code).not.toContain("'no'");
+    }
+    await build.close();
+  });
+
+  it("preserves side-effectful top-level statements", async () => {
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      [
+        "console.log('side effect');",
+        "export const used = 1;",
+        "export const unused = 2;",
+        "",
+      ].join("\n"),
+    );
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(
+      bPath,
+      [
+        'import { used } from "./a.js";',
+        "export const result = used;",
+        "",
+      ].join("\n"),
+    );
+
+    const build = await rollup({ input: bPath });
+    const { output } = await build.generate({ format: "es" });
+    const chunk = output[0];
+
+    if (chunk.type === "chunk") {
+      // Side-effectful statement must be preserved
+      expect(chunk.code).toContain("console.log");
+      expect(chunk.code).toContain("side effect");
+    }
+    await build.close();
+  });
+
+  it("includes everything when treeshake is false", async () => {
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      ["export const used = 'yes';", "export const unused = 'no';", ""].join(
+        "\n",
+      ),
+    );
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(
+      bPath,
+      [
+        'import { used } from "./a.js";',
+        "export const result = used;",
+        "",
+      ].join("\n"),
+    );
+
+    const build = await rollup({ input: bPath, treeshake: false });
+    const { output } = await build.generate({ format: "es" });
+    const chunk = output[0];
+
+    if (chunk.type === "chunk") {
+      // With tree-shaking disabled, everything should be included
+      expect(chunk.code).toContain("used");
+      expect(chunk.code).toContain("unused");
+    }
+    await build.close();
+  });
+
+  it("keeps entry module exports even if unused internally", async () => {
+    const indexPath = join(tempDir, "index.js");
+    await writeFile(
+      indexPath,
+      ["export const foo = 1;", "export const bar = 2;", ""].join("\n"),
+    );
+
+    const build = await rollup({ input: indexPath });
+    const { output } = await build.generate({ format: "es" });
+    const chunk = output[0];
+
+    if (chunk.type === "chunk") {
+      // Entry exports are always preserved
+      expect(chunk.code).toContain("foo");
+      expect(chunk.code).toContain("bar");
+    }
+    await build.close();
+  });
+
+  it("removes unused functions while keeping used ones", async () => {
+    const utilsPath = join(tempDir, "utils.js");
+    await writeFile(
+      utilsPath,
+      [
+        "export const add = (a, b) => a + b;",
+        "export const subtract = (a, b) => a - b;",
+        "export const multiply = (a, b) => a * b;",
+        "",
+      ].join("\n"),
+    );
+
+    const mainPath = join(tempDir, "main.js");
+    await writeFile(
+      mainPath,
+      [
+        'import { add } from "./utils.js";',
+        "export const sum = add(1, 2);",
+        "",
+      ].join("\n"),
+    );
+
+    const build = await rollup({ input: mainPath });
+    const { output } = await build.generate({ format: "es" });
+    const chunk = output[0];
+
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("add");
+      expect(chunk.code).not.toContain("subtract");
+      expect(chunk.code).not.toContain("multiply");
+    }
+    await build.close();
+  });
+
+  it("handles modules with no exports gracefully", async () => {
+    const sideEffectPath = join(tempDir, "side-effect.js");
+    await writeFile(sideEffectPath, "console.log('init');\n");
+
+    const mainPath = join(tempDir, "main.js");
+    await writeFile(
+      mainPath,
+      ['import "./side-effect.js";', "export const x = 1;", ""].join("\n"),
+    );
+
+    const build = await rollup({ input: mainPath });
+    const { output } = await build.generate({ format: "es" });
+    const chunk = output[0];
+
+    if (chunk.type === "chunk") {
+      // Side-effect-only module should still be included
+      expect(chunk.code).toContain("console.log");
+      expect(chunk.code).toContain("init");
+    }
+    await build.close();
+  });
+
+  it("produces valid output with three-module chain and tree-shaking", async () => {
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      [
+        "export const needed = 'keep';",
+        "export const notNeeded = 'drop';",
+        "",
+      ].join("\n"),
+    );
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(
+      bPath,
+      [
+        'import { needed } from "./a.js";',
+        "export const middle = needed;",
+        "export const extra = 'extra';",
+        "",
+      ].join("\n"),
+    );
+
+    const cPath = join(tempDir, "c.js");
+    await writeFile(
+      cPath,
+      [
+        'import { middle } from "./b.js";',
+        "export const final_val = middle;",
+        "",
+      ].join("\n"),
+    );
+
+    const build = await rollup({ input: cPath });
+    const { output } = await build.generate({ format: "es" });
+    const chunk = output[0];
+
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("needed");
+      expect(chunk.code).toContain("keep");
+      expect(chunk.code).toContain("final_val");
+      expect(chunk.code).not.toContain("notNeeded");
+      expect(chunk.code).not.toContain("'drop'");
+    }
+    await build.close();
+  });
+
+  it("works with CJS format and tree-shaking enabled", async () => {
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      ["export const kept = 'yes';", "export const dropped = 'no';", ""].join(
+        "\n",
+      ),
+    );
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(
+      bPath,
+      ['import { kept } from "./a.js";', "export const out = kept;", ""].join(
+        "\n",
+      ),
+    );
+
+    const build = await rollup({ input: bPath });
+    const { output } = await build.generate({ format: "cjs" });
+    const chunk = output[0];
+
+    if (chunk.type === "chunk") {
+      expect(chunk.code).toContain("kept");
+      expect(chunk.code).not.toContain("dropped");
+    }
+    await build.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Wires the existing tree-shaking engine into the build pipeline in `src/rollup.ts`, running scope analysis, pure annotation collection, side-effect analysis, and multi-pass tree-shaking after module graph construction
- Updates `src/build/rollup-build.ts` to respect tree-shaking results during code generation, removing excluded statements and skipping fully-excluded modules
- Adds cross-module binding resolution so the engine can trace import references to their source module's export bindings
- Adds 8 integration tests covering unused export removal, side-effect preservation, `treeshake: false`, entry export preservation, multi-module chains, and CJS format

## Test plan

- [x] All 4885 existing tests pass (119 test files)
- [x] 8 new integration tests in `tests/integration/tree-shaking.test.ts`
- [x] TypeScript strict mode compiles with no errors
- [x] Prettier formatting applied
- [x] Overall coverage at 98.21% (meets >=98% threshold)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)