### PR TITLE
feat: wire code splitting into generate()

### DIFF
--- a/src/build/rollup-build.ts
+++ b/src/build/rollup-build.ts
@@ -38,6 +38,12 @@ import type {
 import { getExportMode } from "../formats/shared.js";
 import { OutputHookExecutor } from "../plugins/output-hooks.js";
 import type { TreeShakeResult } from "../tree-shaking/engine.js";
+import {
+  detectSplitPoints,
+  assignChunks,
+  resolveChunkFileName,
+} from "../splitting/index.js";
+import type { SplittableModule } from "../splitting/index.js";
 
 /**
  * Immutable state describing the result of a build phase.
@@ -253,6 +259,425 @@ const renderSingleModule = (
 };
 
 /**
+ * Converts Module instances to SplittableModule for split-point detection.
+ * Resolves dynamic import sources (relative paths) to absolute module IDs.
+ */
+const toSplittableModules = (
+  modules: ReadonlyArray<Module>,
+): ReadonlyArray<SplittableModule> => {
+  // Build a lookup for resolving relative sources to absolute IDs
+  const moduleById = new Map<string, Module>();
+  for (let i = 0; i < modules.length; i++) {
+    moduleById.set(modules[i].id, modules[i]);
+  }
+
+  const result: Array<SplittableModule> = [];
+  for (let i = 0; i < modules.length; i++) {
+    const mod = modules[i];
+    const importedIds: Array<string> = [];
+    const importerIds: Array<string> = [];
+    for (const dep of mod.dependencies) {
+      if (dep instanceof Module) {
+        importedIds.push(dep.id);
+      }
+    }
+    for (const imp of mod.importers) {
+      importerIds.push(imp.id);
+    }
+
+    // Resolve dynamic import sources to absolute module IDs
+    const dynamicallyImportedIds: Array<string> = [];
+    for (let j = 0; j < mod.dynamicImports.length; j++) {
+      const source = mod.dynamicImports[j];
+      const resolved = resolveDynamicSource(source, mod, modules);
+      if (resolved !== undefined) {
+        dynamicallyImportedIds.push(resolved);
+      }
+    }
+
+    result.push({
+      id: mod.id,
+      isEntry: mod.isEntry,
+      importedIds,
+      dynamicallyImportedIds,
+      importers: importerIds,
+      dynamicImporters: [],
+    });
+  }
+  return result;
+};
+
+/**
+ * Resolves a dynamic import source string to an absolute module ID.
+ */
+const resolveDynamicSource = (
+  source: string,
+  importerMod: Module,
+  allModules: ReadonlyArray<Module>,
+): string | undefined => {
+  const cleanSource = source.replace(/^\.\//, "");
+  // Check dependencies of the importer first
+  for (const dep of importerMod.dependencies) {
+    if (dep instanceof Module) {
+      if (dep.id.endsWith(cleanSource)) {
+        return dep.id;
+      }
+    }
+  }
+  // Fallback: search all modules
+  for (let i = 0; i < allModules.length; i++) {
+    if (allModules[i].id.endsWith(cleanSource)) {
+      return allModules[i].id;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Generates split output with multiple chunks when dynamic imports are present.
+ * Each dynamic import target becomes its own chunk with a distinct file name.
+ * Cross-chunk import() calls are rewritten to reference the generated chunk filename.
+ */
+const generateSplitOutput = async (
+  state: BuildState,
+  modules: ReadonlyArray<Module>,
+  entryModule: Module,
+  format: ModuleFormat,
+  defaultFileName: string,
+  options: OutputOptions,
+  normalizedOutput: NormalizedOutputOptions | undefined,
+  hookExecutor: OutputHookExecutor | undefined,
+  isWrite: boolean,
+): Promise<RollupOutput> => {
+  const splittableModules = toSplittableModules(modules);
+  const splitPoints = detectSplitPoints(splittableModules, [entryModule.id]);
+  const chunkAssignment = assignChunks(
+    splittableModules,
+    [entryModule.id],
+    splitPoints,
+  );
+
+  // Build a module lookup
+  const moduleById = new Map<string, Module>();
+  for (let i = 0; i < modules.length; i++) {
+    moduleById.set(modules[i].id, modules[i]);
+  }
+
+  // Determine which dynamic import sources map to which resolved module IDs
+  const dynamicSourceToResolved = new Map<string, string>();
+  for (let i = 0; i < modules.length; i++) {
+    const mod = modules[i];
+    for (let j = 0; j < mod.dynamicImports.length; j++) {
+      const source = mod.dynamicImports[j];
+      if (!dynamicSourceToResolved.has(source)) {
+        const resolved = resolveDynamicSource(source, mod, modules);
+        if (resolved !== undefined) {
+          dynamicSourceToResolved.set(source, resolved);
+        }
+      }
+    }
+  }
+
+  // For each chunk, determine its root module (entry or dynamic entry)
+  // and which split point it corresponds to
+  const splitPointByModuleId = new Map<string, (typeof splitPoints)[number]>();
+  for (let i = 0; i < splitPoints.length; i++) {
+    splitPointByModuleId.set(splitPoints[i].moduleId, splitPoints[i]);
+  }
+
+  // Generate each chunk
+  const outputChunks: Array<OutputChunk> = [];
+  const chunkFileNameByModuleId = new Map<string, string>();
+
+  // First pass: render all chunks and compute file names
+  const chunkEntries = Array.from(chunkAssignment.entries());
+  const renderedChunks: Array<{
+    name: string;
+    moduleIds: Array<string>;
+    code: string;
+    isEntry: boolean;
+    isDynamicEntry: boolean;
+    facadeModuleId: string;
+    exports: ReadonlyArray<string>;
+    externalImports: ReadonlyArray<ImportBinding>;
+    externalImportSources: Array<string>;
+    importedBindingsRecord: Record<string, Array<string>>;
+  }> = [];
+
+  for (let ci = 0; ci < chunkEntries.length; ci++) {
+    const [chunkName, chunkModuleIds] = chunkEntries[ci];
+
+    // Determine the facade module for this chunk
+    let facadeModule: Module | undefined;
+    const isEntryChunk = chunkModuleIds.includes(entryModule.id);
+
+    if (isEntryChunk) {
+      facadeModule = entryModule;
+    } else {
+      // Find the split point module that acts as the facade
+      for (let m = 0; m < chunkModuleIds.length; m++) {
+        if (splitPointByModuleId.has(chunkModuleIds[m])) {
+          facadeModule = moduleById.get(chunkModuleIds[m]);
+          break;
+        }
+      }
+      if (facadeModule === undefined && chunkModuleIds.length > 0) {
+        facadeModule = moduleById.get(chunkModuleIds[0]);
+      }
+    }
+
+    if (facadeModule === undefined) {
+      continue;
+    }
+
+    const isDynamicEntry =
+      !isEntryChunk && splitPointByModuleId.has(facadeModule.id);
+
+    // Render modules belonging to this chunk
+    const chunkRenderedModules: Array<ConcatModule> = [];
+    for (let m = 0; m < chunkModuleIds.length; m++) {
+      const mod = moduleById.get(chunkModuleIds[m]);
+      if (mod === undefined) {
+        continue;
+      }
+
+      // Skip tree-shaken modules (unless entry/facade)
+      if (
+        state.includedStatementsByModule !== undefined &&
+        !mod.isIncluded &&
+        mod !== facadeModule
+      ) {
+        continue;
+      }
+
+      const isModEntry = mod === facadeModule;
+      const modStatements = state.includedStatementsByModule?.get(mod.id);
+      const rendered = renderSingleModule(
+        mod,
+        isModEntry,
+        format,
+        modStatements,
+      );
+      if (rendered.length > 0) {
+        chunkRenderedModules.push({ id: mod.id, code: rendered });
+      }
+    }
+
+    const concatenated = concatenateModules(chunkRenderedModules);
+
+    // Collect external imports for this chunk's facade
+    const externalImports = getExternalImportBindings(facadeModule);
+    const exportBindings = getExportBindings(facadeModule);
+    const exportNames: Array<string> = [];
+    for (let i = 0; i < exportBindings.length; i++) {
+      exportNames.push(exportBindings[i].exported);
+    }
+
+    const externalImportSources: Array<string> = [];
+    const importedBindingsRecord: Record<string, Array<string>> = {};
+    for (let i = 0; i < externalImports.length; i++) {
+      const imp = externalImports[i];
+      if (!externalImportSources.includes(imp.source)) {
+        externalImportSources.push(imp.source);
+      }
+      if (importedBindingsRecord[imp.source] === undefined) {
+        importedBindingsRecord[imp.source] = [];
+      }
+      importedBindingsRecord[imp.source].push(imp.imported);
+    }
+
+    // Apply format wrapper
+    const formatWrapper = getFormatWrapper(format);
+    const exportsMode = getExportMode(exportNames, format);
+    const formatOptions: FormatOptions = {
+      exports: exportsMode,
+      strict: true,
+      externalImports,
+      exportBindings,
+    };
+
+    const wrappedCode =
+      formatWrapper !== undefined
+        ? formatWrapper.wrapChunk(concatenated.code, formatOptions)
+        : concatenated.code;
+
+    renderedChunks.push({
+      name: chunkName,
+      moduleIds: chunkModuleIds,
+      code: wrappedCode,
+      isEntry: isEntryChunk,
+      isDynamicEntry,
+      facadeModuleId: facadeModule.id,
+      exports: exportNames,
+      externalImports,
+      externalImportSources,
+      importedBindingsRecord,
+    });
+  }
+
+  // Compute file names for all chunks
+  for (let i = 0; i < renderedChunks.length; i++) {
+    const rc = renderedChunks[i];
+    let chunkFileName: string;
+
+    if (rc.isEntry) {
+      // Entry chunk uses entryFileNames pattern or the default fileName
+      const entryPattern =
+        typeof options.entryFileNames === "string"
+          ? options.entryFileNames
+          : undefined;
+      if (entryPattern !== undefined) {
+        chunkFileName = resolveChunkFileName(
+          { name: rc.name, content: rc.code, format, isEntry: true },
+          entryPattern,
+        );
+      } else {
+        chunkFileName = defaultFileName;
+      }
+    } else {
+      // Dynamic chunk uses chunkFileNames pattern
+      const chunkPattern =
+        typeof options.chunkFileNames === "string"
+          ? options.chunkFileNames
+          : undefined;
+      chunkFileName = resolveChunkFileName(
+        { name: rc.name, content: rc.code, format, isEntry: false },
+        chunkPattern,
+      );
+    }
+
+    chunkFileNameByModuleId.set(rc.facadeModuleId, chunkFileName);
+  }
+
+  // Resolve addons once
+  const resolvedAddons = await resolveAllAddons({
+    banner: options.banner as AddonValue,
+    footer: options.footer as AddonValue,
+    intro: options.intro as AddonValue,
+    outro: options.outro as AddonValue,
+  });
+
+  // Second pass: rewrite import() calls in entry chunks and build final OutputChunks
+  for (let i = 0; i < renderedChunks.length; i++) {
+    const rc = renderedChunks[i];
+    let code = rc.code;
+
+    // Rewrite dynamic import() calls to reference chunk file names
+    if (rc.isEntry || rc.isDynamicEntry) {
+      for (const [source, resolvedId] of dynamicSourceToResolved) {
+        const targetFileName = chunkFileNameByModuleId.get(resolvedId);
+        if (targetFileName !== undefined) {
+          // Replace import("./source") or import('./source') with import("./chunkFile")
+          const escapedSource = source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const importPattern = new RegExp(
+            `import\\(\\s*(['"])${escapedSource}\\1\\s*\\)`,
+            "g",
+          );
+          code = code.replace(importPattern, `import("./${targetFileName}")`);
+        }
+      }
+    }
+
+    // Apply addons
+    code = applyAddons(code, resolvedAddons);
+
+    const chunkFileName = chunkFileNameByModuleId.get(rc.facadeModuleId)!;
+
+    // Collect dynamicImports array for the entry chunk
+    const dynamicImportFileNames: Array<string> = [];
+    if (rc.isEntry) {
+      for (const [, resolvedId] of dynamicSourceToResolved) {
+        const fn = chunkFileNameByModuleId.get(resolvedId);
+        if (fn !== undefined && !dynamicImportFileNames.includes(fn)) {
+          dynamicImportFileNames.push(fn);
+        }
+      }
+    }
+
+    // Build modules record
+    const modulesRecord: Record<string, OutputRenderedModule> = {};
+    const removedBindingNames: ReadonlyArray<string> =
+      state.treeShakeResult?.removedBindings ?? [];
+    for (let m = 0; m < rc.moduleIds.length; m++) {
+      const mod = moduleById.get(rc.moduleIds[m]);
+      if (mod === undefined) {
+        continue;
+      }
+      const renderedExports: Array<string> = [];
+      const removedExports: Array<string> = [];
+      for (let j = 0; j < mod.exports.length; j++) {
+        const name = mod.exports[j].exported ?? mod.exports[j].local ?? "";
+        if (removedBindingNames.includes(name) && !mod.isEntry) {
+          removedExports.push(name);
+        } else {
+          renderedExports.push(name);
+        }
+      }
+      modulesRecord[mod.id] = {
+        code: mod.isIncluded ? mod.code : "",
+        originalLength: mod.code.length,
+        removedExports,
+        renderedExports,
+        renderedLength: mod.isIncluded ? mod.code.length : 0,
+      };
+    }
+
+    const renderedChunkInfo: RenderedChunk = {
+      type: "chunk",
+      dynamicImports: dynamicImportFileNames,
+      exports: [...rc.exports],
+      facadeModuleId: rc.facadeModuleId,
+      fileName: chunkFileName,
+      implicitlyLoadedBefore: [],
+      importedBindings: rc.importedBindingsRecord,
+      imports: rc.externalImportSources,
+      isDynamicEntry: rc.isDynamicEntry,
+      isEntry: rc.isEntry,
+      isImplicitEntry: false,
+      moduleIds: rc.moduleIds,
+      modules: modulesRecord,
+      name: rc.name,
+      referencedFiles: [],
+    };
+
+    // Fire renderChunk hook
+    let chunkCode = code;
+    if (hookExecutor !== undefined && normalizedOutput !== undefined) {
+      const renderChunkResult = await hookExecutor.renderChunk(
+        chunkCode,
+        renderedChunkInfo,
+        normalizedOutput,
+      );
+      chunkCode = renderChunkResult.code;
+    }
+
+    const chunk: OutputChunk = {
+      ...renderedChunkInfo,
+      code: chunkCode,
+      preliminaryFileName: chunkFileName,
+      sourcemapFileName: null,
+      map: null,
+    };
+
+    outputChunks.push(chunk);
+  }
+
+  // Fire generateBundle hook
+  if (hookExecutor !== undefined && normalizedOutput !== undefined) {
+    const bundle: OutputBundle = {};
+    for (let i = 0; i < outputChunks.length; i++) {
+      (bundle as Record<string, OutputChunk>)[outputChunks[i].fileName] =
+        outputChunks[i];
+    }
+    await hookExecutor.generateBundle(normalizedOutput, bundle, isWrite);
+  }
+
+  return {
+    output: outputChunks as unknown as readonly [OutputChunk, ...OutputChunk[]],
+  };
+};
+
+/**
  * Generates output from build state and output options.
  * Renders modules via MagicString, concatenates in topological order,
  * and applies format wrappers.
@@ -341,7 +766,29 @@ const generateOutput = async (
     entryModule = modules[modules.length - 1];
   }
 
+  // Detect dynamic imports in the module graph
+  const hasDynamicImports = modules.some(
+    (mod) => mod.dynamicImports.length > 0,
+  );
+  const shouldSplit =
+    hasDynamicImports && options.inlineDynamicImports !== true;
+
   try {
+    if (shouldSplit) {
+      return await generateSplitOutput(
+        state,
+        modules,
+        entryModule,
+        format,
+        fileName,
+        options,
+        normalizedOutput,
+        hookExecutor,
+        isWrite,
+      );
+    }
+
+    // Single-chunk path (no dynamic imports or inlineDynamicImports=true)
     // Render each module, skipping those excluded by tree-shaking
     const renderedModules: Array<ConcatModule> = [];
     for (let i = 0; i < modules.length; i++) {

--- a/tests/integration/code-splitting.test.ts
+++ b/tests/integration/code-splitting.test.ts
@@ -1,0 +1,786 @@
+/**
+ * Integration tests for code splitting via dynamic imports.
+ *
+ * Verifies that generate() produces multiple chunks when the module graph
+ * contains dynamic imports and inlineDynamicImports is not set.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rollup } from "../../src/rollup.js";
+import type { OutputChunk } from "../../src/types.js";
+
+describe("code splitting via dynamic imports", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "steamroller-splitting-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("produces multiple chunks when a module dynamically imports another", async () => {
+    // Module B: statically imported by A
+    const bPath = join(tempDir, "b.js");
+    await writeFile(bPath, "export const b = 'from-b';\n");
+
+    // Module C: dynamically imported by A
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'from-c';\n");
+
+    // Module A: entry, statically imports B, dynamically imports C
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      [
+        'import { b } from "./b.js";',
+        'const loadC = () => import("./c.js");',
+        "export { b, loadC };",
+      ].join("\n") + "\n",
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    // Should produce at least 2 chunks (entry + dynamic)
+    expect(output.length).toBeGreaterThanOrEqual(2);
+
+    // Identify entry and dynamic chunks
+    const entryChunks = output.filter(
+      (o) => o.type === "chunk" && (o as OutputChunk).isEntry,
+    ) as Array<OutputChunk>;
+    const dynamicChunks = output.filter(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as Array<OutputChunk>;
+
+    expect(entryChunks.length).toBe(1);
+    expect(dynamicChunks.length).toBeGreaterThanOrEqual(1);
+
+    const entryChunk = entryChunks[0];
+    const dynamicChunk = dynamicChunks[0];
+
+    // Entry chunk should contain code from A and B
+    expect(entryChunk.code).toContain("from-b");
+    expect(entryChunk.code).toContain("loadC");
+
+    // Dynamic chunk should contain code from C
+    expect(dynamicChunk.code).toContain("from-c");
+
+    // Entry chunk should NOT contain code from C
+    expect(entryChunk.code).not.toContain("from-c");
+
+    // Dynamic chunk should NOT contain code from A or B
+    expect(dynamicChunk.code).not.toContain("from-b");
+
+    // Entry chunk should reference the dynamic chunk via import()
+    expect(entryChunk.code).toContain("import(");
+
+    await build.close();
+  });
+
+  it("entry chunk moduleIds include A and B but not C", async () => {
+    const bPath = join(tempDir, "b.js");
+    await writeFile(bPath, "export const b = 1;\n");
+
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 2;\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      [
+        'import { b } from "./b.js";',
+        'const getC = () => import("./c.js");',
+        "export { b, getC };",
+      ].join("\n") + "\n",
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const entryChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isEntry,
+    ) as OutputChunk;
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(entryChunk).toBeDefined();
+    expect(dynamicChunk).toBeDefined();
+
+    // Entry chunk should list A and B in moduleIds
+    expect(entryChunk.moduleIds).toContain(aPath);
+    expect(entryChunk.moduleIds).toContain(bPath);
+    expect(entryChunk.moduleIds).not.toContain(cPath);
+
+    // Dynamic chunk should list C
+    expect(dynamicChunk.moduleIds).toContain(cPath);
+
+    await build.close();
+  });
+
+  it("inlineDynamicImports=true produces a single chunk", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'inline-c';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const getC = () => import("./c.js");\nexport { getC };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({
+      format: "es",
+      inlineDynamicImports: true,
+    });
+
+    // With inlineDynamicImports, should be exactly 1 chunk
+    expect(output.length).toBe(1);
+    expect(output[0].type).toBe("chunk");
+
+    await build.close();
+  });
+
+  it("dynamic chunk has isDynamicEntry=true and isEntry=false", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 3;\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const lazy = () => import("./c.js");\nexport { lazy };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(dynamicChunk).toBeDefined();
+    expect(dynamicChunk.isDynamicEntry).toBe(true);
+    expect(dynamicChunk.isEntry).toBe(false);
+
+    await build.close();
+  });
+
+  it("entry chunk dynamicImports array references the dynamic chunk file name", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'dyn';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const entryChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isEntry,
+    ) as OutputChunk;
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(entryChunk.dynamicImports.length).toBeGreaterThanOrEqual(1);
+    expect(entryChunk.dynamicImports).toContain(dynamicChunk.fileName);
+
+    await build.close();
+  });
+
+  it("chunks have distinct file names", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'unique';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const fn = () => import("./c.js");\nexport { fn };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const fileNames = output
+      .filter((o) => o.type === "chunk")
+      .map((o) => (o as OutputChunk).fileName);
+
+    // All file names should be unique
+    const unique = new Set(fileNames);
+    expect(unique.size).toBe(fileNames.length);
+
+    await build.close();
+  });
+
+  it("no splitting when there are no dynamic imports", async () => {
+    const bPath = join(tempDir, "b.js");
+    await writeFile(bPath, "export const b = 10;\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'import { b } from "./b.js";\nexport const result = b;\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es" });
+
+    // Single chunk when no dynamic imports
+    expect(output.length).toBe(1);
+    expect(output[0].type).toBe("chunk");
+    expect((output[0] as OutputChunk).isEntry).toBe(true);
+
+    await build.close();
+  });
+
+  it("facadeModuleId of dynamic chunk points to the dynamically imported module", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'facade-test';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const go = () => import("./c.js");\nexport { go };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(dynamicChunk).toBeDefined();
+    expect(dynamicChunk.facadeModuleId).toBe(cPath);
+
+    await build.close();
+  });
+
+  it("multiple dynamic imports produce separate chunks", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'chunk-c';\n");
+
+    const dPath = join(tempDir, "d.js");
+    await writeFile(dPath, "export const d = 'chunk-d';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      [
+        'const loadC = () => import("./c.js");',
+        'const loadD = () => import("./d.js");',
+        "export { loadC, loadD };",
+      ].join("\n") + "\n",
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const dynamicChunks = output.filter(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as Array<OutputChunk>;
+
+    // Should have at least 2 dynamic chunks
+    expect(dynamicChunks.length).toBeGreaterThanOrEqual(2);
+
+    // One chunk should have C content, another D content
+    const allDynamicCode = dynamicChunks.map((ch) => ch.code).join("\n");
+    expect(allDynamicCode).toContain("chunk-c");
+    expect(allDynamicCode).toContain("chunk-d");
+
+    await build.close();
+  });
+
+  it("entry chunk's import() call references the dynamic chunk file path", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'ref-test';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const entryChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isEntry,
+    ) as OutputChunk;
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    // The entry chunk code should contain an import() pointing to the dynamic chunk file
+    expect(entryChunk.code).toContain(dynamicChunk.fileName);
+
+    await build.close();
+  });
+
+  it("CJS format produces separate chunks with require-style wrapping", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'cjs-test';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "cjs", dir: "dist" });
+
+    // Should still split into multiple chunks
+    expect(output.length).toBeGreaterThanOrEqual(2);
+
+    const entryChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isEntry,
+    ) as OutputChunk;
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(entryChunk).toBeDefined();
+    expect(dynamicChunk).toBeDefined();
+    expect(entryChunk.code).toContain("use strict");
+    expect(dynamicChunk.code).toContain("cjs-test");
+
+    await build.close();
+  });
+
+  it("handles dynamic import with single-quoted source in code", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'quote-test';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      "const load = () => import('./c.js');\nexport { load };\n",
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    expect(output.length).toBeGreaterThanOrEqual(2);
+
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+    expect(dynamicChunk).toBeDefined();
+    expect(dynamicChunk.code).toContain("quote-test");
+
+    await build.close();
+  });
+
+  it("external imports are preserved in split chunks", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(
+      cPath,
+      'import { readFile } from "node:fs/promises";\nexport const read = readFile;\n',
+    );
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({
+      input: aPath,
+      treeshake: false,
+      external: ["node:fs/promises"],
+    });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(dynamicChunk).toBeDefined();
+    expect(dynamicChunk.code).toContain("node:fs/promises");
+    expect(dynamicChunk.imports).toContain("node:fs/promises");
+
+    await build.close();
+  });
+
+  it("custom chunkFileNames pattern is applied to dynamic chunks", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'pattern-test';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({
+      format: "es",
+      dir: "dist",
+      chunkFileNames: "chunks/[name]-[hash].js",
+    });
+
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(dynamicChunk).toBeDefined();
+    expect(dynamicChunk.fileName).toMatch(/^chunks\/c-[a-zA-Z0-9_-]+\.js$/);
+
+    await build.close();
+  });
+
+  it("custom entryFileNames pattern is applied to entry chunks", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 1;\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({
+      format: "es",
+      dir: "dist",
+      entryFileNames: "entry/[name].js",
+    });
+
+    const entryChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isEntry,
+    ) as OutputChunk;
+
+    expect(entryChunk).toBeDefined();
+    expect(entryChunk.fileName).toMatch(/^entry\/a\.js$/);
+
+    await build.close();
+  });
+
+  it("banner and footer addons are applied to each chunk", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'addon-test';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({
+      format: "es",
+      dir: "dist",
+      banner: "/* BANNER */",
+      footer: "/* FOOTER */",
+    });
+
+    for (let i = 0; i < output.length; i++) {
+      const chunk = output[i] as OutputChunk;
+      expect(chunk.code).toContain("/* BANNER */");
+      expect(chunk.code).toContain("/* FOOTER */");
+    }
+
+    await build.close();
+  });
+
+  it("modules record in dynamic chunk has correct entries", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'mod-record';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(dynamicChunk).toBeDefined();
+    expect(dynamicChunk.modules).toBeDefined();
+    expect(dynamicChunk.modules[cPath]).toBeDefined();
+    expect(dynamicChunk.modules[cPath].originalLength).toBeGreaterThan(0);
+
+    await build.close();
+  });
+
+  it("code splitting works with tree-shaking enabled", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(
+      cPath,
+      "export const c = 'ts-test';\nexport const unused = 'gone';\n",
+    );
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    // treeshake defaults to true
+    const build = await rollup({ input: aPath });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    expect(output.length).toBeGreaterThanOrEqual(2);
+
+    const entryChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isEntry,
+    ) as OutputChunk;
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(entryChunk).toBeDefined();
+    expect(dynamicChunk).toBeDefined();
+    // Dynamic chunk should exist even with tree-shaking
+    expect(dynamicChunk.moduleIds).toContain(cPath);
+
+    await build.close();
+  });
+
+  it("default export module as dynamic import", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "const c = 42;\nexport default c;\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    expect(output.length).toBeGreaterThanOrEqual(2);
+
+    const dynamicChunk = output.find(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as OutputChunk;
+
+    expect(dynamicChunk).toBeDefined();
+    expect(dynamicChunk.code).toContain("42");
+
+    await build.close();
+  });
+
+  it("dynamically imported module with re-exports", async () => {
+    const helperPath = join(tempDir, "helper.js");
+    await writeFile(helperPath, "export const h = 'helper-val';\n");
+
+    const cPath = join(tempDir, "c.js");
+    await writeFile(
+      cPath,
+      'export { h } from "./helper.js";\nexport const c = "reexport";\n',
+    );
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    expect(output.length).toBeGreaterThanOrEqual(2);
+    await build.close();
+  });
+
+  it("split chunk with export * from another module", async () => {
+    const helperPath = join(tempDir, "helper.js");
+    await writeFile(helperPath, "export const h = 'star-export';\n");
+
+    const cPath = join(tempDir, "c.js");
+    await writeFile(
+      cPath,
+      'export * from "./helper.js";\nexport const c = "star";\n',
+    );
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    expect(output.length).toBeGreaterThanOrEqual(2);
+    await build.close();
+  });
+
+  it("duplicate dynamic import source maps to same chunk", async () => {
+    // Two modules both dynamically import the same target
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'shared-dyn';\n");
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(bPath, 'export const loadC = () => import("./c.js");\n');
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      [
+        'import { loadC } from "./b.js";',
+        'const myLoad = () => import("./c.js");',
+        "export { loadC, myLoad };",
+      ].join("\n") + "\n",
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es", dir: "dist" });
+
+    // Should still produce exactly one dynamic chunk for c.js
+    const dynamicChunks = output.filter(
+      (o) => o.type === "chunk" && (o as OutputChunk).isDynamicEntry,
+    ) as Array<OutputChunk>;
+    expect(dynamicChunks.length).toBe(1);
+    expect(dynamicChunks[0].code).toContain("shared-dyn");
+
+    await build.close();
+  });
+
+  it("handles default export in entry module (single-chunk)", async () => {
+    const aPath = join(tempDir, "a.js");
+    await writeFile(aPath, "const val = 99;\nexport default val;\n");
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0] as OutputChunk;
+    expect(chunk.exports).toContain("default");
+    expect(chunk.code).toContain("99");
+
+    await build.close();
+  });
+
+  it("handles default export in non-entry with CJS format (single-chunk)", async () => {
+    const bPath = join(tempDir, "b.js");
+    await writeFile(bPath, "const b = 50;\nexport default b;\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'import b from "./b.js";\nexport const result = b;\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "cjs" });
+
+    const chunk = output[0] as OutputChunk;
+    expect(chunk.code).toContain("50");
+    expect(chunk.code).toContain("use strict");
+
+    await build.close();
+  });
+
+  it("handles export all from in entry that also imports (single-chunk)", async () => {
+    const bPath = join(tempDir, "b.js");
+    await writeFile(bPath, "export const b = 'star-val';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'import { b } from "./b.js";\nexport { b };\nexport const a = 1;\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "es" });
+
+    const chunk = output[0] as OutputChunk;
+    expect(chunk.code).toContain("star-val");
+    expect(chunk.code).toContain("1");
+
+    await build.close();
+  });
+
+  it("re-export named from internal in non-entry CJS format", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'reexp';\n");
+
+    const bPath = join(tempDir, "b.js");
+    await writeFile(
+      bPath,
+      'import { c } from "./c.js";\nexport { c };\nexport const b = "bval";\n',
+    );
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'import { b, c } from "./b.js";\nexport const result = b + c;\n',
+    );
+
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.generate({ format: "cjs" });
+
+    const chunk = output[0] as OutputChunk;
+    expect(chunk.code).toContain("reexp");
+    expect(chunk.code).toContain("bval");
+
+    await build.close();
+  });
+
+  it("tree-shaking skips unused modules in single-chunk path", async () => {
+    const helperPath = join(tempDir, "helper.js");
+    await writeFile(helperPath, "export const unused = 'unused-val';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'import { unused } from "./helper.js";\nexport const x = 1;\n',
+    );
+
+    // Tree-shaking enabled (default), no dynamic imports -> single-chunk path
+    const build = await rollup({ input: aPath });
+    const { output } = await build.generate({ format: "es" });
+
+    expect(output.length).toBe(1);
+    const chunk = output[0] as OutputChunk;
+    // Tree-shaking should remove the unused import
+    expect(chunk.code).toContain("1");
+
+    await build.close();
+  });
+
+  it("write() with code splitting creates multiple files", async () => {
+    const cPath = join(tempDir, "c.js");
+    await writeFile(cPath, "export const c = 'write-test';\n");
+
+    const aPath = join(tempDir, "a.js");
+    await writeFile(
+      aPath,
+      'const load = () => import("./c.js");\nexport { load };\n',
+    );
+
+    const outDir = join(tempDir, "dist");
+    const build = await rollup({ input: aPath, treeshake: false });
+    const { output } = await build.write({ format: "es", dir: outDir });
+
+    expect(output.length).toBeGreaterThanOrEqual(2);
+
+    // Verify files exist on disk
+    const { readFile: rf } = await import("node:fs/promises");
+    for (let i = 0; i < output.length; i++) {
+      if (output[i].type === "chunk") {
+        const chunk = output[i] as OutputChunk;
+        const filePath = join(outDir, chunk.fileName);
+        const content = await rf(filePath, "utf-8");
+        expect(content).toBe(chunk.code);
+      }
+    }
+
+    await build.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Re-implements code splitting (issue #239) on current main after PR #278 had merge conflicts
- When dynamic imports exist and `inlineDynamicImports` is not true, `generateOutput()` now produces multiple chunks via `detectSplitPoints` and `assignChunks`
- Cross-chunk `import()` calls are rewritten to reference the generated chunk filename
- Supports `chunkFileNames`/`entryFileNames` patterns, addons (banner/footer), CJS format, and tree-shaking

## Test plan

- [x] 28 integration tests covering: multi-chunk output, `inlineDynamicImports=true` single chunk, `isDynamicEntry` flags, `moduleIds` correctness, `dynamicImports` array, distinct filenames, custom naming patterns, addons on all chunks, CJS format, tree-shaking, `write()` disk output, re-exports, `export *`, duplicate dynamic imports, external imports in split chunks
- [x] Full test suite passes (4978 tests, 123 files)
- [x] TypeScript strict mode passes
- [x] Prettier formatting passes

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)